### PR TITLE
Fix Windows build

### DIFF
--- a/src/node/interpreter.js
+++ b/src/node/interpreter.js
@@ -37,7 +37,7 @@ function interpret(filename, argv, flags) {
     return new traceur.modules.Loader(loaderHooks);
   }
   global.SystemLoader = getLoader();
-  global.SystemLoader.import(filename);
+  global.SystemLoader.import(filename.replace(/\\/g, '/'));
 }
 
 module.exports = interpret;


### PR DESCRIPTION
`import` needs to take a name and not a Windows file path with backslashes in it.

Fixes #653
