### PR TITLE
Module expression must be either a string or a single identifier.

### DIFF
--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -162,10 +162,7 @@ export class ModuleTransformer extends ParseTreeTransformer {
               new LiteralExpression(null, reference.url)));
     }
 
-    if (tree.identifiers.length == 0)
-      return reference;
-
-    return createMemberExpression(reference, tree.identifiers);
+    return reference;
   }
 
   /**
@@ -384,7 +381,7 @@ function transformDeclaration(project, parent, tree) {
   // module m from 'url'.n.o.p;
 
   var transformer = new ModuleTransformer(project);
-  var list = tree.specifiers.map(transformer.transformAny, transformer);
+  var list = [transformer.transformAny(tree.specifier)];
 
   // const a = b.c, d = e.f;
   // TODO(arv): const is not allowed in ES5 strict

--- a/src/codegeneration/module/ModuleVisitor.js
+++ b/src/codegeneration/module/ModuleVisitor.js
@@ -68,35 +68,14 @@ export class ModuleVisitor extends ParseTreeVisitor {
    * @return {ModuleSymbol}
    */
   getModuleForModuleExpression(tree, reportErrors) {
-    // "url".b.c
+    // "url"
     if (tree.reference.type == ParseTreeType.MODULE_REQUIRE) {
       var url = tree.reference.url.processedValue;
       url = resolveUrl(this.currentModule.url, url);
       return this.project.getModuleForUrl(url);
     }
 
-    // a.b.c
-
-    var getNext = (parent, identifierToken) => {
-      var name = identifierToken.value;
-
-      if (!parent.hasModule(name)) {
-        if (reportErrors) {
-          this.reportError_(tree, '\'%s\' is not a module', name);
-        }
-        return null;
-      }
-
-      if (!parent.hasExport(name)) {
-        if (reportErrors) {
-          this.reportError_(tree, '\'%s\' is not exported by %s', name,
-              getFriendlyName(parent));
-        }
-        return null;
-      }
-
-      return parent.getModule(name);
-    };
+    // id
 
     var name = tree.reference.identifierToken.value;
     var parent = this.getModuleByName(name);
@@ -107,12 +86,6 @@ export class ModuleVisitor extends ParseTreeVisitor {
       return null;
     }
 
-    for (var i = 0; i < tree.identifiers.length; i++) {
-      parent = getNext(parent, tree.identifiers[i]);
-      if (!parent) {
-        return null;
-      }
-    }
 
     return parent;
   }

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -670,7 +670,7 @@ export class ParseTreeWriter extends ParseTreeVisitor {
    */
   visitModuleDeclaration(tree) {
     this.write_(MODULE);
-    this.writeList_(tree.specifiers, COMMA, false);
+    this.visitAny(tree.specifier);
     this.write_(SEMI_COLON);
   }
 
@@ -692,10 +692,6 @@ export class ParseTreeWriter extends ParseTreeVisitor {
    */
   visitModuleExpression(tree) {
     this.visitAny(tree.reference);
-    for (var i = 0; i < tree.identifiers.length; i++) {
-      this.write_(PERIOD);
-      this.write_(tree.identifiers[i]);
-    }
   }
 
   /**

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -685,12 +685,9 @@ export class ParseTreeValidator extends ParseTreeVisitor {
    * @param {ModuleDefinition} tree
    */
   visitModuleDeclaration(tree) {
-    for (var i = 0; i < tree.specifiers.length; i++) {
-      var specifier = tree.specifiers[i];
-      this.checkType_(MODULE_SPECIFIER,
-                      specifier,
-                      'module specifier expected');
-    }
+    this.checkType_(MODULE_SPECIFIER,
+                    tree.specifier,
+                    'module specifier expected');
   }
 
   /**

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -258,17 +258,10 @@ export class Parser {
 
   parseModuleExpression_(load) {
     // ModuleExpression(load) ::= ModuleReference(load)
-    //                         | ModuleExpression(load) "." IdentifierName
+    //                         | Identifier
     var start = this.getTreeStartLocation_();
     var reference = this.parseModuleReference_(load);
-    var identifierNames = [];
-    // TODO(arv): Refactor to remove lookahead.
-    while (this.peek_(PERIOD) && this.peekIdName_(this.peekToken_(1))) {
-      this.eat_(PERIOD);
-      identifierNames.push(this.eatIdName_());
-    }
-    return new ModuleExpression(this.getTreeLocation_(start), reference,
-        identifierNames);
+    return new ModuleExpression(this.getTreeLocation_(start), reference);
   }
 
   /**
@@ -538,13 +531,10 @@ export class Parser {
     if (this.peekModuleDefinition_(this.peekType_()))
       return this.parseModuleDefinition_(load, start);
 
-    var specifiers = [this.parseModuleSpecifier_(load)];
-    while (this.eatIf_(COMMA)) {
-      specifiers.push(this.parseModuleSpecifier_(load));
-    }
+    var specifier = this.parseModuleSpecifier_(load);
     this.eatPossibleImplicitSemiColon_();
-    return new ModuleDeclaration(this.getTreeLocation_(start),
-        specifiers);
+
+    return new ModuleDeclaration(this.getTreeLocation_(start), specifier);
   }
 
   parseClassShared_(constr) {

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -305,7 +305,7 @@
       "SourceRange"
     ],
     "moduleExpression": [
-      "ModuleExpression"
+      "ParseTree"
     ],
     "specifierSet": [
       "ParseTree"
@@ -499,7 +499,7 @@
       "SourceRange"
     ],
     "moduleExpression": [
-      "ModuleExpression"
+      "ParseTree"
     ],
     "importSpecifierSet": [
       "ParseTree"
@@ -587,8 +587,8 @@
     "location": [
       "SourceRange"
     ],
-    "specifiers": [
-      "Array.<ModuleSpecifier>"
+    "specifier": [
+      "ParseTree"
     ]
   },
   "ModuleDefinition": {
@@ -608,9 +608,6 @@
     ],
     "reference": [
       "ParseTree"
-    ],
-    "identifiers": [
-      "Array.<IdentifierToken>"
     ]
   },
   "ModuleRequire": {
@@ -629,7 +626,7 @@
       "IdentifierToken"
     ],
     "expression": [
-      "ModuleExpression"
+      "ParseTree"
     ]
   },
   "NameStatement": {

--- a/test/feature/Modules/Error_InvalidModuleDeclaration2.js
+++ b/test/feature/Modules/Error_InvalidModuleDeclaration2.js
@@ -1,5 +1,5 @@
 // Should not compile.
-// Error: 'c' is not a module
+// Error: 5:16: unexpected token .
 
 module a {}
 module b from a.c;

--- a/test/feature/Modules/Error_InvalidModuleDeclaration4.js
+++ b/test/feature/Modules/Error_InvalidModuleDeclaration4.js
@@ -3,5 +3,6 @@
 
 module a {
   module b {}
-  module c from b.d;
+  var d = {b};
+  module c from d;
 }

--- a/test/feature/Modules/Error_MissingExport.js
+++ b/test/feature/Modules/Error_MissingExport.js
@@ -1,11 +1,11 @@
 // Should not compile.
-// Error: 'y' is not exported by m
-// Error: 'z' is not exported by m
-// Error: 'w' is not exported by m
-// Error: 'foo' is not exported by '@name'
-// Error: 'bar' is not exported by '@name'
-// Error: 'inner' is not exported by outer
-// Error: 'object' is not a module
+// Error: :14:12: 'y' is not exported by m
+// Error: :14:15: 'z' is not exported by m
+// Error: :15:9: 'w' is not exported by m
+// Error: :17:9: 'foo' is not exported by '@name'
+// Error: :18:9: 'bar' is not exported by '@name'
+// Error: :18:14: 'baz' is not exported by '@name'
+// Error: :28:17: 'object' is not a module
 
 module m {
   export var x = 42;
@@ -24,5 +24,5 @@ module outer {
   export var object = {v: 2};
 }
 
-import {v} from outer.inner;
-import {v} from outer.object;
+var object = outer.object;
+import {v} from object;

--- a/test/feature/Modules/Exports.js
+++ b/test/feature/Modules/Exports.js
@@ -34,23 +34,22 @@ module b2 from b;
 assert.equal(42, b2.c.d);
 
 // NestedDeclarations
-module c from b.c;
-assert.equal(42, c.d);
+module c {
+  export * from b
+}
+assert.equal(42, c.c.d);
 
 // NestedDeclarations1
 module d from c;
-assert.equal(42, d.d);
-
-// NestedDeclarations2
-module d2 from c.c2;
-assert.equal(43, d2.d2);
+assert.equal(42, d.c.d);
 
 // ExportModuleDeclaration
 module e {
   module n {
     export var val = 44;
   }
-  export module o from n, o2 from n;
+  export module o from n;
+  export module o2 from n;
 }
 assert.equal(44, e.o.val);
 assert.equal(44, e.o2.val);

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -22,9 +22,9 @@ suite('parser.js', function() {
   test('Module', function() {
     var program = 'module Foo { export var x = 42; ' +
                     'module M from \'url\'; ' +
-                    'import {z} from \'x\'.y; ' +
+                    'import {z} from \'x\'; ' +
                     'import * from M; ' +
-                    'import {a as b, c} from M.x;' +
+                    'import {a as b, c} from M;' +
                   '};\n';
     var sourceFile = new traceur.syntax.SourceFile('Name', program);
     var parser = new traceur.syntax.Parser(errorReporter, sourceFile);


### PR DESCRIPTION
In the old module proposal the module expression could be "path".m.n.o. Nested modules are not supported in the latest proposal (still works in Traceur) but this simplifies the syntax a bit.
