### PR TITLE
Fix issue with empty destructuring patterns

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -7584,10 +7584,10 @@ System.get('@traceur/module').registerModule("../src/syntax/Parser.js", function
     parseImportClause_: function() {
       var start = this.getTreeStartLocation_();
       if (this.eatIf_(OPEN_CURLY)) {
-        var specifiers = [this.parseImportSpecifier_()];
-        while (this.eatIf_(COMMA)) {
-          if (this.peek_(CLOSE_CURLY)) break;
+        var specifiers = [];
+        while (!this.peek_(CLOSE_CURLY) && !this.isAtEnd()) {
           specifiers.push(this.parseImportSpecifier_());
+          if (!this.eatIf_(COMMA)) break;
         }
         this.eat_(CLOSE_CURLY);
         return new ImportSpecifierSet(this.getTreeLocation_(start), specifiers);
@@ -14221,6 +14221,9 @@ System.get('@traceur/module').registerModule("../src/codegeneration/Destructurin
           return this.desugarPattern_(desugaring, tree.expression);
         default:
           throw new Error('unreachable');
+      }
+      if (desugaring instanceof VariableDeclarationDesugaring && desugaring.declarations.length === 0) {
+        desugaring.assign(createBindingIdentifier(this.getTempIdentifier()), desugaring.rvalue);
       }
       return initialiserFound;
     }

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -281,7 +281,7 @@ export class DestructuringTransformer extends ParameterTransformer {
     });
 
     // Desugar more.
-    var transformedTree =  this.transformVariableDeclarationList(
+    var transformedTree = this.transformVariableDeclarationList(
         createVariableDeclarationList(
             tree.declarationType,
             desugaredDeclarations));
@@ -585,6 +585,16 @@ export class DestructuringTransformer extends ParameterTransformer {
 
       default:
         throw new Error('unreachable');
+    }
+
+    // In case we have `var {} = expr` or `var [] = expr` we use a temp
+    // variable name so that the expression still gets executed.
+    //
+    // AssignmentExpressionDesugaring already works.
+    if (desugaring instanceof VariableDeclarationDesugaring &&
+        desugaring.declarations.length === 0) {
+      desugaring.assign(createBindingIdentifier(this.getTempIdentifier()),
+                        desugaring.rvalue);
     }
 
     return initialiserFound;

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -484,11 +484,11 @@ export class Parser {
   parseImportClause_() {
     var start = this.getTreeStartLocation_();
     if (this.eatIf_(OPEN_CURLY)) {
-      var specifiers = [this.parseImportSpecifier_()];
-      while (this.eatIf_(COMMA)) {
-        if (this.peek_(CLOSE_CURLY))
-          break;
+      var specifiers = [];
+      while (!this.peek_(CLOSE_CURLY) && !this.isAtEnd()) {
         specifiers.push(this.parseImportSpecifier_());
+        if (!this.eatIf_(COMMA))
+          break;
       }
       this.eat_(CLOSE_CURLY);
 

--- a/test/feature/Destructuring/Empty.js
+++ b/test/feature/Destructuring/Empty.js
@@ -1,0 +1,24 @@
+var calls = 0;
+
+var {} = calls++;
+assert.equal(calls, 1);
+
+var [] = calls++;
+assert.equal(calls, 2);
+
+var {} = calls++, [] = calls++;
+assert.equal(calls, 4);
+
+
+///////////////////////
+
+calls = 0;
+
+({} = calls++);
+assert.equal(calls, 1);
+
+[] = calls++;
+assert.equal(calls, 2);
+
+({} = calls++, [] = calls++);
+assert.equal(calls, 4);

--- a/test/feature/Modules/EmptyNamedImport.js
+++ b/test/feature/Modules/EmptyNamedImport.js
@@ -1,0 +1,1 @@
+import {} from './resources/m';


### PR DESCRIPTION
We were generating invalid code for `var {} = expr`.

Fix parsing of `import {} from 'name'` which in turn ended up with a `var {} = ...`.
