### PR TITLE
fix(typeAssertions): handle class setters

### DIFF
--- a/test/feature/TypeAssertions/ClassParams.js
+++ b/test/feature/TypeAssertions/ClassParams.js
@@ -4,12 +4,17 @@ class Test {
   multiple(a:Number, b:Boolean) { return true; }
   initialized(a:Number = 1) { return a; }
   untyped(a) { return true; }
+
+  set name(value: string) {
+    this._name = value;
+  }
 }
 
 var test = new Test();
 test.single(1);
 test.multiple(1, true);
 test.untyped();
+test.name = 'me';
 
 assert.equal(1, test.initialized());
 assert.equal(2, test.initialized(2));
@@ -19,3 +24,4 @@ assert.throw(() => { test.multiple('', false); }, chai.AssertionError);
 assert.throw(() => { test.multiple(false, 1); }, chai.AssertionError);
 assert.throw(() => { test.multiple(1, ''); }, chai.AssertionError);
 assert.throw(() => { test.initialized(''); }, chai.AssertionError);
+assert.throw(() => { test.name = 123; }, chai.AssertionError);


### PR DESCRIPTION
See the added test case for the issue.
Fixes #894

@arv, let me know if you think there is a better way to fix this. I don't like the current solution.
I think we should rather change the SET_ACCESSOR to have the same syntax tree as regular function (ParameterList). Also, currently SET_ACCESSOR processes the function body in the "super" call and thus I need this extra hacky `_isInsideSetAccessor`.

Or maybe we can change order of the transformers, so that `TypeAssertionTransformer` is applied after the SET_ACCESSOR is transformed into a regular function?
