### PR TITLE
Extend Loader API calls for support name manipulation

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -562,7 +562,6 @@
     setupGlobals(global);
   };
   global.System = System;
-  $traceurRuntime.registerModule = System.registerModule;
   $traceurRuntime.getModuleImpl = function(name) {
     var instantiator = getUncoatedModuleInstantiator(name);
     return instantiator && instantiator.getUncoatedModule();
@@ -19713,7 +19712,8 @@ System.registerModule("../src/runtime/LoaderHooks", function() {
       var reporter = this.reporter;
       var normalizedName = codeUnit.name;
       var program = codeUnit.text;
-      var file = new SourceFile(codeUnit.url, program);
+      var url = codeUnit.url || normalizedName;
+      var file = new SourceFile(url, program);
       var parser = new Parser(reporter, file);
       if (codeUnit.type == 'module') codeUnit.data.tree = parser.parseModule(); else codeUnit.data.tree = parser.parseScript();
       codeUnit.data.moduleSymbol = new ModuleSymbol(codeUnit.data.tree, normalizedName);
@@ -19949,13 +19949,12 @@ System.registerModule("../src/runtime/Loader", function() {
     loadTextFile: function(url, callback, errback) {
       return this.loaderHooks.fetch({address: url}, callback, errback);
     },
-    normalize: function(name) {
-      var referrerName = System.referrerName || this.loaderHooks.rootUrl();
-      return System.normalize(name, referrerName);
-    },
     loadUnnormalized: function(name) {
-      var type = arguments[1] !== (void 0) ? arguments[1]: 'script';
-      return this.load(this.normalize(name), type);
+      var referrerName = arguments[1] !== (void 0) ? arguments[1]: this.loaderHooks.rootUrl();
+      var address = arguments[2];
+      var type = arguments[3] !== (void 0) ? arguments[3]: 'script';
+      var normalizedName = System.normalize(name, referrerName, address);
+      return this.load(normalizedName, type);
     },
     load: function(normalizedName, type) {
       var codeUnit = this.getCodeUnit(normalizedName, type);
@@ -19976,14 +19975,18 @@ System.registerModule("../src/runtime/Loader", function() {
       });
       return codeUnit;
     },
-    module: function(code, options) {
-      var codeUnit = new EvalCodeUnit(this.loaderHooks, code, options.address);
+    module: function(code, name, referrerName, address) {
+      var normalizedName = System.normalize(name, referrerName, address);
+      var codeUnit = new EvalCodeUnit(this.loaderHooks, code, normalizedName);
       this.cache.set({}, codeUnit);
       return codeUnit;
     },
     script: function(code) {
       var name = arguments[1] !== (void 0) ? arguments[1]: this.loaderHooks.rootUrl();
-      var codeUnit = new EvalCodeUnit(this.loaderHooks, code, this.normalize(name));
+      var referrerName = arguments[2];
+      var address = arguments[3];
+      var normalizedName = System.normalize(name, referrerName, address);
+      var codeUnit = new EvalCodeUnit(this.loaderHooks, code, normalizedName);
       this.cache.set({}, codeUnit);
       this.handleCodeUnitLoaded(codeUnit);
       return codeUnit;
@@ -20111,34 +20114,57 @@ System.registerModule("../src/runtime/Loader", function() {
   };
   Loader = ($traceurRuntime.createClass)(Loader, {
     import: function(name) {
-      var callback = arguments[1] !== (void 0) ? arguments[1]: (function(module) {});
-      var errback = arguments[2] !== (void 0) ? arguments[2]: (function(ex) {
+      var $__296 = arguments[1] !== (void 0) ? arguments[1]: {},
+          referrerName = $__296.referrerName,
+          address = $__296.address;
+      var callback = arguments[2] !== (void 0) ? arguments[2]: (function(module) {});
+      var errback = arguments[3] !== (void 0) ? arguments[3]: (function(ex) {
         throw ex;
       });
-      var codeUnit = this.internalLoader_.loadUnnormalized(name, 'module');
+      var codeUnit = this.internalLoader_.loadUnnormalized(name, referrerName, address, 'module');
       codeUnit.addListener(function() {
         callback(System.get(codeUnit.name));
       }, errback);
     },
-    module: function(source, options, callback) {
-      var errback = arguments[3];
-      var codeUnit = this.internalLoader_.module (source, options);
+    module: function(source, name) {
+      var $__296 = arguments[2] !== (void 0) ? arguments[2]: {},
+          referrerName = $__296.referrerName,
+          address = $__296.address;
+      var callback = arguments[3] !== (void 0) ? arguments[3]: (function(module) {});
+      var errback = arguments[4] !== (void 0) ? arguments[4]: (function(ex) {
+        throw ex;
+      });
+      var codeUnit = this.internalLoader_.module (source, name, referrerName, address);
       codeUnit.addListener(callback, errback);
       this.internalLoader_.handleCodeUnitLoaded(codeUnit);
     },
     loadAsScript: function(name) {
-      var callback = arguments[1] !== (void 0) ? arguments[1]: (function(result) {});
-      var errback = arguments[2] !== (void 0) ? arguments[2]: (function(ex) {
+      var $__296 = arguments[1] !== (void 0) ? arguments[1]: {},
+          referrerName = $__296.referrerName,
+          address = $__296.address;
+      var callback = arguments[2] !== (void 0) ? arguments[2]: (function(result) {});
+      var errback = arguments[3] !== (void 0) ? arguments[3]: (function(ex) {
         throw ex;
       });
-      var codeUnit = this.internalLoader_.loadUnnormalized(name, 'script');
+      var codeUnit = this.internalLoader_.loadUnnormalized(name, referrerName, address, 'script');
       codeUnit.addListener(function(result) {
         callback(result);
       }, errback);
     },
     script: function(source, name) {
-      var codeUnit = this.internalLoader_.script(source, name);
-      return codeUnit.result;
+      var $__296 = arguments[2] !== (void 0) ? arguments[2]: {},
+          referrerName = $__296.referrerName,
+          address = $__296.address;
+      var callback = arguments[3] !== (void 0) ? arguments[3]: (function(result) {});
+      var errback = arguments[4] !== (void 0) ? arguments[4]: (function(ex) {
+        throw ex;
+      });
+      try {
+        var codeUnit = this.internalLoader_.script(source, name, referrerName, address);
+        callback(codeUnit.result);
+      } catch (ex) {
+        errback(ex);
+      }
     }
   }, {});
   ;
@@ -20184,7 +20210,7 @@ System.registerModule("../src/WebPageTranscoder", function() {
       }));
     },
     addFileFromScriptElement: function(scriptElement, name, content) {
-      this.loader.module (content, {address: name});
+      this.loader.module (content, name);
     },
     nextInlineScriptName_: function() {
       this.numberInlined_ += 1;

--- a/demo/transcode.js
+++ b/demo/transcode.js
@@ -50,7 +50,7 @@ export function transcode(contents, name, onSuccess, onFailure) {
     onSuccess(loaderHooks.transcoded, loaderHooks.sourceMap);
   }
   var loader = new Loader(loaderHooks);
-  loader.module(contents, {address: name}, reportTranscoding, reportErrors);
+  loader.module(contents, name, {}, reportTranscoding, reportErrors);
 }
 
 export function renderSourceMap(source, sourceMap) {

--- a/src/WebPageTranscoder.js
+++ b/src/WebPageTranscoder.js
@@ -43,7 +43,7 @@ export class WebPageTranscoder {
   }
 
   addFileFromScriptElement(scriptElement, name, content) {
-    this.loader.module(content, {address: name});
+    this.loader.module(content, name);
   }
 
   /**

--- a/src/node/inline-module.js
+++ b/src/node/inline-module.js
@@ -80,7 +80,7 @@ function inlineAndCompile(filenames, options, reporter, callback, errback) {
   // The caller needs to do a chdir.
   var basePath = './';
   var depTarget = options && options.depTarget;
-  System.referrerName = options && options.referrer;
+  var referrerName = options && options.referrer;
 
   var loadCount = 0;
   var elements = [];
@@ -88,20 +88,22 @@ function inlineAndCompile(filenames, options, reporter, callback, errback) {
   var loader = new Loader(hooks);
 
   function loadNext() {
-    var codeUnit = loader.loadAsScript(filenames[loadCount], function() {
-      loadCount++;
-      if (loadCount < filenames.length) {
-        loadNext();
-      } else if (depTarget) {
-        callback(null);
-      } else {
-        var tree = allLoaded(basePath, reporter, elements);
-        callback(tree);
-      }
-    }, function() {
-      console.error(codeUnit.error);
-      errback(codeUnit.error);
-    });
+    var codeUnit = loader.loadAsScript(filenames[loadCount],
+      {referrerName: referrerName},
+      function() {
+        loadCount++;
+        if (loadCount < filenames.length) {
+          loadNext();
+        } else if (depTarget) {
+          callback(null);
+        } else {
+          var tree = allLoaded(basePath, reporter, elements);
+          callback(tree);
+        }
+      }, function() {
+        console.error(codeUnit.error);
+        errback(codeUnit.error);
+      });
   }
 
   loadNext();

--- a/src/runtime/LoaderHooks.js
+++ b/src/runtime/LoaderHooks.js
@@ -75,7 +75,9 @@ export class LoaderHooks {
     var reporter = this.reporter;
     var normalizedName = codeUnit.name;
     var program = codeUnit.text;
-    var file = new SourceFile(codeUnit.url, program);
+    // For error reporting, prefer loader URL, fallback if we did not load text.
+    var url = codeUnit.url || normalizedName;
+    var file = new SourceFile(url, program);
     var parser = new Parser(reporter, file);
     if (codeUnit.type == 'module')
       codeUnit.data.tree = parser.parseModule();

--- a/src/runtime/modules.js
+++ b/src/runtime/modules.js
@@ -148,8 +148,6 @@
   };
   global.System = System;
 
-  // TODO(jjb): remove
-  $traceurRuntime.registerModule = System.registerModule;
   $traceurRuntime.getModuleImpl = function(name) {
     var instantiator = getUncoatedModuleInstantiator(name);
     return instantiator && instantiator.getUncoatedModule();

--- a/test/runner.html
+++ b/test/runner.html
@@ -38,7 +38,7 @@ mocha.setup({ui: 'tdd'});
     return new traceur.modules.Loader(loaderHooks);
   }
 
-  getLoader().import('../src/runtime/webLoader', function(module) {
+  getLoader().import('../src/runtime/webLoader', {}, function(module) {
 	  featureSuite(testList, module.webLoader);
 
 	  new traceur.WebPageTranscoder(document.location.href).run(function() {

--- a/test/self-compile.html
+++ b/test/self-compile.html
@@ -16,7 +16,7 @@
       var loaderHooks = new LoaderHooks(new traceur.util.ErrorReporter(), url);
       return new traceur.modules.Loader(loaderHooks);
     }
-    getLoader().import('../src/traceur.js',
+    getLoader().import('../src/traceur.js', {}
         function(mod) {
           console.log('DONE');
         },

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -186,9 +186,9 @@
       }
 
       if (/\.module\.js$/.test(url))
-        moduleLoader.import(url, handleSuccess, handleFailure);
+        moduleLoader.import(url, {}, handleSuccess, handleFailure);
       else
-        moduleLoader.loadAsScript(url, handleSuccess, handleFailure);
+        moduleLoader.loadAsScript(url, {}, handleSuccess, handleFailure);
     });
   }
 

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -64,9 +64,12 @@ suite('modules.js', function() {
     assert.equal(loaderHooks.locate(load), 'http://example.org/a/abc/def.js');
   });
 
-  test('LoaderEval', function() {
-    var result = getLoader().script('(function(x = 42) { return x; })()');
-    assert.equal(42, result);
+  test('LoaderEval', function(done) {
+    getLoader().script('(function(x = 42) { return x; })()', './LoaderEval', {},
+      function(result) {
+        assert.equal(42, result);
+        done();
+      });
   });
 
   test('LoaderModule', function(done) {
@@ -77,16 +80,17 @@ suite('modules.js', function() {
         '\n' +
         '[\'test\', a.name, b.name, c.name];\n';
 
-    var result = getLoader().module(code, {}, function(value) {
-      assert.equal('test', value[0]);
-      assert.equal('A', value[1]);
-      assert.equal('B', value[2]);
-      assert.equal('C', value[3]);
-      done();
-    }, function(error) {
-      fail(error);
-      done();
-    });
+    var result = getLoader().module(code, './LoaderModule', {},
+      function(value) {
+        assert.equal('test', value[0]);
+        assert.equal('A', value[1]);
+        assert.equal('B', value[2]);
+        assert.equal('C', value[3]);
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
   });
 
   test('LoaderModuleWithSubdir', function(done) {
@@ -95,14 +99,15 @@ suite('modules.js', function() {
         '\n' +
         '[d.name, d.e.name];\n';
 
-    var result = getLoader().module(code, {}, function(value) {
-      assert.equal('D', value[0]);
-      assert.equal('E', value[1]);
-      done();
-    }, function(error) {
-      fail(error);
-      done();
-    });
+    var result = getLoader().module(code, 'LoaderModuleWithSubdir', {},
+      function(value) {
+        assert.equal('D', value[0]);
+        assert.equal('E', value[1]);
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
   });
 
   test('LoaderModuleFail', function(done) {
@@ -115,20 +120,21 @@ suite('modules.js', function() {
 
     var reporter = new MutedErrorReporter();
 
-    var result = getLoader(reporter).module(code, {}, function(value) {
-      fail('Should not have succeeded');
-      done();
-    }, function(error) {
-      // We should probably get some meaningful error here.
+    var result = getLoader(reporter).module(code, 'LoaderModuleFail', {},
+      function(value) {
+        fail('Should not have succeeded');
+        done();
+      }, function(error) {
+        // We should probably get some meaningful error here.
 
-      //assert.isTrue(reporter.hadError());
-      assert.isTrue(true);
-      done();
-    });
+        //assert.isTrue(reporter.hadError());
+        assert.isTrue(true);
+        done();
+      });
   });
 
   test('LoaderLoad', function(done) {
-    getLoader().loadAsScript('./test_script.js', function(result) {
+    getLoader().loadAsScript('./test_script.js', {}, function(result) {
       assert.equal('A', result[0]);
       assert.equal('B', result[1]);
       assert.equal('C', result[2]);
@@ -140,21 +146,21 @@ suite('modules.js', function() {
   });
 
   test('LoaderLoadWithReferrer', function(done) {
-    System.referrerName = 'traceur@0.0.1/bin';
-    getLoader().loadAsScript('../test_script.js', function(result) {
-      assert.equal('A', result[0]);
-      assert.equal('B', result[1]);
-      assert.equal('C', result[2]);
-      delete System.referrerName;
-      done();
-    }, function(error) {
-      fail(error);
-      done();
-    });
+    getLoader().loadAsScript('../test_script.js',
+      {referrerName: 'traceur@0.0.1/bin'},
+      function(result) {
+        assert.equal('A', result[0]);
+        assert.equal('B', result[1]);
+        assert.equal('C', result[2]);
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
   });
 
   test('LoaderImport', function(done) {
-    getLoader().import('./test_module.js', function(mod) {
+    getLoader().import('./test_module.js', {}, function(mod) {
       assert.equal('test', mod.name);
       assert.equal('A', mod.a);
       assert.equal('B', mod.b);
@@ -167,17 +173,17 @@ suite('modules.js', function() {
   });
 
   test('LoaderImportWithReferrer', function(done) {
-    System.referrerName = 'traceur@0.0.0/bin';
-    getLoader().import('../test_module.js', function(mod) {
-      assert.equal('test', mod.name);
-      assert.equal('A', mod.a);
-      assert.equal('B', mod.b);
-      assert.equal('C', mod.c);
-      delete System.referrerName;
-      done();
-    }, function(error) {
-      fail(error);
-      done();
-    });
+    getLoader().import('../test_module.js',
+      {referrerName: 'traceur@0.0.1/bin'},
+      function(mod) {
+        assert.equal('test', mod.name);
+        assert.equal('A', mod.a);
+        assert.equal('B', mod.b);
+        assert.equal('C', mod.c);
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
   });
 });

--- a/test/unit/runtime/test_interpret.js
+++ b/test/unit/runtime/test_interpret.js
@@ -16,7 +16,7 @@ import {assert} from '../../../src/util/assert';
 import {resolveUrl} from '../../../src/util/url';
 
 var testScriptName = '../../test/unit/runtime/test_script.js';
-global.SystemLoader.loadAsScript(testScriptName, function(result) {
+global.SystemLoader.loadAsScript(testScriptName, {}, function(result) {
   assert('A', result[0]);
   assert('B', result[1]);
   assert('C', result[2]);
@@ -25,7 +25,7 @@ global.SystemLoader.loadAsScript(testScriptName, function(result) {
 });
 
 var testModuleName = '../../test/unit/runtime/test_module.js';
-global.SystemLoader.import(testModuleName, function(mod) {
+global.SystemLoader.import(testModuleName, {}, function(mod) {
   assert('test', mod.name);
   assert('A', mod.a);
   assert('B', mod.b);


### PR DESCRIPTION
New API:
  Loader.import(name, {referrerName, address}, callback, errback).
  Loader.module(source, name, {referrerName, address}, callback, errback).
  Loader.loadAsScript(name, {referrerName, address}, callback, errback).
  Loader.script(source, name, {referrerName, address}, callback, errback).
where only the first argument is required. The triple name, referrerName, address
are passed to System.normalize().

import/module are similar to js-loaders as discussed:
https://github.com/jorendorff/js-loaders/issues/89.
js-loaders 'options' in module() where we have {referrerName, address}; we add it
to import().

loadAsScript/script are parallel but parse to Script goal. These are not part of js-loaders.
