### PR TITLE
Interpreter: Fix issue where the interpreter was exiting too early

### DIFF
--- a/demo/async-read-file.js
+++ b/demo/async-read-file.js
@@ -1,0 +1,28 @@
+// Run this with
+//
+//   traceur --experimental async-read-file.js file-to-read
+
+var async = (fn) => (...args) => {
+  var deferred = new Deferred;
+  fn(...args, (err, value) => {
+    if (err !== null)
+      deferred.errback(err);
+    else
+      deferred.callback(value);
+  });
+  return deferred.createPromise();
+};
+
+function test(file) {
+  var data, fs = require('fs');
+  try {
+    await data = async(fs.readFile)(file, 'utf8');
+    console.log(`${file} has ${data.split('\n').length} lines`);
+  } catch (ex) {
+    console.error(ex);
+  }
+}
+
+var fileName = process.argv[2];
+test(fileName);
+console.log(`Loading ${fileName}...`);

--- a/src/node/interpreter.js
+++ b/src/node/interpreter.js
@@ -34,9 +34,8 @@ function interpret(filename, argv) {
     // TODO: use a new module rather than the main one.
     mainModule.filename = fs.realpathSync(filename);
     mainModule._compile(compiledCode, mainModule.filename);
-
-    process.exit(0);
   }, function(err) {
+    console.error(err);
     process.exit(1);
   });
 }


### PR DESCRIPTION
This also adds a basic demo showing that this works.

Fix for https://github.com/google/traceur-compiler/issues/19
