### PR TITLE
Make build-test-list work on Windows.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Google Inc. <*@google.com>
 Viktor Kronvall <viktor.kronvall@gmail.com>
 Ben Chan <usrbincc@yahoo.com>
 Eduard Burtescu <edy.burt@gmail.com>
+Peter Hallam <peter@peterhallam.com>


### PR DESCRIPTION
readSync throws at EOF on windows rather than returning 0 bytes read.
