### PR TITLE
Fix issue with Windows style path separators

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -469,8 +469,6 @@ var $___src_util_url_js = (function() {
   }
   function resolveUrl(base, url) {
     if (url[0] === '@') return url;
-    base = base.replace(/\\/g, '/');
-    url = url.replace(/\\/g, '/');
     var parts = split(url);
     var baseParts = split(base);
     if (parts[ComponentIndex.SCHEME]) {
@@ -3233,7 +3231,7 @@ var $___src_semantics_symbols_ModuleSymbol_js = (function() {
         if (!url) {
           console.error('Missing URL');
         }
-        this.url = url;
+        this.url = url.replace(/\\/g, '/');
       },
       addModule: function(module) {
         this.addModuleWithName(module, module.name);

--- a/build/makedep.js
+++ b/build/makedep.js
@@ -24,6 +24,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var normalizePath = require('../src/node/file-util.js').normalizePath;
 
 var flags;
 var cmdName = path.basename(process.argv[1]);
@@ -58,7 +59,7 @@ if (!includes.length) {
 var ErrorReporter = traceur.util.ErrorReporter;
 
 var resolvedIncludes = includes.map(function(include) {
-  return path.resolve(include);
+  return normalizePath(path.resolve(include));
 });
 
 var reporter = new ErrorReporter();

--- a/src/node/compiler.js
+++ b/src/node/compiler.js
@@ -23,6 +23,7 @@ var inlineAndCompile = require('./inline-module.js').inlineAndCompile;
 var util = require('./file-util.js');
 var writeFile = util.writeFile;
 var mkdirRecursive = util.mkdirRecursive;
+var normalizePath = util.normalizePath;
 
 var ErrorReporter = traceur.util.ErrorReporter;
 var TreeWriter = traceur.outputgeneration.TreeWriter;
@@ -69,7 +70,7 @@ function compileToSingleFile(outputFile, includes, useSourceMaps) {
 
   // Make includes relative to output dir so that sourcemap paths are correct.
   resolvedIncludes = resolvedIncludes.map(function(include) {
-    return path.relative(outputDir, include);
+    return normalizePath(path.relative(outputDir, include));
   });
 
   inlineAndCompile(resolvedIncludes, {}, reporter, function(tree) {

--- a/src/node/file-util.js
+++ b/src/node/file-util.js
@@ -64,6 +64,11 @@ function writeFile(filename, contents) {
   fs.writeFileSync(outputfile, contents, 'utf8');
 }
 
+function normalizePath(s) {
+  return path.sep == '\\' ? s.replace(/\\/g, '/') : s;
+}
+
 exports.mkdirRecursive = mkdirRecursive;
+exports.normalizePath = normalizePath;
 exports.removeCommonPrefix = removeCommonPrefix;
 exports.writeFile = writeFile;

--- a/src/node/inline-module.js
+++ b/src/node/inline-module.js
@@ -15,6 +15,7 @@
 var fs = require('fs');
 var path = require('path');
 var NodeLoader = require('./NodeLoader.js');
+var normalizePath = require('./file-util.js').normalizePath;
 
 var generateNameForUrl = traceur.generateNameForUrl;
 var ErrorReporter = traceur.util.ErrorReporter;
@@ -102,7 +103,7 @@ function InlineCodeLoader(reporter, project, elements, depTarget) {
   InternalLoader.call(this, reporter, project, new NodeLoader);
   this.elements = elements;
   this.dirname = project.url;
-  this.depTarget = depTarget && path.relative('.', depTarget);
+  this.depTarget = depTarget && normalizePath(path.relative('.', depTarget));
   this.codeUnitList = [];
 }
 
@@ -118,9 +119,10 @@ InlineCodeLoader.prototype = {
   transformCodeUnit: function(codeUnit) {
     var transformer = new ModuleRequireTransformer(codeUnit.url, this.dirname);
     var tree = transformer.transformAny(codeUnit.tree);
-    if (this.depTarget)
+    if (this.depTarget) {
       console.log('%s: %s', this.depTarget,
-                  path.relative(path.join(__dirname, '../..'), codeUnit.url));
+                  normalizePath(path.relative(path.join(__dirname, '../..'), codeUnit.url)));
+    }
     if (codeUnit === startCodeUnit)
       return tree;
     return wrapProgram(tree, codeUnit.url, this.dirname);

--- a/src/semantics/symbols/ModuleSymbol.js
+++ b/src/semantics/symbols/ModuleSymbol.js
@@ -31,7 +31,7 @@ export class ModuleSymbol extends Symbol {
       // TODO(arv): Find offensive callers.
       console.error('Missing URL');
     }
-    this.url = url;
+    this.url = url.replace(/\\/g, '/');
   }
 
   /**

--- a/src/util/url.js
+++ b/src/util/url.js
@@ -282,10 +282,6 @@ export function resolveUrl(base, url) {
   if (url[0] === '@')
     return url;
 
-  // Make Windows style path separators work.
-  base = base.replace(/\\/g, '/');
-  url = url.replace(/\\/g, '/');
-
   var parts = split(url);
   var baseParts = split(base);
 


### PR DESCRIPTION
`resolveUrl` was written for URLs and not file paths with `\` in them. By replacing all `\` with `/` things works on Windows too.

Fixes #312
