### PR TITLE
Generator collapse end state

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -16955,13 +16955,13 @@ $traceurRuntime.ModuleStore.registerModule("traceur@0.0.16/src/codegeneration/ge
     transformCpsFunctionBody: function(tree, runtimeMethod) {
       var alphaRenamedTree = AlphaRenamer.rename(tree, 'arguments', '$arguments');
       var hasArguments = alphaRenamedTree !== tree;
-      var machine = this.transformAny(alphaRenamedTree);
+      var maybeMachine = this.transformAny(alphaRenamedTree);
       if (this.reporter.hadError()) return tree;
       var machine;
-      if (machine.type !== STATE_MACHINE) {
-        machine = this.statementsToStateMachine_(machine.statements);
+      if (maybeMachine.type !== STATE_MACHINE) {
+        machine = this.statementsToStateMachine_(maybeMachine.statements);
       } else {
-        machine = new StateMachine(machine.startState, machine.fallThroughState, this.removeEmptyStates(machine.states), machine.exceptionBlocks);
+        machine = new StateMachine(maybeMachine.startState, maybeMachine.fallThroughState, this.removeEmptyStates(maybeMachine.states), maybeMachine.exceptionBlocks);
       }
       machine = machine.replaceStateId(machine.fallThroughState, State.END_STATE).replaceStateId(machine.startState, State.START_STATE);
       var statements = this.getMachineVariables(tree, machine);

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -878,20 +878,21 @@ export class CPSTransformer extends ParseTreeTransformer {
     var hasArguments = alphaRenamedTree !== tree;
 
     // transform to a state machine
-    var machine = this.transformAny(alphaRenamedTree);
+    var maybeMachine = this.transformAny(alphaRenamedTree);
     if (this.reporter.hadError())
       return tree;
 
-    // If the FunctionBody has no yield or return no state machine got created
+    // If the FunctionBody has no yield or return, no state machine got created
     // in the above transformation. We therefore convert it below.
     var machine;
-    if (machine.type !== STATE_MACHINE) {
-      machine = this.statementsToStateMachine_(machine.statements);
+    if (maybeMachine.type !== STATE_MACHINE) {
+      machine = this.statementsToStateMachine_(maybeMachine.statements);
     } else {
-      machine = new StateMachine(machine.startState,
-                                 machine.fallThroughState,
-                                 this.removeEmptyStates(machine.states),
-                                 machine.exceptionBlocks);
+      // Remove possibly empty states.
+      machine = new StateMachine(maybeMachine.startState,
+                                 maybeMachine.fallThroughState,
+                                 this.removeEmptyStates(maybeMachine.states),
+                                 maybeMachine.exceptionBlocks);
     }
 
     // Clean up start and end states.


### PR DESCRIPTION
We used to always output

``` js
case 4:
  $ctx.state = END_STATE;
case END_STATE:
  ...
```

Now we skip the state before the END_STATE.
