### PR TITLE
Add comment callback to scanner and parser

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -283,12 +283,13 @@ addFeatureOption('deferredFunctions', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
 addFeatureOption('annotations', EXPERIMENTAL);
 
+addBoolOption('commentCallback');
 addBoolOption('debug');
-addBoolOption('sourceMaps');
 addBoolOption('freeVariableChecker');
-addBoolOption('validate');
-addBoolOption('unstarredGenerators');
+addBoolOption('sourceMaps');
 addBoolOption('typeAssertions');
+addBoolOption('unstarredGenerators');
+addBoolOption('validate');
 
 defaultValues.referrer = '';
 options.referrer = null;

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -3740,6 +3740,10 @@ export class Parser {
     return new SourceRange(start, this.getTreeEndLocation_());
   }
 
+  handleComment(range) {
+    // TODO(arv): Attach to tree nodes.
+  }
+
   /**
    * Consumes the next token and returns it. Will return a never ending stream of
    * END_OF_FILE at the end of the file so callers don't have to check for EOF explicitly.

--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -21,7 +21,10 @@ import {
   idContinueTable,
   idStartTable
 } from './unicode-tables';
-import {parseOptions} from '../options';
+import {
+  options,
+  parseOptions
+} from '../options';
 
 import {
   AMPERSAND,
@@ -613,20 +616,29 @@ function skipComment() {
   return false;
 }
 
+function commentCallback(start, index) {
+ if (options.commentCallback)
+    currentParser.handleComment(lineNumberTable.getSourceRange(start, index));
+}
+
 function skipSingleLineComment() {
+  var start = index;
   // skip '//'
   index += 2;
   while (!isAtEnd() && !isLineTerminator(input.charCodeAt(index++))) {}
   updateCurrentCharCode();
+  commentCallback(start, index);
 }
 
 function skipMultiLineComment() {
+  var start = index;
   var i = input.indexOf('*/', index + 2);
   if (i !== -1)
     index = i + 2;
   else
     index = length;
   updateCurrentCharCode();
+  commentCallback(start, index);
 }
 
 /**

--- a/src/util/SourcePosition.js
+++ b/src/util/SourcePosition.js
@@ -19,8 +19,6 @@ export class SourcePosition {
   /**
    * @param {SourceFile} source
    * @param {number} offset
-   * @param {number} line
-   * @param {number} column
    */
   constructor(source, offset) {
     this.source = source;

--- a/src/util/SourceRange.js
+++ b/src/util/SourceRange.js
@@ -24,4 +24,9 @@ export class SourceRange {
     this.start = start;
     this.end = end;
   }
+
+  toString() {
+    var str = this.start.source.contents;
+    return str.slice(this.start.offset, this.end.offset);
+  }
 }

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -19,6 +19,10 @@ suite('parser.js', function() {
     }
   };
 
+  teardown(function() {
+    traceur.options.reset();
+  });
+
   test('Module', function() {
     var program = 'export var x = 42;\n' +
                   'module M from \'url\';\n' +
@@ -28,6 +32,33 @@ suite('parser.js', function() {
     var parser = new traceur.syntax.Parser(sourceFile, errorReporter);
 
     parser.parseModule();
+  });
+
+  test('handleComment', function() {
+    traceur.options.commentCallback = true;
+
+    var program = '// AAA\n' +
+                  'var b = \'c\';\n' +
+                  '/* DDD */ function e() {}\n';
+    var sourceFile = new traceur.syntax.SourceFile('Name', program);
+    var parser = new traceur.syntax.Parser(sourceFile, errorReporter);
+    var comments = [];
+    parser.handleComment = function(sourceRange) {
+      comments.push(sourceRange);
+    };
+    parser.parseScript();
+
+    assert.equal(comments.length, 2);
+
+    assert.equal(comments[0].start.offset, 0);
+    assert.equal(comments[0].end.offset, 7);
+    assert.equal(comments[0].toString(), '// AAA\n');
+
+    assert.equal(comments[1].start.line, 2);
+    assert.equal(comments[1].start.column, 0);
+    assert.equal(comments[1].end.line, 2);
+    assert.equal(comments[1].end.column, 9);
+    assert.equal(comments[1].toString(), '/* DDD */');
   });
 
 });


### PR DESCRIPTION
This adds a hook to the parser that can be used to later attach comments to the tree.
#206
