### PR TITLE
getopt.js: simplify `nextchar` code.

### DIFF
--- a/src/node/getopt.js
+++ b/src/node/getopt.js
@@ -121,8 +121,7 @@ Getopt.prototype = {
       this.opt = '?';
     }
 
-    this.nextchar %= arg.length;
-    this.optind += !this.nextchar;
+    this.optind += !(this.nextchar %= arg.length);
 
     return true;
   },


### PR DESCRIPTION
I noticed the code was much longer than it needed to be.
