### PR TITLE
Makefile rules for build/node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/traceur.ugly.js
 build/compiled-by-previous-traceur.js
 build/dep.mk
 build/local.mk
+build/node
 build/previous-commit-traceur.js
 node_modules
 out


### PR DESCRIPTION
The files in build/node are checked out from a previous git commit,
ie they are 'known good' versions of src/node files. Added rules to create or update
build/node when src/node/\* changes. Removed the deletion of build/node upon success in
the build and added build/node to .gitignore instead.

TBR=johnjbarton
