### PR TITLE
Fix conflict issue with alpha renaming of this in arrow functions

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -15204,11 +15204,11 @@ System.get('@traceur/module').registerModule("../src/codegeneration/ArrowFunctio
         } else {
           parameters = [];
         }
-        var functionBody = this.transformAny(tree.functionBody);
+        var alphaRenamed = alphaRenameThisAndArguments(this, tree);
+        var functionBody = this.transformAny(alphaRenamed.functionBody);
         if (functionBody.type != FUNCTION_BODY) {
           functionBody = createFunctionBody([createReturnStatement(functionBody)]);
         }
-        functionBody = alphaRenameThisAndArguments(this, functionBody);
         return createParenExpression(createFunctionExpression(new FormalParameterList(null, parameters), functionBody));
       }
     }, {transformTree: function(identifierGenerator, tree) {
@@ -19864,7 +19864,6 @@ System.get('@traceur/module').registerModule("../src/WebPageProject.js", functio
         var done = arguments[0] !== (void 0) ? arguments[0]: (function() {});
         var $__235 = this;
         document.addEventListener('DOMContentLoaded', (function() {
-          var $__235 = $__235;
           var selector = 'script[type="text/traceur"]';
           var scripts = document.querySelectorAll(selector);
           if (!scripts.length) {

--- a/src/codegeneration/ArrowFunctionTransformer.js
+++ b/src/codegeneration/ArrowFunctionTransformer.js
@@ -50,13 +50,13 @@ export class ArrowFunctionTransformer extends TempVarTransformer {
       parameters = [];
     }
 
-    var functionBody = this.transformAny(tree.functionBody);
+    var alphaRenamed = alphaRenameThisAndArguments(this, tree);
+
+    var functionBody = this.transformAny(alphaRenamed.functionBody);
     if (functionBody.type != FUNCTION_BODY) {
       // { return expr; }
       functionBody = createFunctionBody([createReturnStatement(functionBody)]);
     }
-
-    functionBody = alphaRenameThisAndArguments(this, functionBody);
 
     // function(params) { ... }
     return createParenExpression(

--- a/test/feature/ArrowFunctions/AlphaRename.js
+++ b/test/feature/ArrowFunctions/AlphaRename.js
@@ -1,0 +1,22 @@
+var global = this;
+var self = {};
+
+function outer() {
+  var f = () => {
+    assert.equal(this, self);
+
+    var g = () => {
+      assert.equal(this, self);
+    };
+    g();
+
+    var h = function() {
+      assert.equal(this, global);
+    };
+    h();
+  };
+
+  f();
+}
+
+outer.call(self);


### PR DESCRIPTION
By doing the alpha renaming in the outer function first we do the renaming of inner arrow functions too.

Fixes #466
