### PR TITLE
Fix paths issue with modules in 'node_modules'.

### DIFF
--- a/src/node/interpreter.js
+++ b/src/node/interpreter.js
@@ -30,11 +30,13 @@ Module._extensions[ext] = function(module, filename) {
   module._compile(module.compiledCode, module.filename);
 };
 
-function interpret(filename, argv) {
+function interpret(filename, argv, flags) {
   var reporter = new ErrorReporter();
+  var execArgv = [require.main.filename].concat(flags || []);
 
   filename = fs.realpathSync(filename);
   process.argv = ['traceur', filename].concat(argv || []);
+  process.execArgv = process.execArgv.concat(execArgv);
 
   inlineAndCompile([filename], {}, reporter, function(tree) {
     var module = new Module(filename, require.main);


### PR DESCRIPTION
This fixes #224

BUG=https://github.com/google/traceur-compiler/issues/224
TEST=None (blocked by issue #221)

---

Here's the test I used. It's a more thorough version of my test from #226.

```
cat > test-node_modules <<"END_"
#!/bin/sh

## make sure this dir doesn't already exist.
D=$(mktemp -d dir-XXXX)
DD=$D/dir/dir
mkdir -p $DD

for x in $(find $D -type d); do
  mkdir -p $x/node_modules
  ## make reasonably sure this module doesn't already
  ## exist.
  M=$(mktemp -d $x/node_modules/question-XXXX)
  printf "created %s\n" $M
  printf "exports.answer = 42;\n" > $M/index.js
done

F=test-tmp-module.js
cat > $DD/$F <<"END"
var mod = process.argv[2];
console.log('loading: %s', mod);
var question = require(mod);
console.log('success: %s', question.answer);
END

QS=$(find $D -name question-\*|xargs -n 1 basename)
DS=$(find $D -type d -name dir\*)

for js in $PWD/traceur node; do
  printf "# ---- testing %s ----\n" $(basename $js)
  for d in $DS; do
    printf "\n%s\n" $d
    cd $d
    for q in $QS; do
      $js $(find -name $F) $q
    done
    cd - > /dev/null
  done
  echo
done

rm -r $D
END_
chmod +x test-node_modules
./test-node_modules
```
