### PR TITLE
Fix __moduleName tests on Windows.

### DIFF
--- a/src/node/compile-single-file.js
+++ b/src/node/compile-single-file.js
@@ -32,8 +32,8 @@ function compileSingleFile(inputFilePath, outputFilePath) {
     var sourceFile = new SourceFile(inputFilePath, contents);
     var parser = new Parser(reporter, sourceFile);
     var tree = parser.parseModule();
-    var moduleName = inputFilePath.replace(/\.js$/, '').replace(/\\/g,'/');
-    moduleName = path.relative(__dirname, moduleName);
+    var moduleName = inputFilePath.replace(/\.js$/, '');
+    moduleName = path.relative(__dirname, moduleName).replace(/\\/g,'/');
     var transformer = new AttachModuleNameTransformer(moduleName);
     tree = transformer.transformAny(tree);
     transformer = new FromOptionsTransformer(reporter);

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -29,7 +29,7 @@ suite('context test', function() {
   });
 
   function resolve(name) {
-    return path.resolve(__dirname, '../../../' + name);
+    return path.resolve(__dirname, '../../../' + name).replace(/\\/g, '/');
   }
 
   function executeFileWithRuntime(fileName) {


### PR DESCRIPTION
The path normalization was done before calling into Node's
path.resolve which returns back slashes.
