### PR TITLE
Improve `String.prototype.codePointAt` polyfill

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -905,6 +905,9 @@ $traceurRuntime.registerModule("../src/runtime/polyfills/String.js", function() 
     return $indexOf.call(string, searchString, pos) != - 1;
   }
   function codePointAt(position) {
+    if (this == null) {
+      throw TypeError();
+    }
     var string = String(this);
     var size = string.length;
     var index = position ? Number(position): 0;

--- a/src/runtime/polyfills/String.js
+++ b/src/runtime/polyfills/String.js
@@ -87,6 +87,9 @@ export function contains(search) {
 
 export function codePointAt(position) {
   /*! http://mths.be/codepointat v0.1.0 by @mathias */
+  if (this == null) {
+    throw TypeError();
+  }
   var string = String(this);
   var size = string.length;
   // `ToInteger`

--- a/test/feature/StringExtras/CodePointAt.js
+++ b/test/feature/StringExtras/CodePointAt.js
@@ -1,5 +1,6 @@
 assert.equal(String.prototype.codePointAt.length, 1);
 
+// String that starts with a BMP symbol
 assert.equal('abc\uD834\uDF06def'.codePointAt(''), 0x61);
 assert.equal('abc\uD834\uDF06def'.codePointAt('_'), 0x61);
 assert.equal('abc\uD834\uDF06def'.codePointAt(), 0x61);
@@ -55,3 +56,19 @@ assert.equal('\uDF06abc'.codePointAt(false), 0xDF06);
 assert.equal('\uDF06abc'.codePointAt(NaN), 0xDF06);
 assert.equal('\uDF06abc'.codePointAt(null), 0xDF06);
 assert.equal('\uDF06abc'.codePointAt(undefined), 0xDF06);
+
+assertThrows(function() { String.prototype.codePointAt.call(undefined); }, TypeError);
+assertThrows(function() { String.prototype.codePointAt.call(undefined, 4); }, TypeError);
+assertThrows(function() { String.prototype.codePointAt.call(null); }, TypeError);
+assertThrows(function() { String.prototype.codePointAt.call(null, 4); }, TypeError);
+assert.equal(String.prototype.codePointAt.call(42, 0), 0x34);
+assert.equal(String.prototype.codePointAt.call(42, 1), 0x32);
+assert.equal(String.prototype.codePointAt.call({ 'toString': function() { return 'abc'; } }, 2), 0x63);
+
+assertThrows(function() { String.prototype.codePointAt.apply(undefined); }, TypeError);
+assertThrows(function() { String.prototype.codePointAt.apply(undefined, [4]); }, TypeError);
+assertThrows(function() { String.prototype.codePointAt.apply(null); }, TypeError);
+assertThrows(function() { String.prototype.codePointAt.apply(null, [4]); }, TypeError);
+assert.equal(String.prototype.codePointAt.apply(42, [0]), 0x34);
+assert.equal(String.prototype.codePointAt.apply(42, [1]), 0x32);
+assert.equal(String.prototype.codePointAt.apply({ 'toString': function() { return 'abc'; } }, [2]), 0x63);


### PR DESCRIPTION
This patch adds the `CheckObjectCoercible` step that was previously missing.
