### PR TITLE
Fix issue with scanning regular expressions

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -7895,10 +7895,7 @@ var $___src_syntax_Scanner_js = (function() {
     return token ? token.location.start.offset: index;
   }
   function nextRegularExpressionLiteralToken() {
-    var beginIndex = index - 1;
-    if (input.charCodeAt(beginIndex) === 61) {
-      beginIndex = beginIndex - 1;
-    }
+    var beginIndex = index - token.toString().length;
     if (!skipRegularExpressionBody()) {
       return new LiteralToken(REGULAR_EXPRESSION, getTokenString(beginIndex), getTokenRange(beginIndex));
     }

--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -348,12 +348,9 @@ function getOffset() {
 
 /** @return {LiteralToken} */
 function nextRegularExpressionLiteralToken() {
-  // We already passed the leading / so subtract 1, and subtract
-	// an additional 1 if we already ready past /=
-  var beginIndex = index - 1;
-	if (input.charCodeAt(beginIndex) === 61) {  // =
-		beginIndex = beginIndex - 1;
-	}
+  // We already passed the leading / or /= so subtract the length of the last
+  // token.
+  var beginIndex = index - token.toString().length;
 
   // body
   if (!skipRegularExpressionBody()) {

--- a/test/feature/Syntax/RegularExpression.js
+++ b/test/feature/Syntax/RegularExpression.js
@@ -1,0 +1,3 @@
+var re1 = /a*b/;
+var re2 = /=a+/;
+var re3 = /\//;

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -32,15 +32,4 @@ suite('parser.js', function() {
     parser.parseProgram(true);
   });
 
-	test('RegularExpression', function() {
-    var program = 'var re1 = /a*b/; ' +
-                  'var re2 = /=a+/; ' +
-                  'var re3 = /\\//;\n';
-
-    var sourceFile = new traceur.syntax.SourceFile('Name', program);
-    var parser = new traceur.syntax.Parser(errorReporter, sourceFile);
-
-    parser.parseProgram(true);
-	});
-
 });


### PR DESCRIPTION
Since both / and /= are tokens that may start the regular expression we need to go back one or two characters respectively.

This is based on #327 by @seanmiddleditch

Fixes #326
Fixes #327
