### PR TITLE
Have SetAccessor use FormalParameterList

### DIFF
--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -201,12 +201,12 @@ class AnnotationsScope {
     this.scope.metadata.push(...this.transformMetadata_(
         this.transformAccessor_(tree, this.scope.className, 'set'),
         tree.annotations,
-        [tree.parameter]));
+        tree.parameterList.parameters));
 
-    var parameter = this.transformAny(tree.parameter);
-    if (parameter !== tree.parameter || tree.annotations.length > 0) {
+    var parameterList = this.transformAny(tree.parameterList);
+    if (parameterList !== tree.parameterList || tree.annotations.length > 0) {
       tree = new SetAccessor(tree.location, tree.isStatic, tree.name,
-          parameter, [], tree.body);
+          parameterList, [], tree.body);
     }
     return super(tree);
   }

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -332,11 +332,11 @@ export class ClassTransformer extends TempVarTransformer{
   }
 
   transformSetAccessor_(tree, internalName) {
-    var parameter = this.transformAny(tree.parameter);
+    var parameterList = this.transformAny(tree.parameterList);
     var body = this.transformSuperInFunctionBody_(tree, tree.body, internalName);
     if (!tree.isStatic && body === tree.body)
       return tree;
-    return new SetAccessor(tree.location, false, tree.name, parameter,
+    return new SetAccessor(tree.location, false, tree.name, parameterList,
                            tree.annotations, body);
   }
 

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -269,9 +269,7 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
       return super.transformSetAccessor(tree);
 
     var body = this.transformAny(tree.body);
-    var parameter = this.transformAny(tree.parameter);
-    var parameterList = new FormalParameterList(parameter.location,
-                                                [parameter]);
+    var parameterList = this.transformAny(tree.parameterList);
     var func = createFunctionExpression(parameterList, body);
     return this.createProperty_(tree.name,
         {

--- a/src/codegeneration/ParseTreeFactory.js
+++ b/src/codegeneration/ParseTreeFactory.js
@@ -1018,8 +1018,9 @@ export function createSetAccessor(name, parameter, body) {
     name = createPropertyNameToken(name);
   if (typeof parameter == 'string')
     parameter = createIdentifierToken(parameter);
+  var parameterList = createParameterList(parameter);
   var isStatic = false;
-  return new SetAccessor(null, isStatic, name, parameter, [], body);
+  return new SetAccessor(null, isStatic, name, parameterList, [], body);
 }
 
 /**

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -1119,7 +1119,7 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     this.writeSpace_();
     this.visitAny(tree.name);
     this.write_(OPEN_PAREN);
-    this.visitAny(tree.parameter);
+    this.visitAny(tree.parameterList);
     this.write_(CLOSE_PAREN);
     this.writeSpace_();
     this.visitAny(tree.body);

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -2186,11 +2186,11 @@ export class Parser {
     var functionKind = null;
     var name = this.parsePropertyName_();
     this.eat_(OPEN_PAREN);
-    var parameter = this.parsePropertySetParameterList_();
+    var parameterList = this.parsePropertySetParameterList_();
     this.eat_(CLOSE_PAREN);
-    var body = this.parseFunctionBody_(functionKind, parameter);
+    var body = this.parseFunctionBody_(functionKind, parameterList);
     return new SetAccessor(this.getTreeLocation_(start), isStatic, name,
-                           parameter, annotations, body);
+                           parameterList, annotations, body);
   }
 
   /**
@@ -2244,9 +2244,11 @@ export class Parser {
       binding = this.parseBindingIdentifier_();
 
     var typeAnnotation = this.parseTypeAnnotationOpt_();
-    return new FormalParameter(this.getTreeLocation_(start),
+    var parameter = new FormalParameter(this.getTreeLocation_(start),
         new BindingElement(this.getTreeLocation_(start), binding, null),
         typeAnnotation, this.popAnnotations_());
+
+    return new FormalParameterList(parameter.location, [parameter]);
   }
 
   /**

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -809,8 +809,8 @@
     "name": [
       "ParseTree"
     ],
-    "parameter": [
-      "FormalParameter"
+    "parameterList": [
+      "FormalParameterList"
     ],
     "annotations": [
       "Array.<ParseTree>"

--- a/test/feature/TypeAssertions/ClassParams.js
+++ b/test/feature/TypeAssertions/ClassParams.js
@@ -4,12 +4,17 @@ class Test {
   multiple(a:Number, b:Boolean) { return true; }
   initialized(a:Number = 1) { return a; }
   untyped(a) { return true; }
+
+  set name(val: String) {
+    this._name = val;
+  }
 }
 
 var test = new Test();
 test.single(1);
 test.multiple(1, true);
 test.untyped();
+test.name = 'me';
 
 assert.equal(1, test.initialized());
 assert.equal(2, test.initialized(2));
@@ -19,3 +24,4 @@ assert.throw(() => { test.multiple('', false); }, chai.AssertionError);
 assert.throw(() => { test.multiple(false, 1); }, chai.AssertionError);
 assert.throw(() => { test.multiple(1, ''); }, chai.AssertionError);
 assert.throw(() => { test.initialized(''); }, chai.AssertionError);
+assert.throw(() => { test.name = 123; }, chai.AssertionError);


### PR DESCRIPTION
Added test in `test/feature/TypeAssertions/ClassParams.js` demonstrates
the #894 issue, which is fixed by this change.

I believe this is the right fix, instead of another solution proposed in #897. SetAccessor has parameterList (FormalParameterList) and therefore
annotations on SetAccessor can be transformed in the same way as
annotations on any regular function.

This change also removes the FormalParameter -> FormalParameterList
transformation in ObjectLiteralTransformer.

Fixes #894
Closes #917, #897
