### PR TITLE
Move .locate() from System to LoaderHooks.

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -545,19 +545,6 @@
       if (refererName) return resolveUrl(refererName, name);
       return canonicalizeUrl(name);
     },
-    locate: function(load) {
-      load.url = this.locate_(load);
-      return load.url;
-    },
-    locate_: function(load) {
-      var normalizedModuleName = load.name;
-      var asJS = normalizedModuleName + '.js';
-      if (/\.js$/.test(normalizedModuleName)) asJS = normalizedModuleName;
-      if (isAbsolute(asJS)) return asJS;
-      var baseURL = load.metadata && load.metadata.baseURL;
-      if (baseURL) return resolveUrl(baseURL, asJS);
-      return asJS;
-    },
     get: function(name) {
       var m = getUncoatedModuleInstantiator(name);
       if (!m) return undefined;
@@ -19747,6 +19734,9 @@ $traceurRuntime.registerModule("../src/runtime/LoaderHooks", function() {
   var SourceFile = $traceurRuntime.getModuleImpl("../src/syntax/SourceFile").SourceFile;
   var TreeWriter = $traceurRuntime.getModuleImpl("../src/outputgeneration/TreeWriter").TreeWriter;
   var UniqueIdentifierGenerator = $traceurRuntime.getModuleImpl("../src/codegeneration/UniqueIdentifierGenerator").UniqueIdentifierGenerator;
+  var $__290 = $traceurRuntime.getModuleImpl("../src/util/url"),
+      isAbsolute = $__290.isAbsolute,
+      resolveUrl = $__290.resolveUrl;
   var webLoader = $traceurRuntime.getModuleImpl("../src/runtime/webLoader").webLoader;
   var assert = $traceurRuntime.getModuleImpl("../src/util/assert").assert;
   var NOT_STARTED = 0;
@@ -19804,6 +19794,19 @@ $traceurRuntime.registerModule("../src/runtime/LoaderHooks", function() {
           source = $__291.source,
           sourceMap = $__291.sourceMap;
       return undefined;
+    },
+    locate: function(load) {
+      load.url = this.locate_(load);
+      return load.url;
+    },
+    locate_: function(load) {
+      var normalizedModuleName = load.name;
+      var asJS = normalizedModuleName + '.js';
+      if (/\.js$/.test(normalizedModuleName)) asJS = normalizedModuleName;
+      if (isAbsolute(asJS)) return asJS;
+      var baseURL = load.metadata && load.metadata.baseURL;
+      if (baseURL) return resolveUrl(baseURL, asJS);
+      return asJS;
     },
     evaluateCodeUnit: function(codeUnit) {
       var result = ('global', eval)(codeUnit.data.transcoded);
@@ -20008,7 +20011,7 @@ $traceurRuntime.registerModule("../src/runtime/Loader", function() {
       codeUnit.state = LOADING;
       var loader = this;
       var translate = this.translateHook;
-      var url = System.locate(codeUnit);
+      var url = this.loaderHooks.locate(codeUnit);
       codeUnit.abort = this.loadTextFile(url, function(text) {
         codeUnit.text = translate(text);
         codeUnit.state = LOADED;

--- a/src/runtime/Loader.js
+++ b/src/runtime/Loader.js
@@ -200,7 +200,7 @@ class InternalLoader {
     codeUnit.state = LOADING;
     var loader = this;
     var translate = this.translateHook;
-    var url = System.locate(codeUnit);
+    var url = this.loaderHooks.locate(codeUnit);
     codeUnit.abort = this.loadTextFile(url, function(text) {
       codeUnit.text = translate(text);
       codeUnit.state = LOADED;

--- a/src/runtime/LoaderHooks.js
+++ b/src/runtime/LoaderHooks.js
@@ -25,6 +25,7 @@ import {SourceFile} from '../syntax/SourceFile';
 import {TreeWriter} from '../outputgeneration/TreeWriter';
 import {UniqueIdentifierGenerator} from
     '../codegeneration/UniqueIdentifierGenerator';
+import {isAbsolute, resolveUrl} from '../util/url';
 import {webLoader} from './webLoader';
 
 
@@ -101,6 +102,25 @@ export class LoaderHooks {
 
   instantiate({name, metadata, address, source, sourceMap}) {
     return undefined;
+  }
+
+  locate(load) {
+    load.url = this.locate_(load);
+    return load.url;
+  }
+
+  locate_(load) {
+    var normalizedModuleName = load.name;
+    var asJS = normalizedModuleName + '.js';
+    // Tolerate .js endings
+    if (/\.js$/.test(normalizedModuleName))
+      asJS = normalizedModuleName;
+    if (isAbsolute(asJS))
+      return asJS;
+    var baseURL = load.metadata && load.metadata.baseURL;
+    if (baseURL)
+      return resolveUrl(baseURL, asJS);
+    return asJS;
   }
 
   evaluateCodeUnit(codeUnit) {

--- a/src/runtime/modules.js
+++ b/src/runtime/modules.js
@@ -119,26 +119,6 @@
       return canonicalizeUrl(name);
     },
 
-    // Should only be called just before 'fetch'
-    locate(load) {
-      load.url = this.locate_(load);
-      return load.url;
-    },
-
-    locate_(load) {
-      var normalizedModuleName = load.name;
-      var asJS = normalizedModuleName + '.js';
-      // Tolerate .js endings
-      if (/\.js$/.test(normalizedModuleName))
-        asJS = normalizedModuleName;
-      if (isAbsolute(asJS))
-        return asJS;
-      var baseURL = load.metadata && load.metadata.baseURL;
-      if (baseURL)
-        return resolveUrl(baseURL, asJS);
-      return asJS;
-    },
-
     get(name) {
       var m = getUncoatedModuleInstantiator(name);
       if (!m)

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -41,12 +41,28 @@ suite('modules.js', function() {
                                   'unit/runtime/modules.js');
   }
 
-  function getLoader(opt_reporter) {
+  function getLoaderHooks(opt_reporter) {
     var LoaderHooks = traceur.modules.LoaderHooks;
     opt_reporter = opt_reporter || reporter;
-    var loaderHooks = new LoaderHooks(opt_reporter, url, null, loader);
-    return new traceur.modules.Loader(loaderHooks);
+    return new LoaderHooks(opt_reporter, url, null, loader);
   }
+
+  function getLoader(opt_reporter) {
+    return new traceur.modules.Loader(getLoaderHooks(opt_reporter));
+  }
+
+  test('LoaderHooks.locate', function() {
+    var loaderHooks = getLoaderHooks();
+    var load = {
+      metadata: {
+        baseURL: 'http://example.org/a/'
+      }
+    }
+    load.name = '@abc/def';
+    assert.equal(loaderHooks.locate(load), 'http://example.org/a/@abc/def.js');
+    load.name = 'abc/def';
+    assert.equal(loaderHooks.locate(load), 'http://example.org/a/abc/def.js');
+  });
 
   test('LoaderEval', function() {
     var result = getLoader().script('(function(x = 42) { return x; })()');

--- a/test/unit/runtime/System.js
+++ b/test/unit/runtime/System.js
@@ -71,16 +71,4 @@ suite('System.js', function() {
       'http://example.org/b.html');
   });
 
-  test('System.locate', function() {
-    var load = {
-      metadata: {
-        baseURL: 'http://example.org/a/'
-      }
-    }
-    load.name = '@abc/def';
-    assert.equal(System.locate(load), 'http://example.org/a/@abc/def.js');
-    load.name = 'abc/def';
-    assert.equal(System.locate(load), 'http://example.org/a/abc/def.js');
-  });
-
 });


### PR DESCRIPTION
This function is called by the Loader before fetch();
it is essential private API between Loader and LoaderHooks.
