### PR TITLE
Fix transitions between 'lint' and 'nolint'.

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -143,6 +143,8 @@ export class Parser {
      */
     this.allowYield_ = options.unstarredGenerators;
     this.noLint = false;
+    this.noLintChanged_ = false;
+    this.strictSemicolons_ = options.strictSemicolons;
   }
 
   // 14 Program
@@ -3409,9 +3411,15 @@ export class Parser {
    * @private
    */
   eatPossibleImplicitSemiColon_() {
+    var strictSemicolons = this.strictSemicolons_;
     var token = this.peekTokenNoLineTerminator_();
     if (!token) {
-      if (!options.strictSemicolons || this.noLint)
+      // We delay changes in lint-nolint checking until the next token. This is
+      // needed to properly handle (or ignore) semicolon errors occurring at the
+      // boundary of a changeover.
+      if (this.noLintChanged_)
+        strictSemicolons = !strictSemicolons;
+      if (!strictSemicolons)
         return;
     } else {
       switch (token.type) {
@@ -3420,7 +3428,9 @@ export class Parser {
           return;
         case END_OF_FILE:
         case CLOSE_CURLY:
-          if (!options.strictSemicolons || this.noLint)
+          if (this.noLintChanged_)
+            strictSemicolons = !strictSemicolons;
+          if (!strictSemicolons)
             return;
       }
     }
@@ -3581,9 +3591,17 @@ export class Parser {
     // Check for '//:' and 'options.ignoreNolint' first so that we can
     // immediately skip the expensive slice and regexp if it's not needed.
     if (input.charCodeAt(start += 2) === 58 && !options.ignoreNolint) {
-      var text = input.slice(start + 1, start + 7);
-      if (text.search(/^(?:no)?lint\b/) === 0)
-        this.noLint = text[0] === 'n';
+      // We slice one more than the length of 'nolint' so that we can properly
+      // check for the presence or absence of a word boundary.
+      var text = input.slice(start + 1, start + 8);
+      if (text.search(/^(?:no)?lint\b/) === 0) {
+        var noLint = text[0] === 'n';
+        if (noLint !== this.noLint) {
+          this.noLintChanged_ = !this.noLintChanged_;
+          this.noLint = noLint;
+          this.strictSemicolons_ = options.strictSemicolons && !this.noLint;
+        }
+      }
     }
   }
 
@@ -3597,6 +3615,7 @@ export class Parser {
    * @private
    */
   nextToken_() {
+    this.noLintChanged_ = false;
     return this.scanner_.nextToken();
   }
 

--- a/test/feature/Syntax/Error_StrictSemiColonsNoLint.js
+++ b/test/feature/Syntax/Error_StrictSemiColonsNoLint.js
@@ -1,34 +1,60 @@
 // Should not compile.
 // Options: --strict-semicolons
-// Error: 34:1: Semi-colon expected
+// Error: 21:1: Semi-colon expected
+// Error: 38:1: Semi-colon expected
+// Error: 44:1: Semi-colon expected
+// Error: 51:1: Semi-colon expected
+// Error: 61:1: Semi-colon expected
 
 //:this is a nolint error test.
-// It is identical to StrictSemiColonsNoLint.js except for one missing
-// semicolon.
+// It is identical to StrictSemiColonsNoLint.js except for some missing
+// semicolons. This file needs to end in a newline in order for the line
+// number of the last error to match correctly.
 
-// Note: The leading letter in the var names changes for each expected
-// transition between lint and nolint.
-var a0;
-var a1;
+// Note: The var names begin with 'N' in expected nolint zones and with 'L' in
+// expected lint zones.
+
+//:nolintnot
+var L0;
+var L1 // <<< missing semicolon. The error location is at the next token.
 //:nolint
-var b2
+var N2
 //:nolint These don't nest (should they?).
-var b3
+var N3
 // hello lint
-var b4
-var b5
-var b6;
-var b7
-var b8
+var N4
+var N5;
+var N6
 //:lint
 //:nolint
-var c1
-var c2
+var N7
+var N8
 //:hello lint
-var c3
-var c4
-; // Necessary for nolint-to-lint transitions.
+var N9
+var Na
 //:lint
-var d1 // <<< missing semicolon here. The error location is at the next token.
+var Lb // <<< missing semicolon.
 //:lint
-var d2;
+var Lc;
+//:nolint
+var Nd
+//:lint
+var Le // <<< missing semicolon.
+//:nolint
+var Nf
+//:lint
+//:lint
+var Lg // <<< missing semicolon.
+//:nolint
+//:nolint
+//:lintnot
+var Nh
+//:nolint
+//:lint
+//:nolint
+//:lint
+var Li // <<< missing semicolon.
+//:lint
+//:nolint
+//:lint
+//:nolint

--- a/test/feature/Syntax/StrictSemiColonsNoLint.js
+++ b/test/feature/Syntax/StrictSemiColonsNoLint.js
@@ -2,29 +2,50 @@
 
 //:this is a nolint test.
 
-// Note: The leading letter in the var names changes for each expected
-// transition between lint and nolint.
-var a0;
-var a1;
+// Note: The var names begin with 'N' in expected nolint zones and with 'L' in
+// expected lint zones.
+
+//:nolintnot
+var L0;
+var L1;
 //:nolint
-var b2
+var N2
 //:nolint These don't nest (should they?).
-var b3
+var N3
 // hello lint
-var b4
-var b5
-var b6;
-var b7
-var b8
+var N4
+var N5;
+var N6
 //:lint
 //:nolint
-var c1
-var c2
+var N7
+var N8
 //:hello lint
-var c3
-var c4
-; // Necessary for nolint-to-lint transitions.
+var N9
+var Na
 //:lint
-var d1;
+var Lb;
 //:lint
-var d2;
+var Lc;
+//:nolint
+var Nd
+//:lint
+var Le;
+//:nolint
+var Nf
+//:lint
+//:lint
+var Lg;
+//:nolint
+//:nolint
+//:lintnot
+var Nh
+//:nolint
+//:lint
+//:nolint
+//:lint
+var Li;
+//:lint
+//:nolint
+//:lint
+//:nolint


### PR DESCRIPTION
- No longer necessary to insert a semicolon for 'nolint' to 'lint'
  transitions.
- Fix uncaught semicolon errors on 'lint' to 'nolint' transitions.
- Fix false positive with '//:nolintnot'.
- Make the tests a little easier to follow.

BUG=None
TEST=test/feature/Syntax/Error_StrictSemiColonsNoLint.js
     test/feature/Syntax/StrictSemiColonsNoLint.js
