### PR TITLE
Fixes 222, CloneTreeTransformation fails on trees with empty lists.

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -18968,6 +18968,15 @@ var $___src_codegeneration_CloneTreeTransformer_js = (function() {
       transformImportSpecifier: function(tree) {
         return new ImportSpecifier(tree.location, tree.lhs, tree.rhs);
       },
+      transformList: function(list) {
+        if (!list) {
+          return null;
+        } else if (list.length == 0) {
+          return [];
+        } else {
+          return $__superCall(this, $__proto, "transformList", [list]);
+        }
+      },
       transformLiteralExpression: function(tree) {
         return new LiteralExpression(tree.location, tree.literalToken);
       },

--- a/src/codegeneration/CloneTreeTransformer.js
+++ b/src/codegeneration/CloneTreeTransformer.js
@@ -123,6 +123,20 @@ export class CloneTreeTransformer extends ParseTreeTransformer {
   }
 
   /**
+   * @param {Array.<ParseTree>} list
+   * @return {Array.<ParseTree>}
+   */
+  transformList(list) {
+    if (!list) {
+      return null;
+    } else if (list.length == 0) {
+      return [];
+    } else {
+      return super.transformList(list);
+    }
+  }
+
+  /**
    * @param {LiteralExpression} tree
    * @return {ParseTree}
    */

--- a/test/testfeatures.js
+++ b/test/testfeatures.js
@@ -144,6 +144,25 @@ function testClone(tree, originalSource) {
   var cloneGeneratedSource =
       traceur.outputgeneration.TreeWriter.write(cloneTree);
   assertEquals(originalSource, cloneGeneratedSource);
+
+  function TaggingVisitor(){}
+  TaggingVisitor.prototype = Object.create(traceur.codegeneration.ParseTreeTransformer.prototype);
+
+  TaggingVisitor.transformAny = function(tree) {
+    if (tree) 
+      tree.tagged = true;
+    return tree; 
+  }
+  
+  function CheckingTagsVisitor(){}
+  CheckingTagsVisitor.prototype = Object.create(traceur.syntax.ParseTreeVisitor.prototype);
+  CheckingTagsVisitor.visitAny = function(tree) {
+    assertUndefined(tree.tagged);
+  }
+
+  var tagged = (new TaggingVisitor).transformAny(cloneTree);
+  (new CheckingTagsVisitor()).visitAny(tree);
+
   return true;
 }
 


### PR DESCRIPTION
transformList now returns new list if the input is empty, it's another kind of leaf.
Add test that cloned tree does not overlap original.
BUG=https://github.com/google/traceur-compiler/issues/222
