### PR TITLE
Print a stack trace when the interpreter sees an exception.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-runtime: bin/traceur-runtime.js $(RUNTIME_TESTS)
 test: test/test-list.js bin/traceur.js $(COMPILE_BEFORE_TEST) \
 	test/unit/runtime/traceur-runtime \
 	wiki test/amd-compiled test/commonjs-compiled test-interpret \
-	test-interpret-absolute test-inline-module-error
+	test-interpret-absolute test-inline-module-error test-interpret-throw
 	node_modules/.bin/mocha $(MOCHA_OPTIONS) $(TESTS)
 
 test/unit: bin/traceur.js bin/traceur-runtime.js
@@ -97,6 +97,9 @@ test/test-list.js: force
 
 test-interpret: test/unit/runtime/test_interpret.js
 	./traceur $^
+
+test-interpret-throw: test/unit/runtime/throwsError.js
+	./traceur $^ 2>&1 | wc -l | grep '11'
 
 test-interpret-absolute: $(CURDIR)/test/unit/runtime/test_interpret.js
 	./traceur $^

--- a/src/node/interpreter.js
+++ b/src/node/interpreter.js
@@ -25,7 +25,8 @@ function interpret(filename, argv, flags) {
   System.import(moduleName).then(function() {
 
   }).catch(function(err) {
-    console.error(err);
+    console.error(err.stack || err);
+    process.exit(8);
   });
 }
 

--- a/test/unit/runtime/throwsError.js
+++ b/test/unit/runtime/throwsError.js
@@ -1,0 +1,1 @@
+throw new Error('test-intepreter');

--- a/test/unit/runtime/throwsError.output
+++ b/test/unit/runtime/throwsError.output
@@ -1,0 +1,2 @@
+./traceur test/unit/runtime/throwsError.js 2>&1 | wc -l
+      11


### PR DESCRIPTION
Set the process.exit code to 8 on error
Fixes #812

Reviewed on #814.
