### PR TITLE
Refactor options to support arbitrary string values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/dep.mk
 build/local.mk
 build/previous-commit-traceur.js
 build/compiled-by-previous-traceur.js
+bin/traceur-runtime.js
 bin/traceur.map
 bin/traceur.min.js
 bin/traceur.ugly.js

--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -1016,12 +1016,12 @@ $traceurRuntime.registerModule("../src/options.js", function() {
   function coerceOptionValue(v) {
     switch (v) {
       case 'false':
-      case false:
         return false;
-      case 'parse':
-        return 'parse';
-      default:
+      case 'true':
+      case true:
         return true;
+      default:
+        return !!v && String(v);
     }
   }
   function setOption(name, value) {
@@ -1033,14 +1033,13 @@ $traceurRuntime.registerModule("../src/options.js", function() {
       throw Error('Unknown option: ' + name);
     }
   }
-  function optionCallback(name, value) {
-    setOption(name, value);
-  }
   function addOptions(flags) {
     Object.keys(options).forEach(function(name) {
       var dashedName = toDashCase(name);
       if ((name in parseOptions) && (name in transformOptions)) flags.option('--' + dashedName + ' [true|false|parse]', descriptions[name]); else flags.option('--' + dashedName, descriptions[name]);
-      flags.on(dashedName, optionCallback.bind(null, dashedName));
+      flags.on(dashedName, (function(value) {
+        return setOption(dashedName, value);
+      }));
     });
   }
   function filterOption(dashedName) {
@@ -1048,8 +1047,6 @@ $traceurRuntime.registerModule("../src/options.js", function() {
     return name === 'experimental' || !(name in options);
   }
   Object.defineProperties(options, {
-    parse: {value: parseOptions},
-    transform: {value: transformOptions},
     reset: {value: reset},
     fromString: {value: fromString},
     fromArgv: {value: fromArgv},
@@ -1060,7 +1057,7 @@ $traceurRuntime.registerModule("../src/options.js", function() {
   function parseCommand(s) {
     var re = /--([^=]+)(?:=(.+))?/;
     var m = re.exec(s);
-    if (m) setOption(m[1], m[2]);
+    if (m) setOption(m[1], m[2] || true);
   }
   function toCamelCase(s) {
     return s.replace(/-\w/g, function(ch) {
@@ -1076,28 +1073,25 @@ $traceurRuntime.registerModule("../src/options.js", function() {
   var ON_BY_DEFAULT = 1;
   function addFeatureOption(name, kind) {
     if (kind === EXPERIMENTAL) experimentalOptions[name] = true;
-    Object.defineProperty(options, name, {
+    Object.defineProperty(parseOptions, name, {
       get: function() {
-        if (parseOptions[name] === transformOptions[name]) {
-          return parseOptions[name];
-        }
-        return 'parse';
+        return !!options[name];
       },
-      set: function(v) {
-        if (v === 'parse') {
-          parseOptions[name] = true;
-          transformOptions[name] = false;
-        } else {
-          parseOptions[name] = transformOptions[name] = Boolean(v);
-        }
+      enumerable: true,
+      configurable: true
+    });
+    Object.defineProperty(transformOptions, name, {
+      get: function() {
+        var v = options[name];
+        if (v === 'parse') return false;
+        return v;
       },
       enumerable: true,
       configurable: true
     });
     var defaultValue = kind === ON_BY_DEFAULT;
+    options[name] = defaultValue;
     defaultValues[name] = defaultValue;
-    parseOptions[name] = defaultValue;
-    transformOptions[name] = defaultValue;
   }
   function addBoolOption(name) {
     defaultValues[name] = false;
@@ -1123,7 +1117,6 @@ $traceurRuntime.registerModule("../src/options.js", function() {
   addFeatureOption('symbols', EXPERIMENTAL);
   addFeatureOption('deferredFunctions', EXPERIMENTAL);
   addFeatureOption('types', EXPERIMENTAL);
-  addFeatureOption('requireJsModules', EXPERIMENTAL);
   addBoolOption('debug');
   addBoolOption('sourceMaps');
   addBoolOption('freeVariableChecker');
@@ -16965,8 +16958,9 @@ $traceurRuntime.registerModule("../src/codegeneration/FromOptionsTransformer.js"
     if (transformOptions.types) append(TypeTransformer);
     if (transformOptions.numericLiterals) append(NumericLiteralTransformer);
     if (transformOptions.templateLiterals) append(TemplateLiteralTransformer);
-    if (transformOptions.modules && !transformOptions.requireJsModules) append(ModuleTransformer);
-    if (transformOptions.requireJsModules) append(RequireJsTransformer);
+    if (transformOptions.modules) {
+      if (transformOptions.modules === 'requirejs') append(RequireJsTransformer); else append(ModuleTransformer);
+    }
     if (transformOptions.arrowFunctions) append(ArrowFunctionTransformer);
     if (transformOptions.classes) append(ClassTransformer);
     if (transformOptions.propertyNameShorthand) append(PropertyNameShorthandTransformer);

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -70,11 +70,12 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (transformOptions.templateLiterals)
       append(TemplateLiteralTransformer);
 
-    if (transformOptions.modules && !transformOptions.requireJsModules)
-      append(ModuleTransformer);
-
-    if (transformOptions.requireJsModules)
-      append(RequireJsTransformer);
+    if (transformOptions.modules) {
+      if (transformOptions.modules === 'requirejs')
+        append(RequireJsTransformer);
+      else
+        append(ModuleTransformer);
+    }
 
     if (transformOptions.arrowFunctions)
       append(ArrowFunctionTransformer);

--- a/src/node/api.js
+++ b/src/node/api.js
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Node.js API
- *
- * This is what you get when you `require('traceur')`.
- * It's suppose to be used by custom scripts or tools such as Grunt or Karma.
- */
+// Node.js API
+//
+// This is what you get when you `require('traceur')`.
+// It's suppose to be used by custom scripts or tools such as Grunt or Karma.
 
 'use strict';
 
@@ -57,18 +55,11 @@ function compile(content, options) {
     filename: '<unknown file>'
   }, options || {});
 
-  if (options.modules === 'requirejs') {
-    options.modules = 'parse';
-    options.requireJsModules = true;
-  } else if (options.modules === 'traceur') {
-    options.modules = true;
-  }
-
   traceurOptions.reset();
   merge(traceurOptions, options);
 
   var errorReporter = new ErrorReporter();
-  var sourceFile = new SourceFile(options.filename || '<unknown file>', content);
+  var sourceFile = new SourceFile(options.filename, content);
   var parser = new Parser(errorReporter, sourceFile);
   var tree = parser.parseModule();
   var transformer = new FromOptionsTransformer(errorReporter);

--- a/src/node/to-requirejs-compiler.js
+++ b/src/node/to-requirejs-compiler.js
@@ -49,9 +49,7 @@ if (process.argv.length < 4) {
 
 // Nasty, we should rather pass the options to FromOptionsTransformer
 var options = traceur.options;
-options.modules = 'parse';
-options.requireJsModules = true;
-
+options.modules = 'requirejs';
 
 var inputDir = path.normalize(process.argv[2]);
 var outputDir = path.normalize(process.argv[3]);

--- a/src/options.js
+++ b/src/options.js
@@ -12,14 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Options are just a plain old object. There are two read only views on this
+// object, parseOptions and transformOptions.
+//
+// To set an option you do `options.classes = true`.
+//
+// An option value is either true, false or a string. If the value is set to
+// the string "parse" then the transformOption for that option will return
+// false. For example:
+//
+//   options.destructuring = 'parse';
+//   transformOptions.destructuring === false;
+
 export var parseOptions = Object.create(null);
 export var transformOptions = Object.create(null);
+
 var defaultValues = Object.create(null);
 var experimentalOptions = Object.create(null);
 
-/**
- * The options object.
- */
 export var options = {
 
   /**
@@ -86,11 +96,6 @@ function fromArgv(args) {
 
 /**
  * Sets the options based on an object.
- * setFromObject({
- *   spread: true,
- *   defaultParameters: false,
- *   desctructuring: 'parse'
- * });
  */
 function setFromObject(object) {
   Object.keys(object).forEach((name) => {
@@ -101,12 +106,13 @@ function setFromObject(object) {
 function coerceOptionValue(v) {
   switch (v) {
     case 'false':
-    case false:
       return false;
-    case 'parse':
-      return 'parse';
-    default:
+    case 'true':
+    case true:
       return true;
+    default:
+      // Falsey values will be false.
+      return !!v && String(v);
   }
 }
 
@@ -118,10 +124,6 @@ function setOption(name, value) {
   } else {
     throw Error('Unknown option: ' + name);
   }
-}
-
-function optionCallback(name, value) {
-  setOption(name, value);
 }
 
 /**
@@ -137,7 +139,7 @@ function addOptions(flags) {
                    descriptions[name]);
     else
       flags.option('--' + dashedName, descriptions[name]);
-    flags.on(dashedName, optionCallback.bind(null, dashedName));
+    flags.on(dashedName, (value) => setOption(dashedName, value));
   });
 }
 
@@ -152,8 +154,6 @@ function filterOption(dashedName) {
 
 // Make sure non option fields are non enumerable.
 Object.defineProperties(options, {
-  parse: {value: parseOptions},
-  transform: {value: transformOptions},
   reset: {value: reset},
   fromString: {value: fromString},
   fromArgv: {value: fromArgv},
@@ -168,14 +168,15 @@ Object.defineProperties(options, {
  *
  *   --spread, --spread=true
  *   --spread=parse
- *   --spead=false
+ *   --spread=false
  *   --arrowFunctions --arrow-functions
+ *   --modules=requirejs
  */
 function parseCommand(s) {
   var re = /--([^=]+)(?:=(.+))?/;
   var m = re.exec(s);
   if (m)
-    setOption(m[1], m[2]);
+    setOption(m[1], m[2] || true);
 }
 
 /**
@@ -201,37 +202,35 @@ var ON_BY_DEFAULT = 1;
 
 /**
  * Adds a feature option.
- * Each feature option is represented by the parse and transform
- * option with the same name.
- * Setting a feature option sets the parse and transform option.
+ * This also adds a view from the parseOption and the transformOption to the
+ * underlying value.
  */
 function addFeatureOption(name, kind) {
   if (kind === EXPERIMENTAL)
     experimentalOptions[name] = true;
 
-  Object.defineProperty(options, name, {
+  Object.defineProperty(parseOptions, name, {
     get: function() {
-      if (parseOptions[name] === transformOptions[name]) {
-        return parseOptions[name];
-      }
-      return 'parse';
+      return !!options[name];
     },
-    set: function(v) {
-      if (v === 'parse') {
-        parseOptions[name] = true;
-        transformOptions[name] = false;
-      } else {
-        parseOptions[name] = transformOptions[name] = Boolean(v);
-      }
+    enumerable: true,
+    configurable: true
+  });
+
+  Object.defineProperty(transformOptions, name, {
+    get: function() {
+      var v = options[name];
+      if (v === 'parse')
+        return false;
+      return v;
     },
     enumerable: true,
     configurable: true
   });
 
   var defaultValue = kind === ON_BY_DEFAULT;
+  options[name] = defaultValue;
   defaultValues[name] = defaultValue;
-  parseOptions[name] = defaultValue;
-  transformOptions[name] = defaultValue;
 }
 
 /**
@@ -265,8 +264,6 @@ addFeatureOption('blockBinding', EXPERIMENTAL);       // 12.1
 addFeatureOption('symbols', EXPERIMENTAL);
 addFeatureOption('deferredFunctions', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
-
-addFeatureOption('requireJsModules', EXPERIMENTAL);
 
 addBoolOption('debug');
 addBoolOption('sourceMaps');


### PR DESCRIPTION
We now only store the option value on the actual options object. We add views of this that represent the parseOptions and the transformOptions.

This removes the requireJsModule option and let modules be set to requirejs instead.
