### PR TITLE
Add missing `node_modules` dependency to `Makefile`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ bin/traceur.js force:
 build/dep.mk: | $(GENSRC) node_modules
 	node build/makedep.js --depTarget bin/traceur.js $(TFLAGS) $(SRC) > $@
 
+$(TPL_GENSRC_DEPS): | node_modules
+
 src/syntax/trees/ParseTrees.js: \
   build/build-parse-trees.js src/syntax/trees/trees.json
 	node $^ > $@


### PR DESCRIPTION
`$(TPL_GENSRC_DEPS)` depends on `node_modules`. This was causing `make`
to fail with a fresh repo clone. This isn't the cleanest solution, but
there may not be one, since there is a catch-22 here. We can't know the
full set of prerequisites without at least initializing the
`node_modules` prerequisite.

Discussion link:
https://groups.google.com/d/msg/traceur-compiler-discuss/zWvNP_6gHKg/FlcmRC2MwmsJ
