### PR TITLE
Remove non-standard `String.prototype.toArray`

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -35,9 +35,6 @@
       contains: method(function(s) {
         return this.indexOf(s) !== - 1;
       }),
-      toArray: method(function() {
-        return this.split('');
-      }),
       codePointAt: method(function(position) {
         var string = String(this);
         var size = string.length;

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -60,9 +60,6 @@
       contains: method(function(s) {
         return this.indexOf(s) !== -1;
       }),
-      toArray: method(function() {
-        return this.split('');
-      }),
       codePointAt: method(function(position) {
         /*! http://mths.be/codepointat v0.1.0 by @mathias */
         var string = String(this);

--- a/test/feature/StringExtras/ToArray.js
+++ b/test/feature/StringExtras/ToArray.js
@@ -1,2 +1,0 @@
-assertArrayEquals('Cats'.toArray(), ['C', 'a', 't', 's']);
-assertArrayEquals(''.toArray(), []);


### PR DESCRIPTION
`String.prototype.toArray` did not make it to the ES6 draft, and should be removed.
