### PR TITLE
Module instance. Skip one getter if possible

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -559,10 +559,10 @@ System.set('@traceur/module', (function(global) {
       var getter,
           value;
       if (isLive === liveModuleSentinel) {
-        getter = function() {
-          return obj[name];
-        };
-      } else {
+        var descr = Object.getOwnPropertyDescriptor(obj, name);
+        if (descr.get) getter = descr.get;
+      }
+      if (!getter) {
         value = obj[name];
         getter = function() {
           return value;


### PR DESCRIPTION
Improve live module instances to remove one layer of getter if possible.
