### PR TITLE
AMD __transpiledModule flag for System loader transpilation support

### DIFF
--- a/src/codegeneration/AmdTransformer.js
+++ b/src/codegeneration/AmdTransformer.js
@@ -18,7 +18,9 @@ import {createBindingIdentifier} from './ParseTreeFactory';
 import globalThis from './globalThis';
 import {
   parseExpression,
-  parseStatements
+  parseStatement,
+  parseStatements,
+  parsePropertyDefinition
 } from './PlaceholderParser';
 import scopeContainsThis from './scopeContainsThis';
 
@@ -29,11 +31,20 @@ export class AmdTransformer extends ModuleTransformer {
     this.dependencies = [];
   }
 
+  getExportProperties() {
+    var properties = super();
+
+    if (this.exportVisitor_.hasExports())
+      properties.push(parsePropertyDefinition `__transpiledModule: true`);
+    return properties;
+  }
+
   wrapModule(statements) {
     var depPaths = this.dependencies.map((dep) => dep.path);
     var depLocals = this.dependencies.map((dep) => dep.local);
 
     var hasTopLevelThis = statements.some(scopeContainsThis);
+
     var func = parseExpression `function(${depLocals}) {
       ${statements}
     }`;

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -127,15 +127,18 @@ export class ModuleTransformer extends TempVarTransformer {
         `get ${name}() { return ${returnExpression}; }`;
   }
 
-  createExportStatement() {
-    var properties = this.exportVisitor_.namedExports.map((exp) => {
+  getExportProperties() {
+    return this.exportVisitor_.namedExports.map((exp) => {
       // export_name: {get: function() { return export_name },
       return this.getGetterExport(exp);
     });
-    var object = createObjectLiteralExpression(properties);
+  }
 
-    var starExports = this.exportVisitor_.starExports;
-    if (starExports.length) {
+  createExportStatement() {
+    var object = createObjectLiteralExpression(this.getExportProperties());
+    
+    if (this.exportVisitor_.starExports.length) {
+      var starExports = this.exportVisitor_.starExports;
       var starIdents = starExports.map((moduleSpecifier) => {
         return createIdentifierExpression(
             this.getTempVarNameForModuleSpecifier(moduleSpecifier));
@@ -143,7 +146,6 @@ export class ModuleTransformer extends TempVarTransformer {
       var args = createArgumentList(object, ...starIdents);
       return parseStatement `return $traceurRuntime.exportStar(${args})`;
     }
-
     return parseStatement `return ${object}`;
   }
 

--- a/test/amd/NamedExports.js
+++ b/test/amd/NamedExports.js
@@ -1,0 +1,1 @@
+export var someExport = 'val';

--- a/test/node-amd-test.js
+++ b/test/node-amd-test.js
@@ -1,10 +1,21 @@
 var requirejs = require('requirejs');
 var fs = require('fs');
+var path = require('path');
 
 var COMPILED_DIR = __dirname + '/amd-compiled';
 
 function onlyJsFiles(path) {
   return /\.js$/.test(path);
+}
+
+function moduleFromSource(src) {
+  var module;
+  var define = function(deps, factory) {
+    var output = factory();
+    module = output.__transpiledModule ? output : {default: output};
+  }
+  Function('define', src).call(global, define);
+  return module;
 }
 
 var testFiles = fs.readdirSync(COMPILED_DIR).filter(onlyJsFiles);
@@ -19,4 +30,10 @@ suite('amd', function() {
       requirejs(['./' + testFile.replace(/\.js$/, '')], function() {done();});
     });
   });
+
+  test('Transpiled module export', function(done) {
+    var module = moduleFromSource(fs.readFileSync(path.resolve(COMPILED_DIR, 'NamedExports.js')));
+    assert.equal(module.someExport, 'val');
+    done();
+  })
 });

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -93,8 +93,8 @@ suite('context test', function() {
       assert.isNull(error);
       var fileContents = fs.readFileSync(path.resolve(outDir, 'file.js'));
       var depContents = fs.readFileSync(path.resolve(outDir, 'dep.js'));
-      assert.equal(fileContents + '', "define(['./dep'], function($__0) {\n  \"use strict\";\n  var q = ($__0).q;\n  var p = 'module';\n  return {get p() {\n      return p;\n    }};\n});\n");
-      assert.equal(depContents + '', "define([], function() {\n  \"use strict\";\n  var q = 'q';\n  return {get q() {\n      return q;\n    }};\n});\n");
+      assert.equal(fileContents + '', "define(['./dep'], function($__0) {\n  \"use strict\";\n  var q = ($__0).q;\n  var p = 'module';\n  return {\n    get p() {\n      return p;\n    },\n    __transpiledModule: true\n  };\n});\n");
+      assert.equal(depContents + '', "define([], function() {\n  \"use strict\";\n  var q = 'q';\n  return {\n    get q() {\n      return q;\n    },\n    __transpiledModule: true\n  };\n});\n");
       done();
     });
   });


### PR DESCRIPTION
To explain the feature, the reason for this is I want to be able to dynamically load AMD from ES6 Module Loader, but also support loading AMD that is compiled from ES6 and should be treated like an ES6 module.

In this way, one can write ES6 modules, then transpile them back into AMD for production, and have the `System` loader behave identically, just without the Traceur step.

But, in order to distinguish handling between an AMD module and an ES6 in disguise as an AMD module, we need to have some kind of flag to know that we should treat it as the module object directly:

``` javascript
  new Module(amdExport)
```

instead of using the `default` property of a module, which is done for AMD exports normally for compatibility:

``` javascript
  new Module({ default: amdExport })
```

Suggestions welcome if there are better ways of going about this.
