### PR TITLE
Update ObjectLiteralTransformer.js

### DIFF
--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -282,7 +282,8 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
   }
 
   transformPropertyMethodAssignment(tree) {
-    var func = new FunctionExpression(tree.location, null, tree.isGenerator,
+    var name = tree.name.literalToken.value;
+    var func = new FunctionExpression(tree.location, name, tree.isGenerator,
         this.transformAny(tree.formalParameterList), tree.typeAnnotation, [],
         this.transformAny(tree.functionBody));
     if (!this.needsAdvancedTransform) {


### PR DESCRIPTION
Per the spec, a function should have a `name` property that matches the key within an object.

The name is explicitly passed as null, but anything but null, breaks the use of named and unnamed functions.
