### PR TITLE
Ensure that codeUnits have non-empyt .url for source-maps.

### DIFF
--- a/src/runtime/System.js
+++ b/src/runtime/System.js
@@ -22,17 +22,17 @@ import {webLoader} from './webLoader';
 var url;
 var fileLoader;
 if (typeof window !== 'undefined' && window.location) {
-	url = window.location.href;
-	fileLoader = webLoader;
-} // else the node app will override System.
+  url = window.location.href;
+  fileLoader = webLoader;
+}
 
 var loaderHooks = new LoaderHooks(new ErrorReporter(), url, fileLoader);
 export var System = new TraceurLoader(loaderHooks);
 
 if (typeof window !== 'undefined')
-	window.System = System;
+  window.System = System;
 if (typeof global !== 'undefined')
-	global.System = System;
+  global.System = System;
 
 System.map = System.semverMap(__moduleName);
 

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -116,8 +116,8 @@ export class TraceurLoader extends Loader {
    * @param {string} normalizedName
    * @param {string} 'module' or 'script'
    */
-  sourceMap(normalizedName, type) {
-    return this.internalLoader_.sourceMap(normalizedName, type);
+  sourceMapInfo(normalizedName, type) {
+    return this.internalLoader_.sourceMapInfo(normalizedName, type);
   }
 
   /**

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -38,6 +38,7 @@ suite('Loader.js', function() {
     // Windows file paths.
     url = __filename.replace(/\\/g, '/');
     fileLoader = require('../../../src/node/nodeLoader.js');
+    System = require('../../../src/node/System.js');
   } else {
     url = traceur.util.resolveUrl(window.location.href,
                                   'unit/runtime/modules.js');
@@ -99,8 +100,8 @@ suite('Loader.js', function() {
       function(result) {
         loader.options.sourceMaps = false;
         var normalizedName = System.normalize(name);
-        var sourceMap = loader.sourceMap(normalizedName, 'script');
-        assert(sourceMap);
+        var sourceMapInfo = loader.sourceMapInfo(normalizedName, 'script');
+        assert(sourceMapInfo.sourceMap);
         assert.equal(43, result);
         done();
       }).catch(done);
@@ -291,11 +292,11 @@ suite('Loader.js', function() {
     loader.options.sourceMaps = true;
     var src = 'export {name as a} from \'./test_a\';\nexport var d = 4;\n';
     loader.define(normalizedName, src, {}).then(function() {
-      var sourceMap = loader.sourceMap(normalizedName, 'module');
-      assert(sourceMap);
+      var sourceMapInfo = loader.sourceMapInfo(normalizedName, 'module');
+      assert(sourceMapInfo.sourceMap);
       var SourceMapConsumer = traceur.outputgeneration.SourceMapConsumer;
-      var consumer = new SourceMapConsumer(sourceMap);
-      var sourceContent = consumer.sourceContentFor(normalizedName);
+      var consumer = new SourceMapConsumer(sourceMapInfo.sourceMap);
+      var sourceContent = consumer.sourceContentFor(sourceMapInfo.url);
       assert.equal(sourceContent, src);
       done();
     }).catch(done);


### PR DESCRIPTION
The source-map code won't take null.
Centralize the name-invention for possible future improvement.
Name anonymous sources with serial numbers.
