### PR TITLE
Fixes #381: Change the name of generated sources so devtools puts them in folders

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -12527,7 +12527,7 @@ System.get('@traceur/module').registerModule("../src/codegeneration/PlaceholderP
         for (var i = 1; i < sourceLiterals.length; i++) {
           source += PREFIX + (i - 1) + sourceLiterals[i];
         }
-        var file = new SourceFile('parse@TemplateParser', source);
+        var file = new SourceFile('@TemplateParser/parse', source);
         var errorReporter = new MutedErrorReporter();
         var parser = new Parser(errorReporter, file);
         var tree = doParse(parser);
@@ -18458,7 +18458,7 @@ System.get('@traceur/module').registerModule("../src/codegeneration/RuntimeInlin
     getDescriptors: "function(object) {\n        var descriptors = {}, name, names = Object.getOwnPropertyNames(object);\n        for (var i = 0; i < names.length; i++) {\n          var name = names[i];\n          descriptors[name] = Object.getOwnPropertyDescriptor(object, name);\n        }\n        return descriptors;\n      }"
   };
   function parse(source, name) {
-    var file = new SourceFile(name + '@runtime', source);
+    var file = new SourceFile('@runtime/' + name, source);
     var errorReporter = new MutedErrorReporter();
     return new Parser(errorReporter, file).parseAssignmentExpression();
   }

--- a/src/codegeneration/PlaceholderParser.js
+++ b/src/codegeneration/PlaceholderParser.js
@@ -169,7 +169,7 @@ export class PlaceholderParser {
       source += PREFIX + (i - 1) + sourceLiterals[i];
     }
 
-    var file = new SourceFile('parse@TemplateParser', source);
+    var file = new SourceFile('@TemplateParser/parse', source);
     var errorReporter = new MutedErrorReporter();
     var parser = new Parser(errorReporter, file);
     var tree = doParse(parser);

--- a/src/codegeneration/RuntimeInliner.js
+++ b/src/codegeneration/RuntimeInliner.js
@@ -47,7 +47,7 @@ var shared = {
 };
 
 function parse(source, name) {
-  var file = new SourceFile(name + '@runtime', source);
+  var file = new SourceFile('@runtime/' + name, source);
   var errorReporter = new MutedErrorReporter();
   return new Parser(errorReporter, file).parseAssignmentExpression();
 }


### PR DESCRIPTION
@runtime/ and @TemplateParser/ folders replace postfix names.
