### PR TITLE
Inject loader

### DIFF
--- a/src/node/NodeLoader.js
+++ b/src/node/NodeLoader.js
@@ -1,0 +1,45 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var fs = require('fs');
+
+function stripShebang(data) {
+  if (/^#!/.test(data))
+    data = '//' + data;
+  return data;
+}
+
+function NodeLoader() {}
+
+NodeLoader.prototype = {
+  loadSync: function(url) {
+    return stripShebang(fs.readFileSync(url, 'utf8'));
+  },
+
+  load: function(url, callback, errback) {
+    fs.readFile(url, 'utf8', function(err, data) {
+      if (err)
+        errback(err);
+      else
+        callback(stripShebang(data));
+    });
+
+    // Returns an abort function.
+    return function() {
+      callback = function() {};
+    };
+  }
+};
+
+module.exports = NodeLoader;

--- a/src/node/inline-module.js
+++ b/src/node/inline-module.js
@@ -14,6 +14,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var NodeLoader = require('./NodeLoader.js');
 
 var generateNameForUrl = traceur.generateNameForUrl;
 var ErrorReporter = traceur.util.ErrorReporter;
@@ -98,7 +99,7 @@ var startCodeUnit;
  *     printing was requested.
  */
 function InlineCodeLoader(reporter, project, elements, depTarget) {
-  InternalLoader.call(this, reporter, project);
+  InternalLoader.call(this, reporter, project, new NodeLoader);
   this.elements = elements;
   this.dirname = project.url;
   this.depTarget = depTarget && path.relative('.', depTarget);
@@ -123,33 +124,6 @@ InlineCodeLoader.prototype = {
     if (codeUnit === startCodeUnit)
       return tree;
     return wrapProgram(tree, codeUnit.url, this.dirname);
-  },
-
-  loadTextFile: function(filename, callback, errback) {
-    var text;
-    fs.readFile(path.resolve(this.dirname, filename), 'utf8',
-        function(err, data) {
-          if (err) {
-            errback(err);
-          } else {
-            // Ignore shebang lines
-            if (/^#!/.test(data))
-              data = '//' + data;
-            text = data;
-            callback(data);
-          }
-        });
-
-    return {
-      get responseText() {
-        return text;
-      },
-      abort: function() {}
-    };
-  },
-
-  loadTextFileSync: function(url) {
-    return fs.readFileSync(url, 'utf8');
   }
 };
 

--- a/src/node/module-load-override.js
+++ b/src/node/module-load-override.js
@@ -1,0 +1,21 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This monkey patches the InternalLoader to load the file using
+// fs.readFile and fs.readFileSync.
+
+var traceur = require('./traceur.js');
+var NodeLoader = require('./NodeLoader.js');
+
+traceur.modules.internals.InternalLoader.FileLoader = NodeLoader;

--- a/src/runtime/WebLoader.js
+++ b/src/runtime/WebLoader.js
@@ -1,0 +1,47 @@
+// Copyright 2012 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class WebLoader {
+  /**
+   * @return {Function} A function that aborts the async loading.
+   */
+  load(url, callback, errback) {
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function() {
+      if (xhr.status == 200 || xhr.status == 0) {
+        callback(xhr.responseText);
+      } else {
+        errback();
+      }
+      xhr = null;
+    };
+    xhr.onerror = function() {
+      errback();
+    };
+    xhr.open('GET', url, true);
+    xhr.send();
+    return () => xhr.abort();
+  }
+
+  loadSync(url) {
+    var xhr = new XMLHttpRequest();
+    xhr.onerror = function(e) {
+      throw new Error(xhr.statusText);
+    };
+    xhr.open('GET', url, false);
+    xhr.send();
+    if (xhr.status == 200 || xhr.status == 0)
+      return xhr.responseText;
+  }
+}


### PR DESCRIPTION
This creates two implementations to load text files. One for the web using XMLHttpRequest and one for Node using the fs module. By default Traceur uses the web one and node libraries overrides this.
