### PR TITLE
test import default as a name

### DIFF
--- a/test/feature/Modules/ImportDefault.js
+++ b/test/feature/Modules/ImportDefault.js
@@ -3,3 +3,6 @@ assert.equal(x, 42);
 
 import C from './resources/default-class';
 assert.equal(new C().m(), 'm');
+
+import { default as D } from './resources/default-name';
+assert.equal(D, 4);

--- a/test/feature/Modules/resources/default-name.js
+++ b/test/feature/Modules/resources/default-name.js
@@ -1,0 +1,2 @@
+var p = 4;
+export { p as default }


### PR DESCRIPTION
Here is a test for #446. It is passing fine, so this can be left out.

Not sure why I was seeing this fail before.
