### PR TITLE
Add makefile targets bin/tracer-runtime.js and bin/traceur-runtime.min.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ bin/%.min.js: bin/%.js
 bin/traceur-runtime.js: $(RUNTIME_SRC)
 	./traceur --out $@ $(TFLAGS) $?
 
-bin/traceur-bald.js: src/traceur-import.js build/compiled-by-previous-traceur.js
+bin/traceur-bare.js: src/traceur-import.js build/compiled-by-previous-traceur.js
 	./traceur --out $@ $(TFLAGS) $<
 
-concat: bin/traceur-runtime.js bin/traceur-bald.js
+concat: bin/traceur-runtime.js bin/traceur-bare.js
 	cat $? > bin/traceur.js
 
 bin/traceur.js: build/compiled-by-previous-traceur.js


### PR DESCRIPTION
Also target 'concat' to build bin/traceur.js by concatenating bin/traceur-runtime.js and a compile without a runtime. 
The concat target can be tested to verify separate compilation.
