### PR TITLE
Type assertion update

### DIFF
--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -273,7 +273,7 @@ class AnnotationsScope {
     parameters = parameters.map((param) => {
       var metadata = [];
       if (param.typeAnnotation)
-        metadata.push(createIdentifierExpression(param.typeAnnotation.name.value));
+        metadata.push(this.transformAny(param.typeAnnotation));
       if (param.annotations && param.annotations.length > 0)
         metadata.push(...this.transformAnnotations_(param.annotations));
       if (metadata.length > 0) {

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -43,6 +43,7 @@ import {TemplateLiteralTransformer} from './TemplateLiteralTransformer';
 import {TypeTransformer} from './TypeTransformer';
 import {TypeAssertionTransformer} from './TypeAssertionTransformer';
 import {TypeofTransformer} from './TypeofTransformer';
+import {TypeToExpressionTransformer} from './TypeToExpressionTransformer';
 import {UniqueIdentifierGenerator} from './UniqueIdentifierGenerator';
 import {options, transformOptions} from '../options';
 
@@ -71,6 +72,10 @@ export class FromOptionsTransformer extends MultiTransformer {
 
     if (transformOptions.templateLiterals)
       append(TemplateLiteralTransformer);
+
+    if (options.types) {
+      append(TypeToExpressionTransformer);
+    }
 
     if (transformOptions.annotations)
       append(AnnotationsTransformer);

--- a/src/codegeneration/TypeToExpressionTransformer.js
+++ b/src/codegeneration/TypeToExpressionTransformer.js
@@ -1,0 +1,32 @@
+// Copyright 2012 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ParseTreeTransformer} from './ParseTreeTransformer';
+import {
+  createIdentifierExpression,
+  createMemberExpression
+} from './ParseTreeFactory';
+
+
+export class TypeToExpressionTransformer extends ParseTreeTransformer {
+
+  transformTypeName(tree) {
+    return createIdentifierExpression(tree.name);
+  }
+
+  transformPredefinedType(tree) {
+    return createMemberExpression('$traceurRuntime', 'type', tree.typeToken);
+  }
+
+}

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -44,6 +44,15 @@
     };
   }
 
+  // ### Primitive value types
+  var types = {
+    void: function voidType() {},
+    any: function any() {},
+    string: function string() {},
+    number: function number() {},
+    boolean: function boolean() {}
+  };
+
   var method = nonEnum;
 
   // ### Symbols
@@ -572,6 +581,7 @@
     superSet: superSet,
     toObject: toObject,
     toProperty: toProperty,
+    type: types,
     typeof: typeOf,
   };
 

--- a/test/feature/TypeAssertions/FunctionParams.js
+++ b/test/feature/TypeAssertions/FunctionParams.js
@@ -2,12 +2,15 @@
 function single(a:Number) {}
 function multiple(a:Number, b:Boolean) {}
 function untyped(a) {}
+function onlySome(a, b:Number) {}
 
 single(1);
 multiple(1, true);
 untyped();
+onlySome(null, 1);
 
 assert.throw(() => { single(''); }, chai.AssertionError);
 assert.throw(() => { multiple('', false); }, chai.AssertionError);
 assert.throw(() => { multiple(false, 1); }, chai.AssertionError);
 assert.throw(() => { multiple(1, ''); }, chai.AssertionError);
+assert.throw(() => { onlySome(1, true); }, chai.AssertionError);

--- a/test/feature/TypeAssertions/FunctionReturnType.js
+++ b/test/feature/TypeAssertions/FunctionReturnType.js
@@ -55,6 +55,10 @@ function nested(value):Boolean {
   return square(value) > 0;
 }
 
+function returnVoid(x): void {
+  return x;
+}
+
 assert.equal(1, returnType());
 assert.equal(1, multipleReturnPaths(true));
 assert.equal(2, multipleReturnPaths(false));
@@ -69,4 +73,5 @@ assert.isTrue(returnWithinDoWhileLoop(5));
 assert.isFalse(returnWithinDoWhileLoop(20));
 assert.equal(0, returnExpression(0));
 assert.equal(2, returnExpression(4));
+assert.equal(undefined, returnVoid());
 assert.throw(throwsAssertion, chai.AssertionError);

--- a/test/feature/TypeAssertions/PrimitiveValueTypes.js
+++ b/test/feature/TypeAssertions/PrimitiveValueTypes.js
@@ -1,0 +1,20 @@
+// Options: --types=true --type-assertions --type-assertion-module=./resources/assert
+
+function foo(a: string): boolean {
+  var x: number = 1;
+  return true;
+}
+
+function failReturn(): number {
+  return 'str';
+}
+
+function failVariable() {
+  var x: string = true;
+}
+
+
+foo('bar');
+assert.throw(() => { foo(123) }, chai.AssertionError);
+assert.throw(() => { failReturn() }, chai.AssertionError);
+assert.throw(() => { failVariable() }, chai.AssertionError);

--- a/test/feature/TypeAssertions/resources/assert.js
+++ b/test/feature/TypeAssertions/resources/assert.js
@@ -1,6 +1,27 @@
 export var assert = this.assert;
+
 assert.type = function (actual, type) {
+  if (type === $traceurRuntime.type.any) {
+    return actual;
+  }
+
+  if (type === $traceurRuntime.type.void) {
+    assert.isUndefined(actual);
+    return actual;
+  }
+
   var typeName = type.name || type.toString().match(/^\s*function\s*([^\s(]+)/)[1];
   assert.typeOf(actual, typeName);
   return actual;
 };
+
+
+assert.argumentTypes = function(...params) {
+  for (var i = 0; i < params.length; i += 2) {
+    if (params[i + 1] !== null) {
+      assert.type(params[i], params[i + 1]);
+    }
+  }
+};
+
+assert.returnType = assert.type;

--- a/test/feature/Types/TypeAnnotations.js
+++ b/test/feature/Types/TypeAnnotations.js
@@ -1,0 +1,9 @@
+// Options: --types=true --annotations=true
+
+class Test {}
+
+function abc(x: Test) : Test {
+  var a : Test = new Test();
+}
+
+function xyz(x: number, y: boolean): string {}


### PR DESCRIPTION
This is a big commit that contains three changes described below.

Originally it was three different commits as it should be, but during the code review I significantly changed the whole thing and so it would take me a lot of time to split it back into coherent commits, as all the changes depend on each other.

1/ assert all arguments with assert.argumentTypes()

``` js
function request(url: String, callback: Function) {}

// before:
function request(url, callback) {
  assert.type(url, String);
  assert.type(callback, Function);
}

// after:
function request(url, callback) {
  assert.argumentTypes(
    url, String,
    callback, Function
  );
}
```

Instead of asserting each argument on its own, we assert all of them. That has benefits:
- we can show all errors (instead of throwing on first incorrect argument),
- we can show incorrect arg position.

2/ assert function return value with assert.returnType()

``` js
function reverse(str): String {}

// before
function reverse(str) {
  return assert.type(str, String);
}

// after
function revers(str) {
  return assert.returnType(str, String);
}
```

There are some advantages of this approach:
- the assert library can show different error for return value (eg. "Function has to return x"),
- the assert.returnType() has to return the actual value, but assert.type() does not have to.

3/ replace value types with assert.x

``` js
function foo(a: string, b: number, c: boolean, d) {}

// transpiles into
function foo(a, b, c) {
  assert.argumentTypes(
    a, $traceurRuntime.type.string,
    b, $traceurRuntime.type.number,
    c, $traceurRuntime.type.boolean,
    d, $traceurRuntime.type.any
  );
}
```
