### PR TITLE
package.json: Require a specific version for 'source-map'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "closure-library": ">=1.0",
-    "source-map": ">=0.1.16"
+    "source-map": "0.1.16"
   }
 }


### PR DESCRIPTION
This will ensure reproducible builds for any checked-out commit of traceur.

BUG=https://github.com/google/traceur-compiler/issues/243
TEST=None

---

I'm using source-map 0.1.16 as the baseline because that's the version that seems to be most common in the commits of `bin/traceur.js` that followed 2070a8aeb6406db0 Wrap the newest version of 'source-map'.

Unfortunately, you can't reproduce the other builds without some (possibly computer-assisted) trial and error.

---

In terms of the motivation for this patch, not much to say at this point beyond my comments in #243.
