### PR TITLE
Remove redundant call to .replace() in url.js

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -532,7 +532,7 @@
   }
   function joinAndCanonicalizePath(parts) {
     var path = parts[ComponentIndex.PATH] || '';
-    path = removeDotSegments(path.replace(/\/\//.g, '/'));
+    path = removeDotSegments(path);
     parts[ComponentIndex.PATH] = path;
     return buildFromEncodedParts(parts[ComponentIndex.SCHEME], parts[ComponentIndex.USER_INFO], parts[ComponentIndex.DOMAIN], parts[ComponentIndex.PORT], parts[ComponentIndex.PATH], parts[ComponentIndex.QUERY_DATA], parts[ComponentIndex.FRAGMENT]);
   }

--- a/src/runtime/url.js
+++ b/src/runtime/url.js
@@ -249,7 +249,7 @@
    */
   function joinAndCanonicalizePath(parts) {
     var path = parts[ComponentIndex.PATH] || '';
-    path = removeDotSegments(path.replace(/\/\//.g, '/'));
+    path = removeDotSegments(path);
     parts[ComponentIndex.PATH] = path;
 
     return buildFromEncodedParts(

--- a/test/unit/util/url.js
+++ b/test/unit/util/url.js
@@ -59,5 +59,6 @@ suite('url.js', function() {
     var resolveUrl =
         $traceurRuntime.ModuleStore.getForTesting('src/util/url').resolveUrl;
     assert.equal('/a/b/c/d', resolveUrl('/a/b/x/y/', '../../c/d'));
+    assert.equal('/a/b/c/d', resolveUrl('/a/b/x/y/', '../../////c/d'));
   });
 });


### PR DESCRIPTION
Thanks to @errorx666 for the bug report, #869
