### PR TITLE
Replace backslashes in test error messages.

### DIFF
--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -376,7 +376,7 @@ export class InternalLoader {
    * @param {CodeUnit} codeUnit
    */
   handleCodeUnitLoadError(codeUnit) {
-    var message = codeUnit.err ? String(codeUnit.err) :
+    var message = codeUnit.err ? String(codeUnit.err) + '\n' :
         `Failed to load '${codeUnit.address}'.\n`;
     message += codeUnit.nameTrace() + this.loaderHooks.nameTrace(codeUnit);
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -31,7 +31,7 @@
     }
   }
 
-  var reDirectoryResources = /'([^\s]*?\/resources\/[^']*)'/;
+  var reDirectoryResources = /'([^\s]*?[\/\\]resources[\/\\][^']*)'/;
 
   function parseProlog(source) {
     var returnValue = {
@@ -55,8 +55,10 @@
         traceur.options.fromString(m[1]);
       } else if ((m = /\/\/ Error:\s*(.+)/.exec(line))) {
         var errLine = m[1];
+        // Error messages on windows have backslashes in filenames sometimes.
+        errLine.replace(/\\/g, '/');
         var resolvedError = errLine.replace(reDirectoryResources, function(match, p1) {
-          return '\'' + System.normalize(p1) + '\'';
+          return '\'' + System.normalize(p1.replace(/\\/g, '/')) + '\'';
         });
         returnValue.expectedErrors.push(resolvedError);
       }


### PR DESCRIPTION
They may contain windows filenames.
Add a newline to file not found messages.
Fixes #956
