### PR TITLE
Rename traceur.modules.Loader to traceur.runtime.Loader.

### DIFF
--- a/demo/repl.js
+++ b/demo/repl.js
@@ -79,7 +79,7 @@ function compile(cmd, url) {
   try {
     debug('traceur-input: %s', cmd);
     var InterceptOutputLoaderHooks = traceur.runtime.InterceptOutputLoaderHooks;
-    var Loader = traceur.modules.Loader;
+    var Loader = traceur.runtime.Loader;
     var loaderHooks = new InterceptOutputLoaderHooks(reporter, url);
     var loader = new Loader(loaderHooks);
     loader.script(cmd, url);


### PR DESCRIPTION
One missed from last commit. Fixes #708

TBR=@arv
