### PR TITLE
Refactor Loader to not touch ModuleSymbol; better API

### DIFF
--- a/src/codegeneration/module/AttachUrlTransformer.js
+++ b/src/codegeneration/module/AttachUrlTransformer.js
@@ -21,7 +21,7 @@ import {
 
 
 /**
- * Annotates a tree with its ModuleSymbol or URL
+ * Annotates a tree with its URL
  */
 
 export class AttachUrlTransformer extends ParseTreeTransformer {

--- a/src/codegeneration/module/ExportVisitor.js
+++ b/src/codegeneration/module/ExportVisitor.js
@@ -38,16 +38,16 @@ export class ExportVisitor extends ModuleVisitor {
   }
 
   addExport(name, tree) {
-    var module = this.module;
-    if (module.hasExport(name)) {
-      var previousExport = module.getExport(name).tree;
+    var moduleSymbol = this.moduleSymbol;
+    if (moduleSymbol.hasExport(name)) {
+      var previousExport = moduleSymbol.getExport(name).tree;
       this.reportError(tree, `Duplicate export of '${name}'`);
       this.reportError(previousExport,
                        `'${name}' was previously exported here`);
       return;
     }
 
-    module.addExport(new ExportSymbol(name, tree));
+    moduleSymbol.addExport(new ExportSymbol(name, tree));
   }
 
   visitClassDeclaration(tree) {
@@ -75,8 +75,8 @@ export class ExportVisitor extends ModuleVisitor {
   }
 
   visitExportStar(tree) {
-    var module = this.getModuleSymbolForModuleSpecifier(this.moduleSpecifier);
-    module.getExports().forEach(({name}) => {
+    var moduleSymbol = this.getModuleSymbolForModuleSpecifier(this.moduleSpecifier);
+    moduleSymbol.getExports().forEach(({name}) => {
       this.addExport(name, tree);
     });
   }

--- a/src/codegeneration/module/ModuleVisitor.js
+++ b/src/codegeneration/module/ModuleVisitor.js
@@ -28,12 +28,12 @@ export class ModuleVisitor extends ParseTreeVisitor {
   /**
    * @param {traceur.util.ErrorReporter} reporter
    * @param {Loader} loader
-   * @param {ModuleSymbol} module The root of the module system.
+   * @param {ModuleSymbol} moduleSymbol The root of the module system.
    */
-  constructor(reporter, loader, module) {
+  constructor(reporter, loader, moduleSymbol) {
     this.reporter = reporter;
     this.loader_ = loader;
-    this.module = module;
+    this.moduleSymbol = moduleSymbol;
   }
 
   /**
@@ -43,16 +43,16 @@ export class ModuleVisitor extends ParseTreeVisitor {
    */
   getModuleSymbolForModuleSpecifier(tree) {
     var name = tree.token.processedValue;
-    var referrer = this.module.url;
-    var module = this.loader_.getModuleSymbolForModuleSpecifier(name, referrer);
-
-    if (!module) {
+    var referrer = this.moduleSymbol.url;
+    var codeUnit = this.loader_.getCodeUnitForModuleSpecifier(name, referrer);
+    var moduleSymbol = codeUnit.data.moduleSymbol;
+    if (!moduleSymbol) {
       var msg = `${name} is not a module, required by ${referrer}`;
       this.reportError(tree, msg);
       return null;
     }
 
-    return module;
+    return moduleSymbol;
   }
 
   // Limit the trees to visit.

--- a/src/semantics/ModuleAnalyzer.js
+++ b/src/semantics/ModuleAnalyzer.js
@@ -27,36 +27,34 @@ export class ModuleAnalyzer {
    * @param {ErrorReporter} reporter
    * @param {Loader} loader
    */
-  constructor(reporter, loader) {
+  constructor(reporter) {
     this.reporter_ = reporter;
-    this.loader_ = loader;
   }
 
   /**
    * @param {Array.<ParseTree>} trees
-   * @param {Array.<ModuleSymbol>=} roots
+   * @param {Array.<ModuleSymbol>=} moduleSymbols
    * @return {void}
    */
-  analyzeTrees(trees, roots) {
+  analyzeTrees(trees, moduleSymbols, loader) {
     if (!transformOptions.modules)
       return;
 
     var reporter = this.reporter_;
-    var loader = this.loader_;
-    function getRoot(i) {
-      return roots.length ? roots[i] : roots;
+    function getModuleSymbol(i) {
+      return moduleSymbols.length ? moduleSymbols[i] : moduleSymbols;
     }
 
     function doVisit(ctor) {
       for (var i = 0; i < trees.length; i++) {
-        var visitor = new ctor(reporter, loader, getRoot(i));
+        var visitor = new ctor(reporter, loader, getModuleSymbol(i));
         visitor.visitAny(trees[i]);
       }
     }
 
     function reverseVisit(ctor) {
       for (var i = trees.length - 1; i >= 0; i--) {
-        var visitor = new ctor(reporter, loader, getRoot(i));
+        var visitor = new ctor(reporter, loader, getModuleSymbol(i));
         visitor.visitAny(trees[i]);
       }
     }


### PR DESCRIPTION
Propagate to ModuleVisitor family.
Rename 'module' to 'moduleSymbol' when referencing ModuleSymbol objects.

TBR=johnjbarton
