### PR TITLE
module directory parsing command option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ src/syntax/trees/ParseTreeType.js
 src/syntax/trees/ParseTrees.js
 test/unit/codegeneration/PlaceholderParser.generated.js
 test/unit/semantics/FreeVariableChecker.generated.js
+test/unit/node/resources/compile-amd
+test/unit/node/resources/compile-cjs
 test/amd-compiled
 test/bench/esprima
 test/commonjs-compiled

--- a/src/node/command.js
+++ b/src/node/command.js
@@ -36,6 +36,8 @@ flags.option('--out <FILE>', 'Compile all input files into a single file');
 flags.option('--referrer <name>',
     'Prefix compiled code with System.referrName');
 
+flags.option('--dir <INDIR> <OUTDIR>', 'Compile an input directory of modules into an output directory');
+
 flags.option('--sourcemap', 'Generate source maps');
 flags.on('sourcemap', function() {
   flags.sourceMaps = traceur.options.sourceMaps = true;
@@ -52,6 +54,7 @@ flags.on('--help', function() {
   console.log('');
   console.log('    $ %s a.js [args]', cmdName);
   console.log('    $ %s --out compiled.js b.js c.js', cmdName);
+  console.log('    $ %s --dir indir outdir', cmdName);
   console.log('');
 });
 
@@ -108,7 +111,7 @@ function processArguments(argv) {
 
     var option = flags.optionFor(arg);
     if (option) {
-      if (arg === '--out')
+      if (arg === '--out' || arg === '--dir')
         interpretMode = false;
 
       if (option.required)
@@ -159,12 +162,17 @@ var compileToSingleFile = compiler.compileToSingleFile;
 var compileToDirectory = compiler.compileToDirectory;
 
 var out = flags.out;
+var dir = flags.dir;
 if (out) {
   var isSingleFileCompile = /\.js$/.test(out);
   if (isSingleFileCompile)
     compileToSingleFile(out, includes, flags.sourceMaps);
   else
     compileToDirectory(out, includes, flags.sourceMaps);
-} else {
+} else if (dir) {
+  var compileAllJsFilesInDir = require('./compile-single-file.js').compileAllJsFilesInDir;
+  compileAllJsFilesInDir(dir, includes[0]);
+}
+else {
   interpret(path.resolve(includes[0]), includes.slice(1), argv.flags);
 }

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -84,4 +84,32 @@ suite('context test', function() {
           done();
         });
   });
+
+  test('compile module dir option AMD', function(done) {
+    var executable = 'node ' + resolve('src/node/command.js');
+    var inputDir = resolve('test/unit/node/resources/compile-dir');
+    var outDir = resolve('test/unit/node/resources/compile-amd');
+    exec(executable + ' --dir ' + inputDir + ' ' + outDir + ' --modules=amd', function(error, stdout, stderr) {
+      assert.isNull(error);
+      var fileContents = fs.readFileSync(path.resolve(outDir, 'file.js'));
+      var depContents = fs.readFileSync(path.resolve(outDir, 'dep.js'));
+      assert.equal(fileContents + '', "define(['./dep'], function($__0) {\n  \"use strict\";\n  var q = ($__0).q;\n  var p = 'module';\n  return {get p() {\n      return p;\n    }};\n});\n");
+      assert.equal(depContents + '', "define([], function() {\n  \"use strict\";\n  var q = 'q';\n  return {get q() {\n      return q;\n    }};\n});\n");
+      done();
+    });
+  });
+
+  test('compile module dir option CommonJS', function(done) {
+    var executable = 'node ' + resolve('src/node/command.js');
+    var inputDir = resolve('test/unit/node/resources/compile-dir');
+    var outDir = resolve('test/unit/node/resources/compile-cjs');
+    exec(executable + ' --dir ' + inputDir + ' ' + outDir + ' --modules=commonjs', function(error, stdout, stderr) {
+      assert.isNull(error);
+      var fileContents = fs.readFileSync(path.resolve(outDir, 'file.js'));
+      var depContents = fs.readFileSync(path.resolve(outDir, 'dep.js'));
+      assert.equal(fileContents + '', "\"use strict\";\nvar q = require('./dep').q;\nvar p = 'module';\nmodule.exports = {get p() {\n    return p;\n  }};\n");
+      assert.equal(depContents + '', "\"use strict\";\nvar q = 'q';\nmodule.exports = {get q() {\n    return q;\n  }};\n");
+      done();
+    });
+  })
 });

--- a/test/unit/node/resources/compile-dir/dep.js
+++ b/test/unit/node/resources/compile-dir/dep.js
@@ -1,0 +1,1 @@
+export var q = 'q';

--- a/test/unit/node/resources/compile-dir/file.js
+++ b/test/unit/node/resources/compile-dir/file.js
@@ -1,0 +1,2 @@
+import {q} from './dep';
+export var p = 'module';


### PR DESCRIPTION
This option allows the commandline ability to convert a directory of ES6 modules, into an output directory of transpiled modules. The module files remain distinct:

```
  traceur --dir app app-built
```

This then naturally allows the ability to transpile a directory full of ES6 modules into AMD ES5 modules:

```
  traceur --dir app app-built --modules=amd
```

Then does what we want!
