### PR TITLE
Add support for binary and octal numeric literals

### DIFF
--- a/src/codegeneration/NumericLiteralTransformer.js
+++ b/src/codegeneration/NumericLiteralTransformer.js
@@ -1,0 +1,109 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ParseTreeTransformer} from './ParseTreeTransformer.js';
+import {
+  GetAccessor,
+  LiteralExpression,
+  PropertyMethodAssignment,
+  PropertyNameAssignment,
+  SetAccessor,
+} from '../syntax/trees/ParseTrees.js';
+import {LiteralToken} from '../syntax/LiteralToken.js';
+import {
+  NUMBER
+} from '../syntax/TokenType.js';
+
+function needsTransform(token) {
+  return token.type === NUMBER && /^0[bBoO]/.test(token.value);
+}
+
+function transformToken(token) {
+  return new LiteralToken(NUMBER,
+                          String(token.processedValue),
+                          token.location);
+}
+
+export class NumericLiteralTransformer extends ParseTreeTransformer {
+  transformLiteralExpression(tree) {
+    var token = tree.literalToken;
+    if (needsTransform(token))
+      return new LiteralExpression(tree.location, transformToken(token));
+    return tree;
+  }
+
+  transformPropertyNameAssignment(tree) {
+    var token = tree.name;
+    if (needsTransform(token)) {
+      var value = this.transformAny(tree.value);
+      return new PropertyNameAssignment(
+          tree.location,
+          transformToken(token),
+          value);
+    }
+    return super.transformPropertyNameAssignment(tree);
+  }
+
+  transformGetAccessor(tree) {
+    var token = tree.name;
+    if (needsTransform(token)) {
+      var body = this.transformAny(tree.body);
+      return new GetAccessor(
+          tree.location,
+          tree.isStatic,
+          transformToken(token),
+          body);
+    }
+    return super.transformGetAccessor(tree);
+  }
+
+  transformSetAccessor(tree) {
+    var token = tree.name;
+    if (needsTransform(token)) {
+      var parameter = this.transformAny(tree.parameter);
+      var body = this.transformAny(tree.body);
+      return new SetAccessor(
+          tree.location,
+          tree.isStatic,
+          transformToken(token),
+          parameter,
+          body);
+    }
+    return super.transformSetAccessor(tree);
+  }
+
+  transformPropertyMethodAssignment(tree) {
+    var token = tree.name;
+    if (needsTransform(token)) {
+      var formalParameterList = this.transformAny(tree.formalParameterList);
+      var functionBody = this.transformAny(tree.functionBody);
+      return new PropertyMethodAssignment(
+          tree.location,
+          tree.isStatic,
+          tree.isGenerator,
+          transformToken(token),
+          formalParameterList,
+          functionBody);
+    }
+    return super.transformPropertyMethodAssignment(tree);
+  }
+
+  /**
+   * @param {ParseTree} tree
+   * @return {ParseTree}
+   */
+  static transformTree(tree) {
+    return new NumericLiteralTransformer().transformAny(tree);
+  }
+}

--- a/src/codegeneration/ProgramTransformer.js
+++ b/src/codegeneration/ProgramTransformer.js
@@ -28,6 +28,7 @@ import {GeneratorComprehensionTransformer} from
     'GeneratorComprehensionTransformer.js';
 import {GeneratorTransformPass} from './GeneratorTransformPass.js';
 import {ModuleTransformer} from './ModuleTransformer.js';
+import {NumericLiteralTransformer} from './NumericLiteralTransformer.js';
 import {ObjectLiteralTransformer} from './ObjectLiteralTransformer.js';
 import {ObjectMap} from '../util/ObjectMap.js';
 import {ParseTreeValidator} from '../syntax/ParseTreeValidator.js';
@@ -125,6 +126,7 @@ export class ProgramTransformer {
     // tree pass
 
     transform(transformOptions.types, TypeTransformer);
+    transform(transformOptions.numericLiterals, NumericLiteralTransformer);
 
     transform(transformOptions.templateLiterals,
               TemplateLiteralTransformer,

--- a/src/options.js
+++ b/src/options.js
@@ -257,6 +257,7 @@ addFeatureOption('spread', ON_BY_DEFAULT);             // 11.1.4, 11.2.5
 addFeatureOption('generatorComprehension', ON_BY_DEFAULT);
 addFeatureOption('generators', ON_BY_DEFAULT); // 13.4, incomplete
 addFeatureOption('modules', ON_BY_DEFAULT);    // 14
+addFeatureOption('numericLiterals', ON_BY_DEFAULT);
 
 // EXPERIMENTAL
 addFeatureOption('blockBinding', EXPERIMENTAL);       // 12.1

--- a/src/syntax/LiteralToken.js
+++ b/src/syntax/LiteralToken.js
@@ -134,6 +134,17 @@ export class LiteralToken extends Token {
         return null;
 
       case NUMBER:
+        var value = this.value;
+        if (value.charCodeAt(0) === 48) {  // 0
+          switch (value.charCodeAt(1)) {
+            case 66:  // B
+            case 98:  // b
+              return parseInt(this.value.slice(2), 2);
+            case 79:  // O
+            case 111:  // o
+              return parseInt(this.value.slice(2), 8);
+          }
+        }
         return Number(this.value);
 
       case STRING:

--- a/test/feature/NumericLiteral/Error_Disabled.js
+++ b/test/feature/NumericLiteral/Error_Disabled.js
@@ -1,0 +1,5 @@
+// Should not compile.
+// Options: --numeric-literals=false
+// Error: :5:2: Semi-colon expected
+
+0b11;

--- a/test/feature/NumericLiteral/Error_NoBinaryDigits.js
+++ b/test/feature/NumericLiteral/Error_NoBinaryDigits.js
@@ -1,0 +1,5 @@
+// Should not compile.
+// Options: --numeric-literals
+// Error: :5:3: Binary Integer Literal must contain at least one digit
+
+0b;

--- a/test/feature/NumericLiteral/Error_NoOctalDigits.js
+++ b/test/feature/NumericLiteral/Error_NoOctalDigits.js
@@ -1,0 +1,5 @@
+// Should not compile.
+// Options: --numeric-literals
+// Error: :5:3: Octal Integer Literal must contain at least one digit
+
+0o;

--- a/test/feature/NumericLiteral/Simple.js
+++ b/test/feature/NumericLiteral/Simple.js
@@ -1,0 +1,90 @@
+// Options: --numeric-literals
+
+(function() {
+  assert.equal(0, 0b0);
+  assert.equal(1, 0b1);
+  assert.equal(3, 0b11);
+  assert.equal(3, 0b011);
+  assert.equal(0, 0B0);
+  assert.equal(1, 0B1);
+  assert.equal(3, 0B11);
+  assert.equal(3, 0B011);
+
+  assert.equal(0, 0o0);
+  assert.equal(1, 0o1);
+  assert.equal(7, 0o7);
+  assert.equal(8, 0o10);
+  assert.equal(8, 0o010);
+  assert.equal(63, 0o77);
+  assert.equal(0, 0O0);
+  assert.equal(1, 0O1);
+  assert.equal(7, 0O7);
+  assert.equal(8, 0O10);
+  assert.equal(8, 0O010);
+  assert.equal(63, 0O77);
+
+  var o = {
+    0b0: 0,
+    0b1: 1,
+    0b10: 2,
+    0B11: 3,
+    0B0100: 4
+  };
+  assertArrayEquals(Object.keys(o), ['0', '1', '2', '3', '4']);
+
+  var o = {
+    0o0: 0,
+    0o1: 1,
+    0o7: 7,
+    0O10: 8,
+    0O011: 9
+  };
+  assertArrayEquals(Object.keys(o), ['0', '1', '7', '8', '9']);
+
+  var o = {
+    get 0b0() {},
+    get 0b1() {},
+    get 0b10() {},
+    get 0B11() {},
+    get 0B0100() {}
+  };
+  assertArrayEquals(Object.keys(o), ['0', '1', '2', '3', '4']);
+
+  var o = {
+    set 0o0(v) {},
+    set 0o1(v) {},
+    set 0o7(v) {},
+    set 0O10(v) {},
+    set 0O011(v) {}
+  };
+  assertArrayEquals(Object.keys(o), ['0', '1', '7', '8', '9']);
+
+  var o = {
+    0b0() {},
+    0b1() {},
+    0b10() {},
+    0B11() {},
+    0B0100() {}
+  };
+  assertArrayEquals(Object.keys(o), ['0', '1', '2', '3', '4']);
+
+  class C {
+    0b0() {}
+    get 0b1() {}
+    set 0b10(v) {}
+    static 0B11() {}
+    static get 0B100() {}
+    static set 0B101(v) {}
+
+    0o6() {}
+    get 0o7() {}
+    set 0o10(v) {}
+    static 0O11() {}
+    static get 0O12() {}
+    static set 0O13(v) {}
+  }
+  assertArrayEquals(Object.keys(C.prototype),
+      ['0', '1', '2', '6', '7', '8']);
+  assertArrayEquals(Object.keys(C),
+      ['3', '4', '5', '9', '10', '11']);
+})();


### PR DESCRIPTION
This is on by default but can be turned off using
--numeric-literals=false

We support 0b11 and 0o77 in all places where NumericLiteral
is supported.
