### PR TITLE
Array comprehension: Move temp var into function expression.

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -12110,10 +12110,10 @@ var $___src_codegeneration_ComprehensionTransformer_js = (function() {
         $__superCall(this, $__proto, "constructor", arguments);
       },
       transformComprehension: function(tree, statement, isGenerator) {
-        var returnStatement = arguments[3];
-        var prelude = arguments[4];
+        var prefix = arguments[3];
+        var suffix = arguments[4];
         var bindingKind = isGenerator || !options.blockBinding ? VAR: LET;
-        var statements = prelude ? [prelude]: [];
+        var statements = prefix ? [prefix]: [];
         for (var i = tree.comprehensionList.length - 1; i >= 0; i--) {
           var item = tree.comprehensionList[i];
           switch (item.type) {
@@ -12142,7 +12142,7 @@ var $___src_codegeneration_ComprehensionTransformer_js = (function() {
           statement = AlphaRenamer.rename(statement, THIS, tempVar);
         }
         statements.push(statement);
-        if (returnStatement) statements.push(returnStatement);
+        if (suffix) statements.push(suffix);
         var func = new FunctionExpression(null, null, isGenerator, createEmptyParameterList(), createFunctionBody(statements));
         return createParenExpression(createCallExpression(func));
       }
@@ -12684,11 +12684,11 @@ var $___src_codegeneration_ArrayComprehensionTransformer_js = (function() {
         var expression = this.transformAny(tree.expression);
         var index = createIdentifierExpression(this.getTempIdentifier());
         var result = createIdentifierExpression(this.getTempIdentifier());
-        var prelude = parseStatement($__0, index, result);
+        var tempVarsStatatement = parseStatement($__0, index, result);
         var statement = parseStatement($__1, result, index, expression);
         var returnStatement = parseStatement($__2, result);
         var isGenerator = false;
-        var result = this.transformComprehension(tree, statement, isGenerator, returnStatement, prelude);
+        var result = this.transformComprehension(tree, statement, isGenerator, tempVarsStatatement, returnStatement);
         this.popTempVarState();
         return result;
       }

--- a/src/codegeneration/ArrayComprehensionTransformer.js
+++ b/src/codegeneration/ArrayComprehensionTransformer.js
@@ -54,13 +54,14 @@ export class ArrayComprehensionTransformer extends ComprehensionTransformer {
     var index = createIdentifierExpression(this.getTempIdentifier());
     var result = createIdentifierExpression(this.getTempIdentifier());
 
-    var prelude = parseStatement `var ${index} = 0, ${result} = [];`;
+    var tempVarsStatatement = parseStatement `var ${index} = 0, ${result} = [];`;
     var statement = parseStatement `${result}[${index}++] = ${expression};`;
     var returnStatement = parseStatement `return ${result};`;
     var isGenerator = false;
 
     var result = this.transformComprehension(tree, statement, isGenerator,
-                                            returnStatement, prelude);
+                                             tempVarsStatatement,
+                                             returnStatement);
     this.popTempVarState();
     return result;
   }

--- a/src/codegeneration/ComprehensionTransformer.js
+++ b/src/codegeneration/ComprehensionTransformer.js
@@ -75,18 +75,18 @@ export class ComprehensionTransformer extends TempVarTransformer {
    * @param {ParseTree} statement The statement that goes inside the innermost
    *     loop (and if if present).
    * @param {boolean} isGenerator
-   * @param {ParseTree=} returnStatement
-   * @param {ParseTree=} prelude
+   * @param {ParseTree=} prefix
+   * @param {ParseTree=} suffix
    * @return {ParseTree}
    */
   transformComprehension(tree, statement, isGenerator,
-      returnStatement = undefined, prelude = undefined) {
+      prefix = undefined, suffix = undefined) {
 
     // This should really be a let but we don't support let in generators.
     // https://code.google.com/p/traceur-compiler/issues/detail?id=6
     var bindingKind = isGenerator || !options.blockBinding ? VAR : LET;
 
-    var statements = prelude ? [prelude] : [];
+    var statements = prefix ? [prefix] : [];
 
     for (var i = tree.comprehensionList.length - 1; i >= 0; i--) {
       var item = tree.comprehensionList[i];
@@ -123,8 +123,8 @@ export class ComprehensionTransformer extends TempVarTransformer {
     }
 
     statements.push(statement);
-    if (returnStatement)
-      statements.push(returnStatement);
+    if (suffix)
+      statements.push(suffix);
 
     var func = new FunctionExpression(null, null, isGenerator,
                                       createEmptyParameterList(),


### PR DESCRIPTION
Manage the temp var manually instead of using `addTempVar` and pass in a `prelude` statement.

Fixes #296
