### PR TITLE
Test: allow running a single feature test

### DIFF
--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -124,7 +124,7 @@
       traceur.options.reset();
     });
 
-    test(name, function(done) {
+    (/^Only/.test(name) ? test.only : test)(name, function(done) {
       traceur.options.debug = true;
       traceur.options.freeVariableChecker = true;
       traceur.options.validate = true;


### PR DESCRIPTION
This was pretty helpful for me, not sure you want it...

It would be better to read "only" metadata from the prolog, but that would be a bigger change (I would have to read the source file before registering a mocha spec).
