### PR TITLE
Allow commonjs modules to use module.exports directly

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -13440,6 +13440,9 @@ $traceurRuntime.registerModule("../src/codegeneration/module/DirectExportVisitor
     },
     visitExportStar: function(tree) {
       this.starExports.push(this.moduleSpecifier);
+    },
+    hasExports: function() {
+      return this.namedExports.length != 0 || this.starExports.length != 0;
     }
   }, {}, ExportVisitor);
   return {get DirectExportVisitor() {
@@ -13552,6 +13555,9 @@ $traceurRuntime.registerModule("../src/codegeneration/ModuleTransformer.js", fun
         return parseStatement($__112, args);
       }
       return parseStatement($__113, object);
+    },
+    hasExports: function() {
+      return this.exportVisitor_.hasExports();
     },
     transformExportDeclaration: function(tree) {
       this.exportVisitor_.visitAny(tree);
@@ -14943,9 +14949,7 @@ $traceurRuntime.registerModule("../src/codegeneration/CommonJsModuleTransformer.
       $__170 = Object.freeze(Object.defineProperties(["require(", ")"], {raw: {value: Object.freeze(["require(", ")"])}}));
   var FindInFunctionScope = $traceurRuntime.getModuleImpl("../src/codegeneration/FindInFunctionScope.js").FindInFunctionScope;
   var ModuleTransformer = $traceurRuntime.getModuleImpl("../src/codegeneration/ModuleTransformer.js").ModuleTransformer;
-  var $__172 = $traceurRuntime.getModuleImpl("../src/syntax/trees/ParseTreeType.js"),
-      OBJECT_LITERAL_EXPRESSION = $__172.OBJECT_LITERAL_EXPRESSION,
-      RETURN_STATEMENT = $__172.RETURN_STATEMENT;
+  var RETURN_STATEMENT = $traceurRuntime.getModuleImpl("../src/syntax/trees/ParseTreeType.js").RETURN_STATEMENT;
   var assert = $traceurRuntime.getModuleImpl("../src/util/assert.js").assert;
   var $__172 = $traceurRuntime.getModuleImpl("../src/codegeneration/PlaceholderParser.js"),
       parseExpression = $__172.parseExpression,
@@ -14974,7 +14978,7 @@ $traceurRuntime.registerModule("../src/codegeneration/CommonJsModuleTransformer.
       statements = statements.slice(0, - 1);
       assert(last.type === RETURN_STATEMENT);
       var exportObject = last.expression;
-      if (!(exportObject.type == OBJECT_LITERAL_EXPRESSION && exportObject.propertyNameAndValues.length == 0)) {
+      if (this.hasExports()) {
         statements.push(parseStatement($__169, exportObject));
       }
       return statements;

--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -14,10 +14,7 @@
 
 import {FindInFunctionScope} from './FindInFunctionScope';
 import {ModuleTransformer} from './ModuleTransformer';
-import {
-  OBJECT_LITERAL_EXPRESSION,
-  RETURN_STATEMENT
-} from '../syntax/trees/ParseTreeType';
+import {RETURN_STATEMENT} from '../syntax/trees/ParseTreeType';
 import {assert} from '../util/assert';
 import {
   parseExpression,
@@ -53,11 +50,10 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
     assert(last.type === RETURN_STATEMENT);
     var exportObject = last.expression;
 
-    // If the module doesn't use any export statements, it might be because it
-    // wants to make its own changes to "exports" or "module.exports", so we
-    // don't append "module.exports = {}" to the output.
-    if (!(exportObject.type == OBJECT_LITERAL_EXPRESSION &&
-          exportObject.propertyNameAndValues.length == 0)) {
+    // If the module doesn't use any export statements, nor global "this", it
+    // might be because it wants to make its own changes to "exports" or
+    // "module.exports", so we don't append "module.exports = {}" to the output.
+    if (this.hasExports()) {
       statements.push(parseStatement `module.exports = ${exportObject};`);
     }
     return statements;

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -146,6 +146,13 @@ export class ModuleTransformer extends TempVarTransformer {
     return parseStatement `return ${object}`;
   }
 
+  /**
+   * @return {boolean}
+   */
+  hasExports() {
+    return this.exportVisitor_.hasExports();
+  }
+
   transformExportDeclaration(tree) {
     this.exportVisitor_.visitAny(tree);
     return this.transformAny(tree.declaration);

--- a/src/codegeneration/module/DirectExportVisitor.js
+++ b/src/codegeneration/module/DirectExportVisitor.js
@@ -42,4 +42,8 @@ export class DirectExportVisitor extends ExportVisitor {
   visitExportStar(tree) {
     this.starExports.push(this.moduleSpecifier);
   }
+
+  hasExports() {
+    return this.namedExports.length != 0 || this.starExports.length != 0;
+  }
 }


### PR DESCRIPTION
When using CommonJsModuleTransformer, the module can either use the import statement, or the "old" require() function. This allows the same thing for exports. If a module doesn't use any export statements, it can still export values the pre-ES6 way by assigning to exports.foo or module.exports. Traceur users can migrate to ES6 export statements gradually instead of all at once.

Fixes #598.
