### PR TITLE
Minimal Loader API.

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -17531,7 +17531,7 @@ $traceurRuntime.registerModule("../src/runtime/Loader.js", function() {
       this.cache.set({}, codeUnit);
       return codeUnit;
     },
-    eval: function(code, name) {
+    script: function(code, name) {
       var codeUnit = new EvalCodeUnit(this.loaderHooks, code, name);
       this.cache.set({}, codeUnit);
       this.handleCodeUnitLoaded(codeUnit);
@@ -17659,26 +17659,6 @@ $traceurRuntime.registerModule("../src/runtime/Loader.js", function() {
     this.internalLoader_ = new InternalLoader(loaderHooks);
   };
   Loader = ($traceurRuntime.createClass)(Loader, {
-    load: function(url) {
-      var callback = arguments[1] !== (void 0) ? arguments[1]: (function(result) {});
-      var errback = arguments[2] !== (void 0) ? arguments[2]: (function(ex) {
-        throw ex;
-      });
-      var codeUnit = this.internalLoader_.load(url, 'script');
-      codeUnit.addListener(function(result) {
-        callback(result);
-      }, errback);
-    },
-    eval: function(source, name) {
-      var codeUnit = this.internalLoader_.eval(source, name);
-      return codeUnit.result;
-    },
-    module: function(source, options, callback) {
-      var errback = arguments[3];
-      var codeUnit = this.internalLoader_.module (source, options);
-      codeUnit.addListener(callback, errback);
-      this.internalLoader_.handleCodeUnitLoaded(codeUnit);
-    },
     import: function(url) {
       var callback = arguments[1] !== (void 0) ? arguments[1]: (function(module) {});
       var errback = arguments[2] !== (void 0) ? arguments[2]: (function(ex) {
@@ -17689,15 +17669,25 @@ $traceurRuntime.registerModule("../src/runtime/Loader.js", function() {
         callback(System.get(codeUnit.url));
       }, errback);
     },
-    defineGlobal: function(name, value) {
-      throw Error('Not implemented');
+    module: function(source, options, callback) {
+      var errback = arguments[3];
+      var codeUnit = this.internalLoader_.module (source, options);
+      codeUnit.addListener(callback, errback);
+      this.internalLoader_.handleCodeUnitLoaded(codeUnit);
     },
-    defineModule: function(name, moduleInstanceObject) {
-      var cacheKey = arguments[2];
-      throw Error('Not implemented');
+    loadAsScript: function(url) {
+      var callback = arguments[1] !== (void 0) ? arguments[1]: (function(result) {});
+      var errback = arguments[2] !== (void 0) ? arguments[2]: (function(ex) {
+        throw ex;
+      });
+      var codeUnit = this.internalLoader_.load(url, 'script');
+      codeUnit.addListener(function(result) {
+        callback(result);
+      }, errback);
     },
-    createBase: function() {
-      return base;
+    script: function(source, name) {
+      var codeUnit = this.internalLoader_.script(source, name);
+      return codeUnit.result;
     }
   }, {});
   ;

--- a/demo/repl.js
+++ b/demo/repl.js
@@ -82,7 +82,7 @@ function compile(cmd, url) {
     var Loader = traceur.modules.Loader;
     var loaderHooks = new InterceptOutputLoaderHooks(reporter, url);
     var loader = new Loader(loaderHooks);
-    loader.eval(cmd, url);
+    loader.script(cmd, url);
     var output = loaderHooks.transcoded;
     debug('traceur-output: %s', output);
     return output;

--- a/src/node/inline-module.js
+++ b/src/node/inline-module.js
@@ -86,7 +86,7 @@ function inlineAndCompile(filenames, options, reporter, callback, errback) {
   var loader = new Loader(hooks);
 
   function loadNext() {
-    var codeUnit = loader.load(filenames[loadCount],function() {
+    var codeUnit = loader.loadAsScript(filenames[loadCount],function() {
       loadCount++;
       if (loadCount < filenames.length) {
         loadNext();

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -188,7 +188,7 @@
       if (/\.module\.js$/.test(url))
         moduleLoader.import(url, handleSuccess, handleFailure);
       else
-        moduleLoader.load(url, handleSuccess, handleFailure);
+        moduleLoader.loadAsScript(url, handleSuccess, handleFailure);
     });
   }
 

--- a/test/unit/es6/semantics/FreeVariableChecker.js
+++ b/test/unit/es6/semantics/FreeVariableChecker.js
@@ -33,7 +33,7 @@ suite('FreeVariableChecker.traceur.js', function() {
     var url = 'http://www.test.com/';
     var loaderHooks = new LoaderHooks(reporter, url);
     var loader = new Loader(loaderHooks);
-    loader.eval(contents, url);
+    loader.script(contents, url);
     return errors;
   }
 

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -40,7 +40,7 @@ suite('context test', function() {
     var reporter = new traceur.util.TestErrorReporter();
     var loaderHooks = new InterceptOutputLoaderHooks(reporter, fileName);
     var loader = new Loader(loaderHooks);
-    loader.eval(source, fileName);
+    loader.script(source, fileName);
     assert.ok(!reporter.hadError(), reporter.errors.join('\n'));
     var output = loaderHooks.transcoded;
 

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -49,7 +49,7 @@ suite('modules.js', function() {
   }
 
   test('LoaderEval', function() {
-    var result = getLoader().eval('(function(x = 42) { return x; })()');
+    var result = getLoader().script('(function(x = 42) { return x; })()');
     assert.equal(42, result);
   });
 
@@ -112,7 +112,7 @@ suite('modules.js', function() {
   });
 
   test('LoaderLoad', function(done) {
-    getLoader().load('./test_script.js', function(result) {
+    getLoader().loadAsScript('./test_script.js', function(result) {
       assert.equal('A', result[0]);
       assert.equal('B', result[1]);
       assert.equal('C', result[2]);


### PR DESCRIPTION
Close to the spec: import(url, callback, errback),
  module(source, options, callback, errback).
Not in spec: loadAsScript(url, callback, errback),
  script(source, name, callback, errback).
Other functions removed
