### PR TITLE
allow non-binding import

### DIFF
--- a/test/feature/Modules/ImportFromModule.js
+++ b/test/feature/Modules/ImportFromModule.js
@@ -1,3 +1,5 @@
+import './resources/m';
+
 import {a as renamedX, b} from './resources/m';
 import {a} from './resources/m';
 module m2 from './resources/m';


### PR DESCRIPTION
Failing test case for #447. Allows imports of the form:

``` javascript
  import 'some-module';
```
