### PR TITLE
Implement traceur.require

### DIFF
--- a/src/node/interpreter.js
+++ b/src/node/interpreter.js
@@ -15,23 +15,9 @@
 'use strict';
 
 var fs = require('fs');
-var Module = require('module');
 var traceur = require('./traceur.js');
-var util = require('./file-util.js');
-var inlineAndCompile = require('./inline-module.js').inlineAndCompile;
-
-var ErrorReporter = traceur.util.ErrorReporter;
-var TreeWriter = traceur.outputgeneration.TreeWriter;
-
-var ext = '.traceur-compiled';
-
-Module._extensions[ext] = function(module, filename) {
-  module.filename = filename.slice(0, -ext.length);
-  module._compile(module.compiledCode, module.filename);
-};
 
 function interpret(filename, argv, flags) {
-  var reporter = new ErrorReporter();
   var execArgv = [require.main.filename].concat(flags || []);
 
   filename = fs.realpathSync(filename);
@@ -41,15 +27,7 @@ function interpret(filename, argv, flags) {
   if (traceur.options.deferredFunctions)
     require('./deferred.js').wrap();
 
-  inlineAndCompile([filename], {}, reporter, function(tree) {
-    var module = new Module(filename, require.main);
-
-    module.compiledCode = TreeWriter.write(tree);
-    module.load(filename + ext);
-  }, function(err) {
-    console.error(err);
-    process.exit(1);
-  });
+  return traceur.require(filename);
 }
 
 module.exports = interpret;

--- a/src/node/traceur.js
+++ b/src/node/traceur.js
@@ -26,7 +26,8 @@ if (!data)
 // traceur is a module and thus frozen.
 module.exports = {
   __proto__: traceur,
-  require: function(path) {
-    return require('./require.js')(path);
+  // Wrap in a getter to break cyclic dependencies.
+  get require() {
+    return require('./require.js');
   }
 };


### PR DESCRIPTION
This adds a `require` method to the `traceur` object (in Node.js only) which allows you to require js files that go through traceur just like you would require any other js file in Node.js.

``` js
var traceur = require('./src/node/traceur.js');
var x = traceur.require('./x.js');
```

or

``` js
var traceur = require('./src/node/traceur.js');
traceur.require.makeDefault();
var x = require('./x.js');
```

Fixes #239
