### PR TITLE
module is not a keyword

### DIFF
--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export module ParseTreeType from './ParseTreeType.js';
-
+module ParseTreeType from './ParseTreeType.js';
 import * from './ParseTreeType.js';
 import {
   STRING,
   VAR
 } from '../TokenType.js';
 import {Token} from '../Token.js';
-
 module utilJSON from '../../util/JSON.js';
+
+export {ParseTreeType};
 
 /**
  * An abstract syntax tree for JavaScript parse trees.

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -94,4 +94,5 @@ export var codegeneration = {
   }
 };
 
-export module modules from './runtime/module-loader.js';
+module modules from './runtime/module-loader.js';
+export {modules};

--- a/test/feature/Modules/Error_ModuleNoNewline.js
+++ b/test/feature/Modules/Error_ModuleNoNewline.js
@@ -1,0 +1,9 @@
+// Should not compile.
+// Error: :9:3: Semi-colon expected
+
+module 'm' {
+  export var x = 42;
+}
+
+module
+m from 'm';

--- a/test/feature/Modules/Error_ModuleNoNewline2.js
+++ b/test/feature/Modules/Error_ModuleNoNewline2.js
@@ -1,0 +1,10 @@
+// Should not compile.
+// Error: :10:15: 'feature/Modules/m' is not a module
+
+module
+'m'
+{
+  var x = 42;
+}
+
+module m from 'm';

--- a/test/feature/Modules/ModuleNoNewline.js
+++ b/test/feature/Modules/ModuleNoNewline.js
@@ -1,0 +1,15 @@
+module
+'m'
+{
+  var x = 42;
+}
+
+var module = {test: 42};
+
+module;
+module.test;
+// No semicolon on next line
+module
+
+// No semicolon nor newline at end of next line
+module

--- a/test/unit/runtime/subdir/test_d.js
+++ b/test/unit/runtime/subdir/test_d.js
@@ -1,2 +1,3 @@
-export module e from './test_e.js';
+module e from './test_e.js';
+export {e};
 export var name = 'D';


### PR DESCRIPTION
This moves the parsing of modules into the fall through case of the big switch of parse statements. If the expression is `module` and it is followed by a module declaration (also definition for now) then it is parsed as a module.

Fixes #353
