### PR TITLE
Fix issue with generators and empty for loop headers

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -14957,7 +14957,7 @@ var $___src_codegeneration_generator_CPSTransformer_js = (function() {
         var loopBodyMachine = result.body;
         var incrementState = loopBodyMachine.fallThroughState;
         var conditionState = result.increment == null && result.condition != null ? incrementState: this.allocateState();
-        var startState = result.initializer == null ? conditionState: this.allocateState();
+        var startState = result.initializer == null ? (result.condition == null ? loopBodyMachine.startState: conditionState): this.allocateState();
         var fallThroughState = this.allocateState();
         var states = [];
         if (result.initializer != null) {
@@ -15286,7 +15286,7 @@ var $___src_codegeneration_generator_CPSTransformer_js = (function() {
         cases.push(createCaseClause(createNumberLiteral(machine.fallThroughState), this.machineFallThroughStatements(machineEndState)));
         cases.push(createCaseClause(createNumberLiteral(machineEndState), this.machineEndStatements()));
         cases.push(createCaseClause(createNumberLiteral(rethrowState), this.machineRethrowStatements(machineEndState)));
-        cases.push(createDefaultClause([createThrowStatement(createBinaryOperator(createStringLiteral('traceur compiler bug: invalid state in state machine'), createOperatorToken(PLUS), createIdentifierExpression(STATE)))]));
+        cases.push(createDefaultClause([createThrowStatement(createBinaryOperator(createStringLiteral('traceur compiler bug: invalid state in state machine: '), createOperatorToken(PLUS), createIdentifierExpression(STATE)))]));
         return cases;
       },
       addFinallyFallThroughDispatches: function(enclosingFinallyState, tryStates, cases) {
@@ -17585,7 +17585,7 @@ var $___src_syntax_ParseTreeValidator_js = (function() {
           this.checkVisit_(tree.condition.isExpression(), tree.condition, 'expression expected');
         }
         if (tree.increment !== null) {
-          this.checkVisit_(tree.condition.isExpression(), tree.increment, 'expression expected');
+          this.checkVisit_(tree.increment.isExpression(), tree.increment, 'expression expected');
         }
         this.checkVisit_(tree.body.isStatement(), tree.body, 'statement expected');
       },

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -307,7 +307,8 @@ export class CPSTransformer extends ParseTreeTransformer {
             this.allocateState();
     var startState =
         result.initializer == null ?
-            conditionState :
+            (result.condition == null ?
+                loopBodyMachine.startState : conditionState) :
             this.allocateState();
     var fallThroughState = this.allocateState();
 
@@ -328,8 +329,8 @@ export class CPSTransformer extends ParseTreeTransformer {
               fallThroughState,
               result.condition));
     } else {
-      // alternative is to renumber the loopbodyMachine.fallThrough to
-      // loopbodyMachine.start
+      // alternative is to renumber the loopBodyMachine.fallThrough to
+      // loopBodyMachine.start
       states.push(
           new FallThroughState(
               conditionState,
@@ -1178,7 +1179,7 @@ export class CPSTransformer extends ParseTreeTransformer {
             [createThrowStatement(
                 createBinaryOperator(
                     createStringLiteral(
-                        'traceur compiler bug: invalid state in state machine'),
+                        'traceur compiler bug: invalid state in state machine: '),
                     createOperatorToken(PLUS),
                     createIdentifierExpression(STATE)))]));
     return cases;

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -580,7 +580,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
           'expression expected');
     }
     if (tree.increment !== null) {
-      this.checkVisit_(tree.condition.isExpression(), tree.increment,
+      this.checkVisit_(tree.increment.isExpression(), tree.increment,
           'expression expected');
     }
     this.checkVisit_(tree.body.isStatement(), tree.body,

--- a/test/feature/Yield/ForMissingParts.js
+++ b/test/feature/Yield/ForMissingParts.js
@@ -1,0 +1,56 @@
+function* f0() {
+  for (;;) {
+    yield 0;
+  }
+}
+
+function* f1() {
+  for (; ; 1) {
+    yield 1;
+  }
+}
+
+function* f2() {
+  for (; 1; ) {
+    yield 2;
+  }
+}
+
+function* f3() {
+  for (; 1; 1) {
+    yield 3;
+  }
+}
+
+function* f4() {
+  for (1; ; ) {
+    yield 4;
+  }
+}
+
+function* f5() {
+  for (1; ; 1) {
+    yield 5;
+  }
+}
+
+function* f6() {
+  for (1; 1; ) {
+    yield 6;
+  }
+}
+
+function* f7() {
+  for (1; 1; 1) {
+    yield 7;
+  }
+}
+
+assert.equal(0, f0().next().value);
+assert.equal(1, f1().next().value);
+assert.equal(2, f2().next().value);
+assert.equal(3, f3().next().value);
+assert.equal(4, f4().next().value);
+assert.equal(5, f5().next().value);
+assert.equal(6, f6().next().value);
+assert.equal(7, f7().next().value);


### PR DESCRIPTION
In case we have neither initializer state nor condition state, set the start state to the start state of the loop body.

Fixes #331
