### PR TITLE
cli doesn't generate the output file

### DIFF
--- a/src/node/command.js
+++ b/src/node/command.js
@@ -77,7 +77,7 @@ function processArguments(argv) {
   // Preserve the original.
   argv = argv.slice();
 
-  var interpretMode = true;
+  var interpretMode = !(argv.indexOf('--out') > -1);
   for (var i = 2; i < argv.length; i++) {
     var arg = argv[i], index;
     if (arg === '--')
@@ -102,8 +102,6 @@ function processArguments(argv) {
 
     var option = flags.optionFor(arg);
     if (option) {
-      if (arg === '--out')
-        interpretMode = false;
 
       if (option.required)
         i++;


### PR DESCRIPTION
Hi guys, 
`traceur a.js --out b.js`
doesn't generate the output file (b.js), for me at least. It seems like traceur gets stuck in interpretation mode, so here is a quick fix for that. Though it works for me now, I don't suppose it's the solution, probably there're some problems elsewhere under the hood.
