### PR TITLE
Remove Closure Library dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "commander": ">=1.1"
   },
   "devDependencies": {
-    "closure-library": ">=1.0",
     "source-map": "0.1.16",
     "mocha": ">=1.9",
     "chai": ">=1.5"


### PR DESCRIPTION
We no longer use Closure Library for testing.
