### PR TITLE
Interpreter: Add traceur path and flags to process.execArgv.

### DIFF
--- a/src/node/command.js
+++ b/src/node/command.js
@@ -104,13 +104,16 @@ function processArguments(argv) {
     } else if (interpretMode) {
       // Add a hint to stop commander.js from parsing following arguments.
       argv.splice(i, 0, '--');
+      // Save traceur flags for interpret.js.
+      argv.flags = argv.slice(2, i);
       break;
     }
   }
   return argv;
 }
 
-flags.parse(processArguments(process.argv));
+var argv = processArguments(process.argv);
+flags.parse(argv);
 
 var includes = flags.args;
 
@@ -134,5 +137,5 @@ if (out) {
   else
     compileToDirectory(out, includes, flags.sourceMaps);
 } else {
-  interpret(includes[0], includes.slice(1));
+  interpret(includes[0], includes.slice(1), argv.flags);
 }

--- a/src/node/interpreter.js
+++ b/src/node/interpreter.js
@@ -22,13 +22,15 @@ var inlineAndCompile = require('./inline-module.js').inlineAndCompile;
 var ErrorReporter = traceur.util.ErrorReporter;
 var TreeWriter = traceur.outputgeneration.TreeWriter;
 
-function interpret(filename, argv) {
+function interpret(filename, argv, flags) {
   var reporter = new ErrorReporter();
+  var mainModule = require.main;
+  var execArgv = [mainModule.filename].concat(flags || []);
 
   process.argv = ['traceur', filename].concat(argv || []);
+  process.execArgv = process.execArgv.concat(execArgv);
 
   inlineAndCompile([filename], {}, reporter, function(tree) {
-    var mainModule = require.main;
     var compiledCode = TreeWriter.write(tree);
 
     // TODO: use a new module rather than the main one.


### PR DESCRIPTION
BUG=https://github.com/google/traceur-compiler/issues/227
