### PR TITLE
Fix test runner and regressed tests

### DIFF
--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -131,7 +131,11 @@ export class FromOptionsTransformer extends MultiTransformer {
       append(CollectionTransformer);
 
     // Issue errors for any unbound variables
-    if (options.freeVariableChecker)
-      this.append((tree) => FreeVariableChecker.checkScript(reporter, tree));
+    if (options.freeVariableChecker) {
+      this.append((tree) => {
+        FreeVariableChecker.checkScript(reporter, tree);
+        return tree;
+      });
+    }
   }
 }

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -59,8 +59,8 @@ var EXPORT_STAR_CODE = `
               enumerable: true
             });
           })(arguments[i], names[j]);
+        }
       }
-
       return object;
     }`;
 

--- a/test/feature/ArrowFunctions/ArrowFunctions.js
+++ b/test/feature/ArrowFunctions/ArrowFunctions.js
@@ -42,7 +42,7 @@ assert.equal(42, f());
 }
 
 var h = (x, ...xs) => xs;
-assertArrayEquals([-1, 0, 1, true], h(0, 1, true));
+assertArrayEquals([0, 1, true], h(-1, 0, 1, true));
 
 assert.equal(typeof (() => {}), 'function');
 assert.equal(Object.getPrototypeOf(() => {}), Function.prototype);

--- a/test/feature/Classes/Types.js
+++ b/test/feature/Classes/Types.js
@@ -2,7 +2,7 @@
 
 class Typed {
   constructor(x : number) {
-    this.x;
+    this.x_ = x;
   }
 
   addTo(y : number) : number {
@@ -11,11 +11,11 @@ class Typed {
   }
 
   get x() : number {
-    return this.x;
+    return this.x_;
   }
 
   set x(x : number) {
-    this.x = x;
+    this.x_ = x;
   }
 }
 


### PR DESCRIPTION
If `options.freeVariableChecker` was true then the FromOptionsTransformer returned `undefined` instead of a ParseTree. This caused all the tests to have empty code.

Fixing the above revealed a few broken tests. Most of them were just test errors but there was one  issue with modules. Module instances acquired using `module m from 'name'` are supposed to be live.
