### PR TITLE
Fix iteration when running with node --harmony.

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -153,7 +153,6 @@
     enumerable: false
   });
   $freeze(SymbolValue.prototype);
-  Symbol.iterator = Symbol();
   function toProperty(name) {
     if (isSymbol(name)) return name[symbolInternalProperty];
     return name;
@@ -530,8 +529,8 @@
     });
   }
   function setupGlobals(global) {
-    if (!global.Symbol) global.Symbol = Symbol;
-    if (!global.Symbol.iterator) global.Symbol.iterator = Symbol();
+    global.Symbol = Symbol;
+    global.Symbol.iterator = Symbol();
     polyfillString(global.String);
     polyfillObject(global.Object);
     polyfillArray(global.Array);

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -248,8 +248,6 @@
   });
   $freeze(SymbolValue.prototype);
 
-  Symbol.iterator = Symbol();
-
   function toProperty(name) {
     if (isSymbol(name))
       return name[symbolInternalProperty];
@@ -706,10 +704,8 @@
   }
 
   function setupGlobals(global) {
-    if (!global.Symbol)
-      global.Symbol = Symbol;
-    if (!global.Symbol.iterator)
-      global.Symbol.iterator = Symbol();
+    global.Symbol = Symbol;
+    global.Symbol.iterator = Symbol();
 
     polyfillString(global.String);
     polyfillObject(global.Object);


### PR DESCRIPTION
The current versions of Traceur (0.0.7 and master) don't work with `node --harmony`. The problem is that the attribute name that is used for the iterator is different when defined on `Array.prototype` vs when used in the generated code.

The following exceptions occur:

```
TypeError: Property '[object Object]' of object #<Object> is not a function
 at /Users/rolftimmermans/Code/vendor/traceur-compiler/test/unit/node/resources/generator.js:803:41
 at ContextifyScript.Script.runInNewContext (vm.js:38:15)
 at Object.exports.runInNewContext (vm.js:65:17)
 at executeFileWithRuntime (/Users/rolftimmermans/Code/vendor/traceur-compiler/test/unit/node/generated-code-dependencies.js:48:8)
 at Context.<anonymous> (/Users/rolftimmermans/Code/vendor/traceur-compiler/test/unit/node/generated-code-dependencies.js:61:18)
 at Test.Runnable.run (/Users/rolftimmermans/Code/vendor/traceur-compiler/node_modules/mocha/lib/runnable.js:211:32)
 at Runner.runTest (/Users/rolftimmermans/Code/vendor/traceur-compiler/node_modules/mocha/lib/runner.js:358:10)
 at /Users/rolftimmermans/Code/vendor/traceur-compiler/node_modules/mocha/lib/runner.js:404:12
 at next (/Users/rolftimmermans/Code/vendor/traceur-compiler/node_modules/mocha/lib/runner.js:284:14)
 at /Users/rolftimmermans/Code/vendor/traceur-compiler/node_modules/mocha/lib/runner.js:293:7
```

This is an attempt to fix the problem. Tests pass on node with and without the harmony flag (replacing `node_modules/.bin/mocha` with `node_modules/.bin/mocha --harmony` in the `Makefile`).
