### PR TITLE
Add missing `to` in `path.relative(from, to)` in `compileToDirectory`.

### DIFF
--- a/src/node/compiler.js
+++ b/src/node/compiler.js
@@ -93,7 +93,7 @@ function compileToDirectory(outputFile, includes, useSourceMaps) {
     inlineAndCompile(includes.slice(current, current + 1), {}, reporter,
         function(tree) {
           var outputFile = path.join(outputDir, includes[current]);
-          var sourceRoot = path.relative(path.dirname(outputFile));
+          var sourceRoot = path.relative(path.dirname(outputFile), '.');
           writeTreeToFile(tree, outputFile, useSourceMaps, sourceRoot);
           current++;
           next();


### PR DESCRIPTION
Commit joyent/node@089ec5861357 to node broke this non-standard shortcut.

Fixes #304
