### PR TITLE
WebPageTranscoder cannot pass name as argument.

### DIFF
--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -21693,7 +21693,8 @@ System.register("traceur@0.0.33/src/WebPageTranscoder", [], function() {
       }));
     },
     addFileFromScriptElement: function(scriptElement, name, content) {
-      this.loader.module(content, name);
+      var source = content + '//# sourceURL=' + name + '\n';
+      this.loader.module(source);
     },
     nextInlineScriptName_: function() {
       this.numberInlined_ += 1;

--- a/src/WebPageTranscoder.js
+++ b/src/WebPageTranscoder.js
@@ -43,7 +43,8 @@ export class WebPageTranscoder {
   }
 
   addFileFromScriptElement(scriptElement, name, content) {
-    this.loader.module(content, name);
+    var source = content + '//# sourceURL=' + name + '\n';
+    this.loader.module(source);
   }
 
   /**


### PR DESCRIPTION
(Caught by recent destructuring check.)
