### PR TITLE
updates link to REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ how they work for you and what's still causing you to use more boilerplate and
 Read the
 [Getting Started](https://github.com/google/traceur-compiler/wiki/GettingStarted)
 page to get up and running. You can use some language features right now and
-even try it out in your browser [here](http://traceur-compiler.googlecode.com/git/demo/repl.html).
+even try it out in your browser [here](http://google.github.io/traceur-compiler/demo/repl.html).
 Just type in some code and see what Traceur produces. For an idea of what is
 available and what we have in the pipeline, see the
 [Language Features](https://github.com/google/traceur-compiler/wiki/LanguageFeatures)


### PR DESCRIPTION
Review URL: https://github.com/google/traceur-compiler/pull/597

Closes #597.
