### PR TITLE
Add es6 pure transformer

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -21673,13 +21673,48 @@ System.register("traceur@0.0.33/src/codegeneration/CloneTreeTransformer", [], fu
       return CloneTreeTransformer;
     }};
 });
+System.register("traceur@0.0.33/src/codegeneration/PureES6Transformer", [], function() {
+  "use strict";
+  var __moduleName = "traceur@0.0.33/src/codegeneration/PureES6Transformer";
+  var AnnotationsTransformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/AnnotationsTransformer")).AnnotationsTransformer;
+  var FreeVariableChecker = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/semantics/FreeVariableChecker")).FreeVariableChecker;
+  var MultiTransformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/MultiTransformer")).MultiTransformer;
+  var TypeTransformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/TypeTransformer")).TypeTransformer;
+  var UniqueIdentifierGenerator = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/UniqueIdentifierGenerator")).UniqueIdentifierGenerator;
+  var $__340 = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/options")),
+      options = $__340.options,
+      transformOptions = $__340.transformOptions;
+  var PureES6Transformer = function PureES6Transformer(reporter) {
+    var idGenerator = arguments[1] !== (void 0) ? arguments[1] : new UniqueIdentifierGenerator();
+    var $__338 = this;
+    $traceurRuntime.superCall(this, $PureES6Transformer.prototype, "constructor", [reporter, options.validate]);
+    var append = (function(transformer) {
+      $__338.append((function(tree) {
+        return new transformer(idGenerator, reporter).transformAny(tree);
+      }));
+    });
+    append(AnnotationsTransformer);
+    append(TypeTransformer);
+    if (options.freeVariableChecker) {
+      this.append((function(tree) {
+        FreeVariableChecker.checkScript(reporter, tree);
+        return tree;
+      }));
+    }
+  };
+  var $PureES6Transformer = PureES6Transformer;
+  ($traceurRuntime.createClass)(PureES6Transformer, {}, {}, MultiTransformer);
+  return {get PureES6Transformer() {
+      return PureES6Transformer;
+    }};
+});
 System.register("traceur@0.0.33/src/codegeneration/module/createModuleEvaluationStatement", [], function() {
   "use strict";
   var __moduleName = "traceur@0.0.33/src/codegeneration/module/createModuleEvaluationStatement";
-  var $__338 = Object.freeze(Object.defineProperties(["System.get(", " +'')"], {raw: {value: Object.freeze(["System.get(", " +'')"])}}));
+  var $__341 = Object.freeze(Object.defineProperties(["System.get(", " +'')"], {raw: {value: Object.freeze(["System.get(", " +'')"])}}));
   var parseStatement = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/PlaceholderParser")).parseStatement;
   function createModuleEvaluationStatement(normalizedName) {
-    return parseStatement($__338, normalizedName);
+    return parseStatement($__341, normalizedName);
   }
   return {get createModuleEvaluationStatement() {
       return createModuleEvaluationStatement;
@@ -21704,18 +21739,18 @@ System.register("traceur@0.0.33/src/runtime/TraceurLoader", [], function() {
   var $TraceurLoader = TraceurLoader;
   ($traceurRuntime.createClass)(TraceurLoader, {
     loadAsScript: function(name) {
-      var $__341 = $traceurRuntime.assertObject(arguments[1] !== (void 0) ? arguments[1] : {}),
-          referrerName = $__341.referrerName,
-          address = $__341.address;
+      var $__344 = $traceurRuntime.assertObject(arguments[1] !== (void 0) ? arguments[1] : {}),
+          referrerName = $__344.referrerName,
+          address = $__344.address;
       return this.internalLoader_.load(name, referrerName, address, 'script').then((function(codeUnit) {
         return codeUnit.result;
       }));
     },
     script: function(source) {
-      var $__341 = $traceurRuntime.assertObject(arguments[1] !== (void 0) ? arguments[1] : {}),
-          name = $__341.name,
-          referrerName = $__341.referrerName,
-          address = $__341.address;
+      var $__344 = $traceurRuntime.assertObject(arguments[1] !== (void 0) ? arguments[1] : {}),
+          name = $__344.name,
+          referrerName = $__344.referrerName,
+          address = $__344.address;
       return this.internalLoader_.script(source, name, referrerName, address);
     },
     semVerRegExp_: function() {
@@ -21793,9 +21828,9 @@ System.register("traceur@0.0.33/src/runtime/System", [], function() {
 System.register("traceur@0.0.33/src/util/TestErrorReporter", [], function() {
   "use strict";
   var __moduleName = "traceur@0.0.33/src/util/TestErrorReporter";
-  var $__344 = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/util/ErrorReporter")),
-      ErrorReporter = $__344.ErrorReporter,
-      format = $__344.format;
+  var $__347 = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/util/ErrorReporter")),
+      ErrorReporter = $__347.ErrorReporter,
+      format = $__347.format;
   var TestErrorReporter = function TestErrorReporter() {
     this.errors = [];
   };
@@ -21852,10 +21887,12 @@ System.register("traceur@0.0.33/src/traceur", [], function() {
   var AttachModuleNameTransformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/module/AttachModuleNameTransformer")).AttachModuleNameTransformer;
   var CloneTreeTransformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/CloneTreeTransformer")).CloneTreeTransformer;
   var FromOptionsTransformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/FromOptionsTransformer")).FromOptionsTransformer;
+  var PureES6Transformer = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/PureES6Transformer")).PureES6Transformer;
   var createModuleEvaluationStatement = $traceurRuntime.assertObject(System.get("traceur@0.0.33/src/codegeneration/module/createModuleEvaluationStatement")).createModuleEvaluationStatement;
   var codegeneration = {
     CloneTreeTransformer: CloneTreeTransformer,
     FromOptionsTransformer: FromOptionsTransformer,
+    PureES6Transformer: PureES6Transformer,
     module: {
       AttachModuleNameTransformer: AttachModuleNameTransformer,
       createModuleEvaluationStatement: createModuleEvaluationStatement

--- a/src/codegeneration/PureES6Transformer.js
+++ b/src/codegeneration/PureES6Transformer.js
@@ -1,0 +1,54 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AnnotationsTransformer} from './AnnotationsTransformer';
+import {FreeVariableChecker} from '../semantics/FreeVariableChecker';
+import {MultiTransformer} from './MultiTransformer';
+import {TypeTransformer} from './TypeTransformer';
+import {UniqueIdentifierGenerator} from './UniqueIdentifierGenerator';
+import {options, transformOptions} from '../options';
+
+/**
+ * MultiTransformer that only transforms non ES6 features, such as:
+ * - annotations
+ * - types
+ *
+ * This is used to transform ES6+ code into pure ES6.
+ */
+export class PureES6Transformer extends MultiTransformer {
+  /**
+   * @param {ErrorReporter} reporter
+   * @param {UniqueIdGenerator=} idGenerator
+   */
+  constructor(reporter, idGenerator = new UniqueIdentifierGenerator()) {
+    super(reporter, options.validate);
+
+    var append = (transformer) => {
+      this.append((tree) => {
+        return new transformer(idGenerator, reporter).transformAny(tree);
+      });
+    };
+
+    append(AnnotationsTransformer);
+    append(TypeTransformer);
+
+    // Issue errors for any unbound variables
+    if (options.freeVariableChecker) {
+      this.append((tree) => {
+        FreeVariableChecker.checkScript(reporter, tree);
+        return tree;
+      });
+    }
+  }
+}

--- a/src/node/api.js
+++ b/src/node/api.js
@@ -25,6 +25,7 @@ var AttachModuleNameTransformer =
     traceur.codegeneration.module.AttachModuleNameTransformer;
 var ErrorReporter = traceur.util.TestErrorReporter;
 var FromOptionsTransformer = traceur.codegeneration.FromOptionsTransformer;
+var PureES6Transformer = traceur.codegeneration.PureES6Transformer;
 var Parser = traceur.syntax.Parser;
 var SourceFile = traceur.syntax.SourceFile;
 var SourceMapGenerator = traceur.outputgeneration.SourceMapGenerator;
@@ -58,6 +59,7 @@ var RUNTIME_PATH = path.join(__dirname, '../../bin/traceur-runtime.js');
  */
 function compile(content, options) {
   options = merge({
+    outputLanguage: 'es5',
     modules: 'commonjs',
     filename: '<unknown file>',
     sourceMap: false,
@@ -75,7 +77,13 @@ function compile(content, options) {
   moduleName = path.relative(options.cwd, moduleName).replace(/\\/g,'/');
   var transformer = new AttachModuleNameTransformer(moduleName);
   tree = transformer.transformAny(tree);
-  transformer = new FromOptionsTransformer(errorReporter);
+
+  if (options.outputLanguage.toLowerCase() === 'es6') {
+    transformer = new PureES6Transformer(errorReporter);
+  } else {
+    transformer = new FromOptionsTransformer(errorReporter);
+  }
+
   var transformedTree = transformer.transform(tree);
 
   if (errorReporter.hadError()) {

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -58,11 +58,13 @@ export var outputgeneration = {
 import {AttachModuleNameTransformer} from './codegeneration/module/AttachModuleNameTransformer';
 import {CloneTreeTransformer} from './codegeneration/CloneTreeTransformer';
 import {FromOptionsTransformer} from './codegeneration/FromOptionsTransformer';
+import {PureES6Transformer} from './codegeneration/PureES6Transformer';
 import {createModuleEvaluationStatement} from './codegeneration/module/createModuleEvaluationStatement';
 
 export var codegeneration = {
   CloneTreeTransformer,
   FromOptionsTransformer,
+  PureES6Transformer,
   module: {
     AttachModuleNameTransformer,
     createModuleEvaluationStatement


### PR DESCRIPTION
This is a proposal for discussion. I'm not saying we should merge it as it is.

I want to be able to transform ES6+ (ES6 + types, annotations, etc) into pure ES6. @arv what do you think would be the best way to do this?
