### PR TITLE
Add support for return yield expression

### DIFF
--- a/test/feature/Yield/ReturnYield.js
+++ b/test/feature/Yield/ReturnYield.js
@@ -1,0 +1,8 @@
+function* f() {
+  return yield 111;
+}
+
+var g = f();
+
+assert.deepEqual({value: 111, done: false}, g.next());
+assert.deepEqual({value: undefined, done: done}, g.next());

--- a/test/feature/Yield/ReturnYieldFor.js
+++ b/test/feature/Yield/ReturnYieldFor.js
@@ -1,0 +1,15 @@
+function* f() {
+  return yield* h();
+}
+
+function* h() {
+  yield 111;
+  yield 222;
+  return 333;
+}
+
+var g = f();
+
+assert.deepEqual({value: 111, done: false}, g.next());
+assert.deepEqual({value: 222, done: false}, g.next());
+assert.deepEqual({value: 333, done: true}, g.next());


### PR DESCRIPTION
This adds support for `return yield expression` by transforming that to `{yield expression; return $yieldSent}`. This is done the same was as for `var a = yield b` statements.

Fixes #317
