### PR TITLE
`traceur-runtime` AMD dependency as a replacement for __transpiledModule export

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -15093,7 +15093,7 @@ $traceurRuntime.ModuleStore.registerModule("traceur@0.0.22/src/codegeneration/Am
   var $__136 = Object.freeze(Object.defineProperties(["__transpiledModule: true"], {raw: {value: Object.freeze(["__transpiledModule: true"])}})),
       $__137 = Object.freeze(Object.defineProperties(["function(", ") {\n      ", "\n    }"], {raw: {value: Object.freeze(["function(", ") {\n      ", "\n    }"])}})),
       $__138 = Object.freeze(Object.defineProperties(["", ".bind(", ")"], {raw: {value: Object.freeze(["", ".bind(", ")"])}})),
-      $__139 = Object.freeze(Object.defineProperties(["define(", ", ", ");"], {raw: {value: Object.freeze(["define(", ", ", ");"])}}));
+      $__139 = Object.freeze(Object.defineProperties(["define(", ", ", ", 'transpiled-module');"], {raw: {value: Object.freeze(["define(", ", ", ", 'transpiled-module');"])}}));
   var ModuleTransformer = $traceurRuntime.getModuleImpl("traceur@0.0.22/src/codegeneration/ModuleTransformer").ModuleTransformer;
   var VAR = $traceurRuntime.getModuleImpl("traceur@0.0.22/src/syntax/TokenType").VAR;
   var createBindingIdentifier = $traceurRuntime.getModuleImpl("traceur@0.0.22/src/codegeneration/ParseTreeFactory").createBindingIdentifier;

--- a/src/codegeneration/AmdTransformer.js
+++ b/src/codegeneration/AmdTransformer.js
@@ -52,7 +52,7 @@ export class AmdTransformer extends ModuleTransformer {
     if (hasTopLevelThis)
       func = parseExpression `${func}.bind(${globalThis()})`;
 
-    return parseStatements `define(${depPaths}, ${func});`;
+    return parseStatements `define(${depPaths}, ${func}, 'transpiled-module');`;
   }
 
   transformModuleSpecifier(tree) {

--- a/test/node-amd-test.js
+++ b/test/node-amd-test.js
@@ -10,9 +10,9 @@ function onlyJsFiles(path) {
 
 function moduleFromSource(src) {
   var module;
-  var define = function(deps, factory) {
+  var define = function(deps, factory, isES6) {
     var output = factory();
-    module = output.__transpiledModule ? output : {default: output};
+    module = isES6 ? output : {default: output};
   }
   Function('define', src).call(global, define);
   return module;

--- a/test/unit/codegeneration/AmdTransformer.js
+++ b/test/unit/codegeneration/AmdTransformer.js
@@ -29,7 +29,7 @@ suite('AmdTransformer.js', function() {
 
     test('with no dependencies', function() {
       assertEqualIgnoringWhiteSpaces(
-          'define([], function() {"CODE";});',
+          'define([], function() {"CODE";}, \'transpiled-module\');',
           writeArray(transformer.wrapModule([str('CODE')])));
     });
 
@@ -38,7 +38,7 @@ suite('AmdTransformer.js', function() {
       transformer.dependencies.push({path: './bar', local: '__dep1'});
 
       assertEqualIgnoringWhiteSpaces(
-          'define(["./foo", "./bar"], function(__dep0, __dep1) {"CODE";});',
+          'define(["./foo", "./bar"], function(__dep0, __dep1) {"CODE";}, \'transpiled-module\');',
           writeArray(transformer.wrapModule([str('CODE')])));
     });
   });

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -122,8 +122,8 @@ suite('context test', function() {
       assert.isNull(error);
       var fileContents = fs.readFileSync(path.resolve(outDir, 'file.js'));
       var depContents = fs.readFileSync(path.resolve(outDir, 'dep.js'));
-      assert.equal(fileContents + '', "define(['./dep'], function($__0) {\n  \"use strict\";\n  var __moduleName = \"../../test/unit/node/resources/compile-dir/file\";\n  var q = ($__0).q;\n  var p = 'module';\n  return {\n    get p() {\n      return p;\n    },\n    __transpiledModule: true\n  };\n});\n");
-      assert.equal(depContents + '', "define([], function() {\n  \"use strict\";\n  var __moduleName = \"../../test/unit/node/resources/compile-dir/dep\";\n  var q = 'q';\n  return {\n    get q() {\n      return q;\n    },\n    __transpiledModule: true\n  };\n});\n");
+      assert.equal(fileContents + '', "define(['./dep'], function($__0) {\n  \"use strict\";\n  var __moduleName = \"../../test/unit/node/resources/compile-dir/file\";\n  var q = ($__0).q;\n  var p = 'module';\n  return {\n    get p() {\n      return p;\n    },\n    __transpiledModule: true\n  };\n}, 'transpiled-module');\n");
+      assert.equal(depContents + '', "define([], function() {\n  \"use strict\";\n  var __moduleName = \"../../test/unit/node/resources/compile-dir/dep\";\n  var q = 'q';\n  return {\n    get q() {\n      return q;\n    },\n    __transpiledModule: true\n  };\n}, 'transpiled-module');\n");
       done();
     });
   });


### PR DESCRIPTION
Unfortunately it turns out the `__transpiledModule` export from https://github.com/google/traceur-compiler/pull/683 isn't sufficient.

The reason for this is that the export can only be detected after execution, while we need to have metadata that can be detected at the linking stage.

For example, if an ES6 module imports an AMD module, it has to access the module from the `default` property. But if an ES6 module is transpiled into AMD, and loads that same AMD module trying to access the `default` property, this causes an error.

This fix creates the following syntax instead:

``` javascript
define(['traceur-runtime'], function() {
  // ...
});
```

An ES6 loader can detect this dependency and know that it is loading a transpiled ES6 module.

Additionally in AMD environments, ES6 compiled into ES5 becomes modular with the runtime allowing transpiled ES6 and normal ES5 modules to play well together.
