### PR TITLE
Use ExplodeExpressionTransformer for ExpressionStatement

### DIFF
--- a/src/codegeneration/ExplodeExpressionTransformer.js
+++ b/src/codegeneration/ExplodeExpressionTransformer.js
@@ -88,12 +88,8 @@ class CommaExpressionBuilder {
     this.expressions = [];
   }
   add(tree) {
-    if (tree.type === COMMA_EXPRESSION) {
+    if (tree.type === COMMA_EXPRESSION)
       this.expressions.push(...getExpressions(tree));
-    } else {
-      assert(tree.type === LITERAL_EXPRESSION ||
-             tree.type === IDENTIFIER_EXPRESSION);
-    }
     return this;
   }
   build(tree) {

--- a/src/codegeneration/generator/GeneratorTransformer.js
+++ b/src/codegeneration/generator/GeneratorTransformer.js
@@ -210,6 +210,10 @@ export class GeneratorTransformer extends CPSTransformer {
     if (isYieldAssign(expression))
       return this.transformYieldAssign_(expression);
 
+    if (this.expressionNeedsStateMachine_(expression)) {
+       return this.expressionToStateMachine_(expression).machine;
+    }
+
     return super.transformExpressionStatement(tree);
   }
 

--- a/test/feature/Yield/BinaryOperator.js
+++ b/test/feature/Yield/BinaryOperator.js
@@ -1,0 +1,9 @@
+function* f(x) {
+  var a = (yield x) + (yield x + 1);
+  return a;
+}
+
+var g = f(1);
+assert.deepEqual(g.next(), {value: 1, done: false});
+assert.deepEqual(g.next(1), {value: 2, done: false});
+assert.deepEqual(g.next(2), {value: 3, done: true});

--- a/test/feature/Yield/CommaOperator.js
+++ b/test/feature/Yield/CommaOperator.js
@@ -1,0 +1,9 @@
+function* f(x, y) {
+  yield x, yield y;
+  return x + y;
+}
+
+var g = f(1, 2);
+assert.deepEqual(g.next(), {value: 1, done: false});
+assert.deepEqual(g.next(1), {value: 2, done: false});
+assert.deepEqual(g.next(2), {value: 3, done: true});

--- a/test/feature/Yield/Error_UnsupportedYieldExpression2.js
+++ b/test/feature/Yield/Error_UnsupportedYieldExpression2.js
@@ -1,5 +1,0 @@
-// Should not compile.
-// Error: Only 'a = yield b' and 'var a = yield b' currently supported.
-function* G(x) {
-  var a = (yield x) + (yield x);
-}


### PR DESCRIPTION
Use explode expression transformer on expression statement. This allows us to remove all the remaining preprocessing of generator functions.
