### PR TITLE
Require curly parens around import and export

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -8855,11 +8855,8 @@ var $___src_syntax_Parser_js = (function() {
           this.eat_(CLOSE_CURLY);
           return new ImportSpecifierSet(this.getTreeLocation_(start), specifiers);
         }
-        if (this.peek_(STAR)) {
-          var star = this.eat_(STAR);
-          return new ImportSpecifierSet(this.getTreeLocation_(start), star);
-        }
-        return this.parseIdentifierNameExpression_();
+        var star = this.eat_(STAR);
+        return new ImportSpecifierSet(this.getTreeLocation_(start), star);
       },
       parseImportSpecifier_: function() {
         var start = this.getTreeStartLocation_();
@@ -8918,15 +8915,13 @@ var $___src_syntax_Parser_js = (function() {
       parseExportMapping_: function(load) {
         var start = this.getTreeStartLocation_();
         var specifierSet, expression;
-        if (this.eatIf_(STAR)) {
-          specifierSet = new ExportStar(this.getTreeLocation_(start));
-          expression = this.parseFromModuleExpressionOpt_(load, true);
-        } else if (this.peek_(OPEN_CURLY)) {
+        if (this.peek_(OPEN_CURLY)) {
           specifierSet = this.parseExportSpecifierSet_();
           expression = this.parseFromModuleExpressionOpt_(load, false);
         } else {
-          specifierSet = this.parseIdentifierExpression_();
-          expression = this.parseFromModuleExpressionOpt_(load, false);
+          this.eat_(STAR);
+          specifierSet = new ExportStar(this.getTreeLocation_(start));
+          expression = this.parseFromModuleExpressionOpt_(load, true);
         }
         return new ExportMapping(this.getTreeLocation_(start), expression, specifierSet);
       },
@@ -15909,7 +15904,7 @@ var $___src_codegeneration_generator_GeneratorTransformer_js = (function() {
 }).call(this);
 var $___src_codegeneration_GeneratorTransformPass_js = (function() {
   "use strict";
-  var $__2 = Object.freeze(Object.defineProperties(["\r\n          if (", " == ", ") {\r\n            ", " = ", ";\r\n            throw ", ";\r\n          }"], {raw: {value: Object.freeze(["\r\n          if (", " == ", ") {\r\n            ", " = ", ";\r\n            throw ", ";\r\n          }"])}})), $__3 = Object.freeze(Object.defineProperties(["\r\n        {\r\n          var ", " = ", ".getIterator(", ");\r\n          var ", ";\r\n\r\n          // TODO: Should 'yield *' handle non-generator iterators? A strict\r\n          // interpretation of harmony:generators would indicate 'no', but\r\n          // 'yes' seems makes more sense from a language-user's perspective.\r\n\r\n          // received = void 0;\r\n          ", " = void 0;\r\n          // send = true; // roughly equivalent\r\n          ", " = ", ";\r\n\r\n          while (true) {\r\n            if (", " == ", ") {\r\n              ", " = ", ".next(", ");\r\n            } else {\r\n              ", " = ", ".throw(", ");\r\n            }\r\n            if (", ".done) {\r\n              ", " = ", ".value;\r\n              break;\r\n            }\r\n            // Normally, this would go through transformYieldForExpression_\r\n            // which would rethrow and we would catch it and set up the states\r\n            // again.\r\n            ", ";\r\n          }\r\n        }"], {raw: {value: Object.freeze(["\r\n        {\r\n          var ", " = ", ".getIterator(", ");\r\n          var ", ";\r\n\r\n          // TODO: Should 'yield *' handle non-generator iterators? A strict\r\n          // interpretation of harmony:generators would indicate 'no', but\r\n          // 'yes' seems makes more sense from a language-user's perspective.\r\n\r\n          // received = void 0;\r\n          ", " = void 0;\r\n          // send = true; // roughly equivalent\r\n          ", " = ", ";\r\n\r\n          while (true) {\r\n            if (", " == ", ") {\r\n              ", " = ", ".next(", ");\r\n            } else {\r\n              ", " = ", ".throw(", ");\r\n            }\r\n            if (", ".done) {\r\n              ", " = ", ".value;\r\n              break;\r\n            }\r\n            // Normally, this would go through transformYieldForExpression_\r\n            // which would rethrow and we would catch it and set up the states\r\n            // again.\r\n            ", ";\r\n          }\r\n        }"])}}));
+  var $__2 = Object.freeze(Object.defineProperties(["\n          if (", " == ", ") {\n            ", " = ", ";\n            throw ", ";\n          }"], {raw: {value: Object.freeze(["\n          if (", " == ", ") {\n            ", " = ", ";\n            throw ", ";\n          }"])}})), $__3 = Object.freeze(Object.defineProperties(["\n        {\n          var ", " = ", ".getIterator(", ");\n          var ", ";\n\n          // TODO: Should 'yield *' handle non-generator iterators? A strict\n          // interpretation of harmony:generators would indicate 'no', but\n          // 'yes' seems makes more sense from a language-user's perspective.\n\n          // received = void 0;\n          ", " = void 0;\n          // send = true; // roughly equivalent\n          ", " = ", ";\n\n          while (true) {\n            if (", " == ", ") {\n              ", " = ", ".next(", ");\n            } else {\n              ", " = ", ".throw(", ");\n            }\n            if (", ".done) {\n              ", " = ", ".value;\n              break;\n            }\n            // Normally, this would go through transformYieldForExpression_\n            // which would rethrow and we would catch it and set up the states\n            // again.\n            ", ";\n          }\n        }"], {raw: {value: Object.freeze(["\n        {\n          var ", " = ", ".getIterator(", ");\n          var ", ";\n\n          // TODO: Should 'yield *' handle non-generator iterators? A strict\n          // interpretation of harmony:generators would indicate 'no', but\n          // 'yes' seems makes more sense from a language-user's perspective.\n\n          // received = void 0;\n          ", " = void 0;\n          // send = true; // roughly equivalent\n          ", " = ", ";\n\n          while (true) {\n            if (", " == ", ") {\n              ", " = ", ".next(", ");\n            } else {\n              ", " = ", ".throw(", ");\n            }\n            if (", ".done) {\n              ", " = ", ".value;\n              break;\n            }\n            // Normally, this would go through transformYieldForExpression_\n            // which would rethrow and we would catch it and set up the states\n            // again.\n            ", ";\n          }\n        }"])}}));
   var AsyncTransformer = $___src_codegeneration_generator_AsyncTransformer_js.AsyncTransformer;
   var ForInTransformPass = $___src_codegeneration_generator_ForInTransformPass_js.ForInTransformPass;
   var $__10 = $___src_syntax_trees_ParseTrees_js, GetAccessor = $__10.GetAccessor, SetAccessor = $__10.SetAccessor;

--- a/src/runtime/modules.js
+++ b/src/runtime/modules.js
@@ -665,9 +665,9 @@ export class CodeLoader {
 }
 
 export module internals {
-  export CodeUnit;
-  export EvalCodeUnit;
-  export EvalLoadCodeUnit;
-  export InternalLoader;
-  export LoadCodeUnit;
+  export {CodeUnit};
+  export {EvalCodeUnit};
+  export {EvalLoadCodeUnit};
+  export {InternalLoader};
+  export {LoadCodeUnit};
 };

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -350,7 +350,6 @@ export class Parser {
   }
 
   //ImportSpecifierSet ::= "*"
-  //                  | IdentifierName
   //                  | "{" (ImportSpecifier ("," ImportSpecifier)*)? ","? "}"
   /**
    * @param {SourcePosition} start
@@ -374,12 +373,8 @@ export class Parser {
       return new ImportSpecifierSet(this.getTreeLocation_(start), specifiers);
     }
 
-    if (this.peek_(STAR)) {
-      var star = this.eat_(STAR);
-      return new ImportSpecifierSet(this.getTreeLocation_(start), star);
-    }
-
-    return this.parseIdentifierNameExpression_();
+    var star = this.eat_(STAR);
+    return new ImportSpecifierSet(this.getTreeLocation_(start), star);
   }
 
   // ImportSpecifier ::= IdentifierName ("as" Identifier)?
@@ -461,22 +456,19 @@ export class Parser {
 
   parseExportMapping_(load) {
     // ExportMapping ::=
-    //     Identifier ("from" ModuleExpression(load))?
     //     "*" "from" ModuleExpression(load)
     //     ExportSpecifierSet ("from" ModuleExpression(load))?
     var start = this.getTreeStartLocation_();
 
     var specifierSet, expression;
 
-    if (this.eatIf_(STAR)) {
-      specifierSet = new ExportStar(this.getTreeLocation_(start));
-      expression = this.parseFromModuleExpressionOpt_(load, true);
-    } else if (this.peek_(OPEN_CURLY)) {
+    if (this.peek_(OPEN_CURLY)) {
       specifierSet = this.parseExportSpecifierSet_();
       expression = this.parseFromModuleExpressionOpt_(load, false);
-    } else {  // ID
-      specifierSet = this.parseIdentifierExpression_();
-      expression = this.parseFromModuleExpressionOpt_(load, false);
+    } else {
+      this.eat_(STAR);
+      specifierSet = new ExportStar(this.getTreeLocation_(start));
+      expression = this.parseFromModuleExpressionOpt_(load, true);
     }
 
     return new ExportMapping(this.getTreeLocation_(start), expression,

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -16,7 +16,7 @@ module traceur {
   var global = this;
 
   import {options} from './options.js';
-  export options;
+  export {options};
 
   /**
    * Generates an identifier string that represents a URL.
@@ -47,60 +47,60 @@ module traceur {
       throw Error('Assertion failed');
   }
 
-  export WebPageProject from './WebPageProject.js';
+  export {WebPageProject} from './WebPageProject.js';
 
   export module semantics {
-    export FreeVariableChecker from './semantics/FreeVariableChecker.js';
-    export ModuleAnalyzer from './semantics/ModuleAnalyzer.js';
-    export VariableBinder from './semantics/VariableBinder.js';
+    export {FreeVariableChecker} from './semantics/FreeVariableChecker.js';
+    export {ModuleAnalyzer} from './semantics/ModuleAnalyzer.js';
+    export {VariableBinder} from './semantics/VariableBinder.js';
 
     export module symbols {
-      export Project from './semantics/symbols/Project.js';
+      export {Project} from './semantics/symbols/Project.js';
     }
   }
 
   export module util {
-    export ErrorReporter from './util/ErrorReporter.js';
-    export MutedErrorReporter from './util/MutedErrorReporter.js';
-    export SourcePosition from './util/SourcePosition.js';
-    export TestErrorReporter from './util/TestErrorReporter.js';
+    export {ErrorReporter} from './util/ErrorReporter.js';
+    export {MutedErrorReporter} from './util/MutedErrorReporter.js';
+    export {SourcePosition} from './util/SourcePosition.js';
+    export {TestErrorReporter} from './util/TestErrorReporter.js';
     export {canonicalizeUrl, resolveUrl} from './util/url.js';
-    export removeDotSegments from './util/url.js';
+    export {removeDotSegments} from './util/url.js';
   }
 
   export module syntax {
-    export IdentifierToken from './syntax/IdentifierToken.js';
-    export LiteralToken from './syntax/LiteralToken.js';
-    export Parser from './syntax/Parser.js';
-    export ParseTreeValidator from './syntax/ParseTreeValidator.js';
-    export ParseTreeVisitor from './syntax/ParseTreeVisitor.js';
-    export Scanner from './syntax/Scanner.js';
-    export SourceFile from './syntax/SourceFile.js';
-    export Token from './syntax/Token.js';
+    export {IdentifierToken} from './syntax/IdentifierToken.js';
+    export {LiteralToken} from './syntax/LiteralToken.js';
+    export {Parser} from './syntax/Parser.js';
+    export {ParseTreeValidator} from './syntax/ParseTreeValidator.js';
+    export {ParseTreeVisitor} from './syntax/ParseTreeVisitor.js';
+    export {Scanner} from './syntax/Scanner.js';
+    export {SourceFile} from './syntax/SourceFile.js';
+    export {Token} from './syntax/Token.js';
     export module TokenType from './syntax/TokenType.js';
 
     export module trees {
       export * from './syntax/trees/ParseTrees.js';
-      export ParseTree from './syntax/trees/ParseTree.js';
+      export {ParseTree} from './syntax/trees/ParseTree.js';
       export module ParseTreeType from './syntax/trees/ParseTreeType.js';
     }
   }
 
   export module outputgeneration {
-    export ParseTreeWriter from './outputgeneration/ParseTreeWriter.js';
-    export ParseTreeMapWriter from './outputgeneration/ParseTreeMapWriter.js';
-    export ProjectWriter from './outputgeneration/ProjectWriter.js';
-    export SourceMapConsumer from './outputgeneration/SourceMapIntegration.js';
-    export SourceMapGenerator from './outputgeneration/SourceMapIntegration.js';
-    export TreeWriter from './outputgeneration/TreeWriter.js';
+    export {ParseTreeWriter} from './outputgeneration/ParseTreeWriter.js';
+    export {ParseTreeMapWriter} from './outputgeneration/ParseTreeMapWriter.js';
+    export {ProjectWriter} from './outputgeneration/ProjectWriter.js';
+    export {SourceMapConsumer} from './outputgeneration/SourceMapIntegration.js';
+    export {SourceMapGenerator} from './outputgeneration/SourceMapIntegration.js';
+    export {TreeWriter} from './outputgeneration/TreeWriter.js';
   }
 
   export module codegeneration {
-    export Compiler from './codegeneration/Compiler.js';
-    export ModuleTransformer from './codegeneration/ModuleTransformer.js';
-    export ParseTreeTransformer from './codegeneration/ParseTreeTransformer.js';
-    export ProgramTransformer from './codegeneration/ProgramTransformer.js';
-    export CloneTreeTransformer from './codegeneration/CloneTreeTransformer.js';
+    export {Compiler} from './codegeneration/Compiler.js';
+    export {ModuleTransformer} from './codegeneration/ModuleTransformer.js';
+    export {ParseTreeTransformer} from './codegeneration/ParseTreeTransformer.js';
+    export {ProgramTransformer} from './codegeneration/ProgramTransformer.js';
+    export {CloneTreeTransformer} from './codegeneration/CloneTreeTransformer.js';
     export module ParseTreeFactory from './codegeneration/ParseTreeFactory.js';
 
     export {
@@ -109,7 +109,7 @@ module traceur {
     } from './codegeneration/PlaceholderParser.js';
 
     export module module {
-      export ModuleRequireVisitor from
+      export {ModuleRequireVisitor} from
           './codegeneration/module/ModuleRequireVisitor.js';
     }
   }

--- a/test/feature/Collection/Call.js
+++ b/test/feature/Collection/Call.js
@@ -1,6 +1,6 @@
 // Options: --trap-member-lookup
 
-import elementGet from '@name';
+import {elementGet} from '@name';
 
 {
   var getLog = [];

--- a/test/feature/Modules/Error_InvalidExport.js
+++ b/test/feature/Modules/Error_InvalidExport.js
@@ -5,5 +5,5 @@ module a {
   module b {
     module c {};
   }
-  export c from b;
+  export {c} from b;
 }

--- a/test/feature/Modules/Error_MissingExport.js
+++ b/test/feature/Modules/Error_MissingExport.js
@@ -12,9 +12,9 @@ module m {
 }
 
 import {x, y, z} from m;
-import w from m;
+import {w} from m;
 
-import foo from '@name';
+import {foo} from '@name';
 import {bar, baz} from '@name';
 
 module outer {
@@ -24,5 +24,5 @@ module outer {
   export var object = {v: 2};
 }
 
-import v from outer.inner;
-import v from outer.object;
+import {v} from outer.inner;
+import {v} from outer.object;

--- a/test/feature/Modules/Exports.js
+++ b/test/feature/Modules/Exports.js
@@ -80,7 +80,7 @@ assert.equal('q', p2.q2.name);
 // ExportIdentifier
 module f {
   var g = 'g';
-  export g;
+  export {g};
 }
 assert.equal('g', f.g);
 
@@ -90,7 +90,7 @@ module h {
     export var j = 'j';
     export var l = 'l';
   }
-  export j from i, {j as k, l} from i;
+  export {j} from i, {j as k, l} from i;
 }
 assert.equal('j', h.j);
 assert.equal('j', h.k);
@@ -104,7 +104,7 @@ module m {
     export var q = 'q';
   }
 
-  export n, {o as n2}, q from o, {q as p} from o;
+  export {n}, {o as n2}, {q} from o, {q as p} from o;
 }
 assert.equal('n', m.n);
 assert.equal('q', m.n2.q);

--- a/test/feature/Modules/ImportAsExportAs.js
+++ b/test/feature/Modules/ImportAsExportAs.js
@@ -5,7 +5,7 @@ module m2 {
 
 module m {
   import {var as x} from m2;  
-  export x;
+  export {x};
 }
 
 assert.equal(m.x, 'z');

--- a/test/feature/Modules/ImportFromLocalModule.js
+++ b/test/feature/Modules/ImportFromLocalModule.js
@@ -4,7 +4,7 @@ module m {
 }
 
 import {x as renamedX, y} from m;
-import x from m;
+import {x} from m;
 module m2 from m;
 
 assert.equal(1, x);

--- a/test/feature/Modules/ImportFromStandardLibrary.js
+++ b/test/feature/Modules/ImportFromStandardLibrary.js
@@ -1,5 +1,5 @@
 import {Name as create, isName} from '@name';
-import Name from '@name';
+import {Name} from '@name';
 module n from '@name'
 
 var n1 = create();

--- a/test/feature/PrivateNames/Inherited.js
+++ b/test/feature/PrivateNames/Inherited.js
@@ -1,6 +1,6 @@
 // Options: --private-names
 
-import Name from '@name';
+import {Name} from '@name';
 
 var n = new Name;
 var p = {};

--- a/test/feature/PrivateNames/Object.js
+++ b/test/feature/PrivateNames/Object.js
@@ -1,6 +1,6 @@
 // Options: --private-names
 
-import Name from '@name';
+import {Name} from '@name';
 var n = new Name;
 var object = {};
 object[n] = 42;

--- a/test/feature/Yield/TreeUsingPrivateNameSyntax.js
+++ b/test/feature/Yield/TreeUsingPrivateNameSyntax.js
@@ -1,6 +1,6 @@
 // Options: --private-names --private-name-syntax
 
-import iterator from '@iter';
+import {iterator} from '@iter';
 // TODO(arv): Add support for import @iterator
 private @iterator = iterator;
 

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -22,7 +22,7 @@ suite('parser.js', function() {
   test('Module', function() {
     var program = 'module Foo { export var x = 42; ' +
                     'module M from \'url\'; ' +
-                    'import z from \'x\'.y; ' +
+                    'import {z} from \'x\'.y; ' +
                     'import * from M; ' +
                     'import {a as b, c} from M.x;' +
                   '};\n';


### PR DESCRIPTION
Old:

import foo from bar;
export baz;

New:

import {foo} from bar;
export {baz};
