### PR TITLE
Report internal errors even when using Promises.

### DIFF
--- a/src/node/inline-module.js
+++ b/src/node/inline-module.js
@@ -140,6 +140,8 @@ function inlineAndCompile(filenames, options, reporter, callback, errback) {
           }
         }, function(err) {
           errback(err);
+        }).catch(function(ex) {
+          console.error('Internal error ' + (ex.stack || ex));
         });
   }
 

--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -44,20 +44,20 @@ class CodeUnit {
    */
   constructor(loaderHooks, normalizedName, type, state,
       name, referrerName, address) {
-    this.loaderHooks = loaderHooks;
-    this.normalizedName = normalizedName;
-    this.type = type;
-    this.name_ = name;
-    this.referrerName_ = referrerName;
-    this.address_ = address;
-    this.url = InternalLoader.uniqueName(normalizedName, address);
-    this.uid = getUid();
-    this.state_ = state || NOT_STARTED;
-    this.error = null;
-    this.result = null;
-    this.data_ = {};
-    this.dependencies = [];
     this.promise = new Promise((res, rej) => {
+      this.loaderHooks = loaderHooks;
+      this.normalizedName = normalizedName;
+      this.type = type;
+      this.name_ = name;
+      this.referrerName_ = referrerName;
+      this.address_ = address;
+      this.url = InternalLoader.uniqueName(normalizedName, address);
+      this.uid = getUid();
+      this.state_ = state || NOT_STARTED;
+      this.error = null;
+      this.result = null;
+      this.data_ = {};
+      this.dependencies = [];
       this.resolve = res;
       this.reject = rej;
     });
@@ -238,10 +238,14 @@ export class InternalLoader {
         this.handleCodeUnitLoaded(codeUnit);
         return codeUnit;
       }).catch((err) => {
-        codeUnit.state = ERROR;
-        codeUnit.abort = function() {};
-        codeUnit.err = err;
-        this.handleCodeUnitLoadError(codeUnit);
+        try {
+          codeUnit.state = ERROR;
+          codeUnit.abort = function() {};
+          codeUnit.err = err;
+          this.handleCodeUnitLoadError(codeUnit);
+        } catch (ex) {
+          console.error('Internal Error ' + (ex.stack || ex));
+        }
       });
     }
 


### PR DESCRIPTION
The part of traceur that uses promises is susceptiable to mystery errors.
Avoid some of this in InternalLoader.
Catch errors in inline-module loadNext() and report to console,
