### PR TITLE
Add 'make self' and update self-compile.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,11 +120,11 @@ debug: build/compiled-by-previous-traceur.js $(SRC)
 
 self: force
 	mkdir -p build/node
-	mv src/node/* build/node
-	git checkout -- src/node
-	-make debug
-	mv build/node/* src/node
-	rmdir build/node
+	mv src/node/* build/node # Save in case of src diffs.
+	git checkout -- src/node # Over-write with last-good node compiler front.
+	-make debug              # Build with last-good node compiler front.
+	mv build/node/* src/node # Restore possible src diffs.
+	rmdir build/node         # Clean up.
 
 # Prerequisites following '|' are rebuilt just like ordinary prerequisites.
 # However, they don't cause remakes if they're newer than the target. See:

--- a/test/self-compile.html
+++ b/test/self-compile.html
@@ -13,9 +13,11 @@
     var url = window.location.href;
 
     function getLoader() {
-      traceur.options.reporter = new traceur.util.ErrorReporter();
-      traceur.options.rootURL = url;
-      return new traceur.modules.CodeLoader(traceur.options);
+      var loaderOptions = {
+        reporter: new traceur.util.ErrorReporter(),
+        rootURL: url
+      };
+      return new traceur.modules.CodeLoader(loaderOptions);
     }
     getLoader().import('../src/traceur.js',
         function(mod) {


### PR DESCRIPTION
This separates bin/traceur.js from src/node/*:
 in working on module loading use self-compile.html
 to debug compilation, then make test to deal with src/node.
