### PR TITLE
Support circular dependency in System.register() under modules='instantiate' option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Galimzyanov Dmitry <dmt021@gmail.com>
 Rick Waldron <waldron.rick@gmail.com>
 A. Matías Quezada <amatiasq@gmail.com>
 Sam Day <sday@atlassian.com>
+Guy Bedford <guybedford@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ UNIT_TESTS = \
 TESTS = \
 	test/node-commonjs-test.js \
 	test/node-amd-test.js \
+	test/node-instantiate-test.js \
 	test/node-feature-test.js \
 	test/node-api-test.js \
 	$(RUNTIME_TESTS) \

--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -14,61 +14,330 @@
 
 
 import {assert} from '../util/assert';
-import {createIdentifierExpression} from './ParseTreeFactory';
-import globalThis from './globalThis';
+import {
+  ClassExpression,
+  EmptyStatement,
+  NamedExport
+} from '../syntax/trees/ParseTrees';
+import {
+  THIS
+} from '../syntax/PredefinedName';
+import {
+  EXPORT_DEFAULT,
+  EXPORT_SPECIFIER,
+  EXPORT_STAR
+} from '../syntax/trees/ParseTreeType';
+import {AlphaRenamer} from './AlphaRenamer';
+import {
+  createIdentifierExpression,
+  createMemberExpression,
+  createObjectLiteralExpression
+} from './ParseTreeFactory';
 import {ModuleTransformer} from './ModuleTransformer';
 import {
   parseExpression,
+  parsePropertyDefinition,
+  parseStatement,
   parseStatements
 } from './PlaceholderParser';
-import scopeContainsThis from './scopeContainsThis';
+import HoistVariablesTransformer from './HoistVariablesTransformer';
 
 /**
- * @fileoverview Transform a module to a 'instantiate' format:
- * System.register(localName, [deps], function(normalizedNames) {});
- * where [deps] are unnormalized (module-specifier-like) names.
+ * Extracts variable and function declarations from the module scope.
  */
+class DeclarationExtractionTransformer extends HoistVariablesTransformer {
+  constructor(identifierGenerator) {
+    super();
+    this.identifierGenerator = identifierGenerator
+    this.declarations_ = [];
+  }
+  getDeclarationStatements() {
+    return [this.getVariableStatement(), ...this.declarations_];
+  }
+  addDeclaration(tree) {
+    this.declarations_.push(tree);
+  }
+  transformFunctionDeclaration(tree) {
+    this.addDeclaration(tree);
+    return new EmptyStatement(null);
+  }
+  transformClassDeclaration(tree) {
+    this.addVariable(tree.name.identifierToken.value);
 
+    // Convert a class declaration into a class expression.
+    tree = new ClassExpression(tree.location, tree.name, tree.superClass, tree.elements, tree.annotations);
+  
+    return parseStatement `${tree.name.identifierToken} = ${tree}`;
+  }
+}
+
+/**
+ * Renames a given identifier to any new expression.
+ */
+class ReplaceIdentifierExpressionTransformer extends AlphaRenamer {
+  constructor(oldName, newExpression) {
+    super();
+    this.oldName_ = oldName;
+    this.newExpression_ = newExpression;
+  }
+  transformIdentifierExpression(tree) {
+    if (this.oldName_ == tree.identifierToken.value) {
+      return this.newExpression_;
+    } else {
+      return tree;
+    }
+  }
+  transformThisExpression(tree) {
+    if (this.oldName_ !== THIS)
+      return tree;
+    return this.newExpression_;
+  }
+  static rename(tree, oldName, newExpression) {
+    return new ReplaceIdentifierExpressionTransformer(oldName, newExpression).transformAny(tree);
+  }
+}
+
+
+/**
+ * Transform a module to a 'instantiate' format:
+ * System.register(localName, [deps], function(depList) {});
+ * where [deps] are unnormalized (module-specifier-like) names
+ * and depList is the array of de-duped dependency modules.
+ */
 export class InstantiateModuleTransformer extends ModuleTransformer {
 
   constructor(identifierGenerator) {
     super(identifierGenerator);
+    this.declarationExtractionTransformer = 
+        new DeclarationExtractionTransformer(identifierGenerator, this.moduleBindings_);
     this.dependencies = [];
+    this.depMapIdentifier = createIdentifierExpression(this.identifierGenerator.generateUniqueIdentifier());
+    this.moduleBindings_ = [];
   }
 
   wrapModule(statements) {
-    var depPaths = this.dependencies.map((dep) => dep.path);
-    var depLocals = this.dependencies.map((dep) => dep.local);
-
-    var hasTopLevelThis = statements.some(scopeContainsThis);
-
-    var func = parseExpression `function(${depLocals}) {
-      ${statements}
-    }`;
-
-    if (hasTopLevelThis)
-      func = parseExpression `${func}.bind(${globalThis()})`;
-
-    return parseStatements
-        `System.register(${this.moduleName}, ${depPaths}, ${func});`;
+    return parseStatements 
+      `System.register(${this.moduleName}, ${this.dependencies}, function(${this.depMapIdentifier}) {
+        ${statements}
+      });`;
   }
 
   /**
+   * Create the primary System.register structure, separating
+   * declaration bindings from execution for ES6 binding support.
+   * 
+   * Converts:
+   *   import {s} from 's';
+   *   export {p} from 'q';
+   *   q(s);
+   *   function q() {
+   *     s();
+   *   }
+   * 
+   *
+   * Hoisting the declarations and writing the exports into:
+   *   function q() {
+   *     s();
+   *   }
+   *   return {
+   *     exports: {
+   *       get p() {
+   *         return $__depMap[1].p;
+   *       },
+   *       set p(value) {
+   *         $__depMap[1].p = value;
+   *       }
+   *     },
+   *     execute: function() {
+   *       q(s);
+   *     }
+   *   };
+   *
+   * Then replace the import binding identifiers into:
+   *   function q() {
+   *     $__depMap[0]['s']();
+   *   }
+   *   return {
+   *     exports: {
+   *       get p() {
+   *         return $__depMap[1].p;
+   *       },
+   *       set p(value) {
+   *         $__depMap[1].p = value;
+   *       }
+   *     },
+   *     execute: function() {
+   *       q($__depMap[0]['s']);
+   *     }
+   *   };
+   *
+   * Note that $__depMap is actually $__0 in output.
+   */
+  appendExportStatement(statements) {
+    
+    // Transform statements into execution statements only, with declarations removed.
+    var executionStatements = statements.map(
+      (statement) => this.declarationExtractionTransformer.transformAny(statement)
+    );
+
+    var executionFunction = executionStatements.length ? parseExpression `function() {
+      ${executionStatements}
+    }` : parseExpression `function() {}`;
+
+    // Extract the declaration statements for hoisting from the previous transform.
+    var declarationStatements = this.declarationExtractionTransformer.getDeclarationStatements();
+
+    var exportStarDeps = this.exportVisitor_.starExports.map(
+      (moduleSpecifier) => moduleSpecifier.token.processedValue
+    );
+
+    if (exportStarDeps.length) {
+      declarationStatements.push(parseStatement `return {
+        exports: ${this.getExportObject()},
+        exportStar: ${exportStarDeps},
+        execute: ${executionFunction}
+      }`);
+    } else {
+      declarationStatements.push(parseStatement `return {
+        exports: ${this.getExportObject()},
+        execute: ${executionFunction}
+      }`);
+    }
+
+    // Replace import identifiers with an appropriate module member expression.
+    // NB one optimization might be to use temporary variables for modules in execute only.
+    this.moduleBindings_.forEach((binding) => {
+      var moduleMemberExpression = parseExpression
+          `${this.depMapIdentifier}[${binding.depIndex}][${binding.importName}]`;
+
+      declarationStatements = declarationStatements.map((statement) =>
+        ReplaceIdentifierExpressionTransformer.rename(statement, binding.variableName, moduleMemberExpression)
+      );
+    });
+
+    return declarationStatements;
+  }
+
+  getExportObject() {
+    return createObjectLiteralExpression(this.getExportProperties());
+  }
+
+  addModuleBinding(moduleBinding) {
+    this.moduleBindings_.push(moduleBinding);
+  }
+
+  getOrCreateDependencyIndex(moduleSpecifier) {
+    var name = moduleSpecifier.token.processedValue;
+
+    var depIndex = this.dependencies.indexOf(name);
+
+    if (depIndex == -1) {
+      depIndex = this.dependencies.length;
+      this.dependencies.push(name);
+    }
+    return depIndex;
+  }
+  /**
    * For
    *  import {foo} from './foo';
-   * transcode the './foo' part to
-   *  System.get(tempVar);
-   * where tempVar is a function argument.
+   * transform the './foo' part to
+   *  $__depMap[n];
+   * where n is the dependency index.
+   *
    * @param {ModuleSpecifier} tree
    * @return {ParseTree}
    */
   transformModuleSpecifier(tree) {
-    assert(this.moduleName);
-    var name = tree.token.processedValue;
-    var localName = this.getTempIdentifier();
-    this.dependencies.push({path: tree.token, local: localName});
-    var localIdentifier = createIdentifierExpression(localName);
+    var depIndex = this.getOrCreateDependencyIndex(tree);
+    
+    return parseExpression `${this.depMapIdentifier}[${depIndex}]`;
+  }
 
-    return parseExpression `System.get(${localIdentifier})`;
+  getExportExpression({name, tree, moduleSpecifier}) {
+    switch (tree.type) {
+      case EXPORT_DEFAULT:
+        return createIdentifierExpression('$__default');
+
+      case EXPORT_SPECIFIER:
+        if (moduleSpecifier) {
+          return createMemberExpression(moduleSpecifier, tree.lhs);
+        }
+        
+        return createIdentifierExpression(tree.lhs);
+
+      default:
+        return createIdentifierExpression(name);
+    }
+  }
+
+  getSetterExport(exp) {
+    return parsePropertyDefinition `set ${exp.name}(value) { ${this.getExportExpression(exp)} = value; }`;
+  }
+
+  getGetterExport(exp) {
+    return parsePropertyDefinition `get ${exp.name}() { return ${this.getExportExpression(exp)}; }`;
+  }
+
+  transformExportDeclaration(tree) {
+    // Transform function, variable, class and default export declarations.
+    if (!tree.declaration.specifierSet) {
+      this.exportVisitor_.visitAny(tree);
+      return this.transformAny(tree.declaration);
+    }
+
+    // All other declarations are visited then removed.
+    if (tree.declaration.specifierSet.type != EXPORT_STAR) {
+      tree.declaration = this.transformAny(tree.declaration);
+      tree.annotations = this.transformList(tree.annotations);
+    }
+    this.exportVisitor_.visitAny(tree);
+
+    return new EmptyStatement(null);
+  }
+
+  transformNamedExport(tree) {
+    var moduleSpecifier = this.transformAny(tree.moduleSpecifier);
+    var specifierSet = this.transformAny(tree.specifierSet);
+    if (moduleSpecifier === tree.moduleSpecifier && specifierSet === tree.specifierSet) {
+      return tree;
+    }
+    return new NamedExport(tree.location, moduleSpecifier, specifierSet);
+  }
+
+  transformImportDeclaration(tree) {
+    this.moduleSpecifierKind_ = 'import';
+
+    this.curDepIndex_ = this.getOrCreateDependencyIndex(tree.moduleSpecifier);
+
+    this.transformAny(tree.importClause);
+
+    return new EmptyStatement(tree.location);
+  }
+
+  transformImportedBinding(tree) {
+    this.addModuleBinding({
+      variableName: tree.binding.identifierToken.value,
+      depIndex: this.curDepIndex_,
+      importName: 'default'
+    });
+    return tree;
+  }
+
+  transformImportSpecifier(tree) {
+    var importName;
+    var localName;
+
+    if (tree.rhs) {
+      localName = tree.rhs.value;
+      importName = tree.lhs.value;
+    } else {
+      localName = importName = tree.lhs.value;
+    }
+
+    this.addModuleBinding({
+      variableName: localName,
+      depIndex: this.curDepIndex_, 
+      importName: importName
+    });
   }
 }

--- a/src/runtime/ModuleStore.js
+++ b/src/runtime/ModuleStore.js
@@ -145,12 +145,24 @@
     bundleStore: Object.create(null),
 
     register(name, deps, func) {
-      if (!deps || !deps.length) {
+      if (!deps || !deps.length && !func.length) {
+        // Traceur System.register
         this.registerModule(name, func);
       } else {
+        // System.register instantiate form
         this.bundleStore[name] = {
           deps: deps,
-          execute: func
+          execute: function() {
+            var depMap = {};
+            deps.forEach((dep, index) => depMap[dep] = arguments[index]);
+
+            // TODO: separate into two-phase declaration / execution
+            var registryEntry = func.call(this, depMap);
+            
+            registryEntry.execute.call(this);
+            
+            return registryEntry.exports;
+          }
         };
       }
     },

--- a/test/instantiate/circular1.js
+++ b/test/instantiate/circular1.js
@@ -1,0 +1,11 @@
+import {fn2, variable2} from './circular2';
+
+export var variable1 = 'test circular 1';
+
+fn2();
+
+export var output;
+
+export function fn1() {
+  output = variable2;
+}

--- a/test/instantiate/circular2.js
+++ b/test/instantiate/circular2.js
@@ -1,0 +1,11 @@
+import {fn1, variable1} from './circular1';
+
+export var variable2 = 'test circular 2';
+
+fn1();
+
+export var output;
+
+export function fn2() {
+  output = variable1;
+}

--- a/test/instantiate/export.js
+++ b/test/instantiate/export.js
@@ -1,0 +1,10 @@
+export var p = 5;
+export function foo() {};
+export var q = {};
+
+export default function bar() {};
+
+var s = 4;
+
+export {s};
+export {s as t, q as m};

--- a/test/instantiate/rebinding.js
+++ b/test/instantiate/rebinding.js
@@ -1,0 +1,1 @@
+export var p = 4;

--- a/test/instantiate/reexport-binding.js
+++ b/test/instantiate/reexport-binding.js
@@ -1,0 +1,2 @@
+import {p} from './rebinding';
+p = 3;

--- a/test/instantiate/reexport1.js
+++ b/test/instantiate/reexport1.js
@@ -1,0 +1,1 @@
+export * from './export';

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -1,0 +1,31 @@
+var System = require('../third_party/es6-module-loader/index').System;
+
+System.baseURL = __dirname + '/instantiate/';
+
+suite('instantiate', function() {
+  test('Circular dependencies', function(done) {
+    System.import('circular1').then(function(m1) {
+      System.import('circular2').then(function(m2) {
+        assert.equal(m2.output, 'test circular 1');
+        assert.equal(m1.output, 'test circular 2');
+        done();
+      }).catch(done);
+    }).catch(done);
+  });
+
+  test('Re-export', function(done) {
+    System.import('reexport1').then(function(m) {
+      assert(m.p, 5);
+      done();
+    }).catch(done);
+  });
+
+  test('Re-export bindings', function(done) {
+    System.import('reexport-binding').then(function(m) {
+      System.import('rebinding').then(function(m) {
+        assert.equal(m.p, 3);
+        done();
+      }).catch(done);
+    }).catch(done);
+  });
+});

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -115,12 +115,13 @@ suite('context test', function() {
         function(error, stdout, stderr) {
           assert.isNull(error);
           executeFileWithRuntime(tempFileName);
-          var module = System.get('test/unit/node/resources/import-another-x');
-          assert.equal(global.anotherResult, 17);
-          done();
+          System.import('test/unit/node/resources/import-another-x').then(function(module) {
+            assert.equal(module.iAmNotScript, true);
+            assert.equal(anotherResult, 17);
+            done();
+          });
         });
   });
-
 
   test('script option per file', function(done) {
     tempFileName = resolve(uuid.v4() + '.js');

--- a/test/unit/node/resources/register-module-bindings.js
+++ b/test/unit/node/resources/register-module-bindings.js
@@ -1,0 +1,6 @@
+export class q extends p() {
+
+}
+export function p() {
+  return {};
+}

--- a/third_party/es6-module-loader/index.js
+++ b/third_party/es6-module-loader/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  Loader: require('./loader'),
+  Module: Module,
+  System: require('./system')
+};

--- a/third_party/es6-module-loader/loader.js
+++ b/third_party/es6-module-loader/loader.js
@@ -1,0 +1,959 @@
+/*
+*********************************************************************************************
+
+  Loader Polyfill
+
+    - Implemented exactly to the 2013-12-02 Specification Draft -
+      https://github.com/jorendorff/js-loaders/blob/e60d3651/specs/es6-modules-2013-12-02.pdf
+      with the only exceptions as described here
+
+    - Abstract functions have been combined where possible, and their associated functions 
+      commented
+
+    - When the traceur global is detected, declarative modules are transformed by Traceur
+      before execution. The Traceur parse tree is stored as load.body, analogously to the
+      spec
+
+    - Link and EnsureEvaluated have been customised from the spec
+
+    - Module Linkage records are stored as: { module: (actual module), dependencies, body, name, address }
+
+    - Cycles are not supported at all and will throw an error
+
+    - Realm implementation is entirely omitted. As such, Loader.global and Loader.realm
+      accessors will throw errors, as well as Loader.eval. Realm arguments are not passed.
+
+    - Loader module table iteration currently not yet implemented
+
+*********************************************************************************************
+*/
+
+// Some Helpers
+
+// logs a linkset snapshot for debugging
+/* function snapshot(loader) {
+  console.log('---Snapshot---');
+  for (var i = 0; i < loader.loads.length; i++) {
+    var load = loader.loads[i];
+    var linkSetLog = '  ' + load.name + ' (' + load.status + '): ';
+
+    for (var j = 0; j < load.linkSets.length; j++) {
+      linkSetLog += '{' + logloads(load.linkSets[j].loads) + '} ';
+    }
+    console.log(linkSetLog);
+  }
+  console.log('');
+}
+function logloads(loads) {
+  var log = '';
+  for (var k = 0; k < loads.length; k++)
+    log += loads[k].name + (k != loads.length - 1 ? ' ' : '');
+  return log;
+} */
+
+(function (__global) {
+  (function() {
+    var Promise = __global.Promise || require('./promise');
+
+    var traceur;
+
+    var defineProperty;
+    try {
+      if (!!Object.defineProperty({}, 'a', {})) {
+        defineProperty = Object.defineProperty;
+      }
+    } catch (e) {
+      defineProperty = function (obj, prop, opt) {
+        try {
+          obj[prop] = opt.value || opt.get.call(obj);
+        }
+        catch(e) {}
+      }
+    }
+
+    console.assert = console.assert || function() {};
+
+    // Define an IE-friendly shim good-enough for purposes
+    var indexOf = Array.prototype.indexOf || function(item) { 
+      for (var i = 0, thisLen = this.length; i < thisLen; i++) {
+        if (this[i] === item) {
+          return i;
+        }
+      }
+      return -1;
+    };
+
+    // 15.2.3 - Runtime Semantics: Loader State
+
+    // 15.2.3.11
+    function createLoaderLoad(object) {
+      return {
+        // modules is an object for ES5 implementation
+        modules: {},
+        loads: [],
+        loaderObj: object
+      };
+    }
+
+    // 15.2.3.2 Load Records and LoadRequest Objects
+
+    // 15.2.3.2.1
+    function createLoad(name) {
+      return {
+        status: 'loading',
+        name: name,
+        linkSets: [],
+        dependencies: [],
+        metadata: {}
+      };
+    }
+
+    // 15.2.3.2.2 createLoadRequestObject, absorbed into calling functions
+    
+    // 15.2.4
+
+    // 15.2.4.1
+    function loadModule(loader, name, options) {
+      return new Promise(asyncStartLoadPartwayThrough({
+        step: options.address ? 'fetch' : 'locate',
+        loader: loader,
+        moduleName: name,
+        moduleMetadata: {},
+        moduleSource: options.source,
+        moduleAddress: options.address
+      }));
+    }
+
+    // 15.2.4.2
+    function requestLoad(loader, request, refererName, refererAddress) {
+      // 15.2.4.2.1 CallNormalize
+      return new Promise(function(resolve, reject) {
+        resolve(loader.loaderObj.normalize(request, refererName, refererAddress));
+      })
+      // 15.2.4.2.2 GetOrCreateLoad
+      .then(function(name) {
+        var load;
+        if (loader.modules[name]) {
+          load = createLoad(name);
+          load.status = 'linked';
+          load.module = loader.modules[name];
+          return load;
+        }
+
+        for (var i = 0, l = loader.loads.length; i < l; i++) {
+          load = loader.loads[i];
+          if (load.name != name)
+            continue;
+          console.assert(load.status == 'loading' || load.status == 'loaded', 'loading or loaded');
+          return load;
+        }
+
+        load = createLoad(name);
+        loader.loads.push(load);
+
+        setTimeout(function() {
+          proceedToLocate(loader, load);
+        }, 7);
+
+        return load;
+      });
+    }
+    
+    // 15.2.4.3
+    function proceedToLocate(loader, load) {
+      proceedToFetch(loader, load,
+        Promise.resolve()
+        // 15.2.4.3.1 CallLocate
+        .then(function() {
+          return loader.loaderObj.locate({ name: load.name, metadata: load.metadata });
+        })
+      );
+    }
+
+    // 15.2.4.4
+    function proceedToFetch(loader, load, p) {
+      proceedToTranslate(loader, load, 
+        p
+        // 15.2.4.4.1 CallFetch
+        .then(function(address) {
+          if (load.linkSets.length == 0)
+            return;
+          load.address = address;
+
+          return loader.loaderObj.fetch({ name: load.name, metadata: load.metadata, address: address });
+        })
+      );
+    }
+
+    // 15.2.4.5
+    function proceedToTranslate(loader, load, p) {
+      p
+      // 15.2.4.5.1 CallTranslate
+      .then(function(source) {
+        if (load.linkSets.length == 0)
+          return;
+        return loader.loaderObj.translate({ name: load.name, metadata: load.metadata, address: load.address, source: source });
+      })
+
+      // 15.2.4.5.2 CallInstantiate
+      .then(function(source) {
+        if (load.linkSets.length == 0)
+          return;
+        load.source = source;
+        return loader.loaderObj.instantiate({ name: load.name, metadata: load.metadata, address: load.address, source: source });
+      })
+
+      // 15.2.4.5.3 InstantiateSucceeded
+      .then(function(instantiateResult) {
+        if (load.linkSets.length == 0)
+          return;
+
+        var depsList;
+        if (instantiateResult === undefined) {
+          if (!__global.traceur)
+            throw new TypeError('Include Traceur for module syntax support');
+
+          traceur = traceur || __global.traceur;
+          load.address = load.address || 'anon' + ++anonCnt;
+
+          console.assert(load.source, 'Non-empty source');
+
+          try {
+            var parser = new traceur.syntax.Parser(new traceur.syntax.SourceFile(load.address, load.source));
+            var body = parser.parseModule();
+
+            load.kind = 'declarative';
+
+            depsList = getImports(body);
+
+            var oldSourceMaps = traceur.options.sourceMaps;
+            var oldModules = traceur.options.modules;
+
+            traceur.options.sourceMaps = true;
+            traceur.options.modules = 'instantiate';
+
+            var reporter = new traceur.util.ErrorReporter();
+
+            reporter.reportMessageInternal = function(location, kind, format, args) {
+              throw new SyntaxError(kind, location.start && location.start.line_, location.start && location.start.column_);
+            }
+
+            // traceur expects its version of System
+            var curSystem = __global.System;
+            __global.System = __global.traceurSystem || curSystem;
+
+            var tree = (new traceur.codegeneration.module.AttachModuleNameTransformer(load.name)).transformAny(body);
+            tree = (new traceur.codegeneration.FromOptionsTransformer(reporter)).transform(tree);
+
+            var sourceMapGenerator = new traceur.outputgeneration.SourceMapGenerator({ file: load.address });
+            var options = { sourceMapGenerator: sourceMapGenerator };
+
+            var source = traceur.outputgeneration.TreeWriter.write(tree, options);
+
+            if (__global.btoa)
+              source += '\n//# sourceMappingURL=data:application/json;base64,' + btoa(unescape(encodeURIComponent(options.sourceMap))) + '\n';
+
+            // now run System.register
+            var curRegister = System.register;
+            
+            System.register = function(name, deps, declare) {
+              // store the registered declaration as load.declare
+              load.declare = declare;
+            }
+
+            __eval(source, __global, load.name);
+          }
+          catch(e) {
+            if (e.name == 'SyntaxError' || e.name == 'TypeError') 
+              e.message = 'Evaluating ' + (load.name || load.address) + '\n\t' + e.message;
+            if (curRegister)
+              System.register = curRegister;
+            if (curSystem)
+              __global.System = curSystem;
+            if (oldSourceMaps)
+              traceur.options.sourceMaps = oldSourceMaps;
+            if (oldModules)
+              traceur.options.modules = oldModules;
+            throw e;
+          }
+          System.register = curRegister;
+          __global.System = curSystem;
+          traceur.options.sourceMaps = oldSourceMaps;
+          traceur.options.modules = oldModules;
+        }
+        else if (typeof instantiateResult == 'object') {
+          depsList = instantiateResult.deps || [];
+          load.execute = instantiateResult.execute;
+          load.kind = 'dynamic';
+        }
+        else
+          throw TypeError('Invalid instantiate return value');
+
+        // 15.2.4.6 ProcessLoadDependencies
+        load.dependencies = [];
+        load.depsList = depsList
+        var loadPromises = [];
+        for (var i = 0, l = depsList.length; i < l; i++) (function(request) {
+          loadPromises.push(
+            requestLoad(loader, request, load.name, load.address)
+
+            // 15.2.4.6.1 AddDependencyLoad (load is parentLoad)
+            .then(function(depLoad) {
+
+              console.assert(!load.dependencies.some(function(dep) {
+                return dep.key == request;
+              }), 'not already a dependency');
+
+              load.dependencies.push({
+                key: request,
+                value: depLoad.name
+              });
+
+              if (depLoad.status != 'linked') {
+                var linkSets = load.linkSets.concat([]);
+                for (var i = 0, l = linkSets.length; i < l; i++)
+                  addLoadToLinkSet(linkSets[i], depLoad);
+              }
+
+              // console.log('AddDependencyLoad ' + depLoad.name + ' for ' + load.name);
+              // snapshot(loader);
+            })
+          );
+        })(depsList[i]);
+
+        return Promise.all(loadPromises);
+      })
+
+      // 15.2.4.6.2 LoadSucceeded
+      .then(function() {
+        // console.log('LoadSucceeded ' + load.name);
+        // snapshot(loader);
+
+        console.assert(load.status == 'loading', 'is loading');
+
+        load.status = 'loaded';
+
+        var linkSets = load.linkSets.concat([]);
+        for (var i = 0, l = linkSets.length; i < l; i++)
+          updateLinkSetOnLoad(linkSets[i], load);
+      })
+
+      // 15.2.4.5.4 LoadFailed
+      ['catch'](function(exc) {
+        console.assert(load.status == 'loading', 'is loading on fail');
+        load.status = 'failed';
+        load.exception = exc;
+
+        var linkSets = load.linkSets.concat([]);
+        for (var i = 0, l = linkSets.length; i < l; i++)
+          linkSetFailed(linkSets[i], exc);
+
+        console.assert(load.linkSets.length == 0, 'linkSets not removed');
+      });
+    }
+
+    // 15.2.4.7 PromiseOfStartLoadPartwayThrough absorbed into calling functions
+
+    // 15.2.4.7.1
+    function asyncStartLoadPartwayThrough(stepState) {
+      return function(resolve, reject) {
+        var loader = stepState.loader;
+        var name = stepState.moduleName;
+        var step = stepState.step;
+
+        if (loader.modules[name]) 
+          throw new TypeError('"' + name + '" already exists in the module table');
+
+        // NB this still seems wrong for LoadModule as we may load a dependency
+        // of another module directly before it has finished loading.
+        for (var i = 0, l = loader.loads.length; i < l; i++)
+          if (loader.loads[i].name == name)
+            throw new TypeError('"' + name + '" already loading');
+
+        var load = createLoad(name);
+        
+        load.metadata = stepState.moduleMetadata;
+
+        var linkSet = createLinkSet(loader, load);
+
+        loader.loads.push(load);
+
+        resolve(linkSet.done);
+
+        if (step == 'locate')
+          proceedToLocate(loader, load);
+
+        else if (step == 'fetch')
+          proceedToFetch(loader, load, Promise.resolve(stepState.moduleAddress));
+
+        else {
+          console.assert(step == 'translate', 'translate step');
+          load.address = stepState.moduleAddress;
+          proceedToTranslate(loader, load, Promise.resolve(stepState.moduleSource));
+        }
+      }
+    }
+
+    // Declarative linking functions run through alternative implementation:
+    // 15.2.5.1.1 CreateModuleLinkageRecord not implemented
+    // 15.2.5.1.2 LookupExport not implemented
+    // 15.2.5.1.3 LookupModuleDependency not implemented
+
+    // 15.2.5.2.1
+    function createLinkSet(loader, startingLoad) {
+      var linkSet = {
+        loader: loader,
+        loads: [],
+        loadingCount: 0
+      };
+      linkSet.done = new Promise(function(resolve, reject) {
+        linkSet.resolve = resolve;
+        linkSet.reject = reject;
+      });
+      addLoadToLinkSet(linkSet, startingLoad);
+      return linkSet;
+    }
+    // 15.2.5.2.2
+    function addLoadToLinkSet(linkSet, load) {
+      console.assert(load.status == 'loading' || load.status == 'loaded', 'loading or loaded on link set');
+
+      for (var i = 0, l = linkSet.loads.length; i < l; i++)
+        if (linkSet.loads[i] == load)
+          return;
+
+      linkSet.loads.push(load);
+      load.linkSets.push(linkSet);
+
+      if (load.status != 'loaded') {
+        linkSet.loadingCount++;
+      }
+
+      var loader = linkSet.loader;
+
+      for (var i = 0, l = load.dependencies.length; i < l; i++) {
+        var name = load.dependencies[i].value;
+
+        if (loader.modules[name])
+          continue;
+
+        for (var j = 0, d = loader.loads.length; j < d; j++) {
+          if (loader.loads[j].name != name)
+            continue;
+          
+          addLoadToLinkSet(linkSet, loader.loads[j]);
+          break;
+        }
+      }
+      // console.log('add to linkset ' + load.name);
+      // snapshot(linkSet.loader);
+    }
+
+    // 15.2.5.2.3
+    function updateLinkSetOnLoad(linkSet, load) {
+      console.assert(load.status == 'loaded' || load.status == 'linked', 'loaded or linked');
+
+      // console.log('update linkset on load ' + load.name);
+      // snapshot(linkSet.loader);
+
+      linkSet.loadingCount--;
+
+      if (linkSet.loadingCount > 0)
+        return;
+
+      var startingLoad = linkSet.loads[0];
+      try {
+        link(linkSet);
+      }
+      catch(exc) {
+        return linkSetFailed(linkSet, exc);
+      }
+
+      console.assert(linkSet.loads.length == 0, 'loads cleared');
+
+      linkSet.resolve(startingLoad);
+    }
+
+    // 15.2.5.2.4
+    function linkSetFailed(linkSet, exc) {
+      var loads = linkSet.loads.concat([]);
+      for (var i = 0, l = loads.length; i < l; i++) {
+        var load = loads[i];
+        var linkIndex = indexOf.call(load.linkSets, linkSet);
+        console.assert(linkIndex != -1, 'link not present');
+        load.linkSets.splice(linkIndex, 1);
+        if (load.linkSets.length == 0) {
+          var globalLoadsIndex = indexOf.call(linkSet.loader.loads, load);
+          if (globalLoadsIndex != -1)
+            linkSet.loader.loads.splice(globalLoadsIndex, 1);
+        }
+      }
+      linkSet.reject(exc);
+    }
+
+    // 15.2.5.2.5
+    function finishLoad(loader, load) {
+      // if not anonymous, add to the module table
+      if (load.name) {
+        console.assert(!loader.modules[load.name], 'load not in module table');
+        loader.modules[load.name] = load.module;
+      }
+      var loadIndex = indexOf.call(loader.loads, load);
+      if (loadIndex != -1)
+        loader.loads.splice(loadIndex, 1);
+      for (var i = 0, l = load.linkSets.length; i < l; i++) {
+        loadIndex = indexOf.call(load.linkSets[i].loads, load);
+        if (loadIndex != -1)
+          load.linkSets[i].loads.splice(loadIndex, 1);
+      }
+      load.linkSets.splice(0, load.linkSets.length);
+    }
+
+    // 15.2.5.3 Module Linking Groups
+
+    // 15.2.5.3.2 BuildLinkageGroups alternative implementation
+    // Adjustments:
+    // 1. groups is an already-interleaved array of group kinds
+    // 2. load.groupIndex is set when this function runs
+    // 3. load.groupIndex is the interleaved index ie 0 declarative, 1 dynamic, 2 declarative, ... (or starting with dynamic)
+    function buildLinkageGroups(load, loads, groups, loader) {
+      groups[load.groupIndex] = groups[load.groupIndex] || [];
+
+      // if the load already has a group index and its in its group, its already been done
+      // this logic naturally handles cycles
+      if (indexOf.call(groups[load.groupIndex], load) != -1)
+        return;
+
+      // now add it to the group to indicate its been seen
+      groups[load.groupIndex].push(load);
+
+      for (var i = 0; i < loads.length; i++) {
+        var loadDep = loads[i];
+
+        // dependencies not found are already linked
+        for (var j = 0; j < load.dependencies.length; j++) {
+          if (loadDep.name == load.dependencies[j].value) {
+            // by definition all loads in linkset are loaded, not linked
+            console.assert(loadDep.status == 'loaded', 'Load in linkSet not loaded!');
+
+            // if it is a group transition, the index of the dependency has gone up
+            // otherwise it is the same as the parent
+            var loadDepGroupIndex = load.groupIndex + (loadDep.kind != load.kind);
+
+            if (!loadDep.groupIndex) {
+              loadDep.groupIndex = loadDepGroupIndex;
+            }
+            else if (loadDep.groupIndex != loadDepGroupIndex) {
+              // if the dependency already has a group index
+              // a groupIndex inconsistency implies a mixed dependency cycle
+              throw new TypeError('Mixed dependency cycle detected.');
+            }
+
+            buildLinkageGroups(loadDep, loads, groups, loader);
+          }
+        }
+      }
+    }
+
+    // 15.2.5.4
+    function link(linkSet) {
+
+      var loader = linkSet.loader;
+
+      // console.log('linking {' + logloads(loads) + '}');
+      // snapshot(loader);
+
+      // 15.2.5.3.1 LinkageGroups alternative implementation
+
+      // build all the groups
+      // because the first load represents the top of the tree
+      // for a given linkset, we can work down from there
+      var groups = [];
+      var startingLoad = linkSet.loads[0];
+      startingLoad.groupIndex = 0;
+      buildLinkageGroups(startingLoad, linkSet.loads, groups, loader);
+
+      // determine the kind of the bottom group
+      var curGroupDeclarative = (startingLoad.kind == 'declarative') == groups.length % 2;
+
+      // run through the groups from bottom to top
+      for (var i = groups.length - 1; i >= 0; i--) {
+        var group = groups[i];
+        for (var j = 0; j < group.length; j++) {
+          var load = group[j];
+
+          // 15.2.5.5 LinkDeclarativeModules adjusted
+          if (curGroupDeclarative) {
+            linkDeclarativeModule(load, linkSet.loads, loader);
+          }
+          // 15.2.5.6 LinkDynamicModules adjusted
+          else {
+            var module = load.execute();
+            if (!(module.__esModule))
+              throw new TypeError('Execution must define a Module instance');
+            load.module = {
+              module: module
+            };
+            load.status = 'linked';
+          }
+          finishLoad(loader, load);
+        }
+
+        // alternative current kind for next loop
+        curGroupDeclarative = !curGroupDeclarative;
+      }
+    }
+
+    // custom declarative linking function
+    function linkDeclarativeModule(load, loads, loader) {
+      // only link if already not already started linking (stops at circular)
+      if (load.module)
+        return;
+
+      // declare the module with an empty depMap
+      var depMap = [];
+      var sys = __global.System;
+      __global.System = loader;
+      var registryEntry = load.declare.call(__global, depMap);
+
+      __global.System = sys;
+
+      var moduleDependencies = [];
+
+      // module is just a plain object, until we evaluate it
+      var module = registryEntry.exports;
+
+      console.assert(!load.module, 'Load module already declared!');
+
+      load.module = {
+        name: load.name,
+        dependencies: moduleDependencies,
+        execute: registryEntry.execute,
+        exports: module,
+        evaluated: false
+      };
+
+      // now link all the module dependencies
+      // amending the depMap as we go
+      for (var i = 0; i < load.dependencies.length; i++) {
+        var depName = load.dependencies[i].value;
+        var depModule;
+        // if dependency already a module, use that
+        if (loader.modules[depName]) {
+          depModule = loader.modules[depName];
+        }
+        // otherwise we need to link the dependency
+        else {
+          for (var j = 0; j < loads.length; j++) {
+            if (loads[j].name != depName)
+              continue;
+            
+            linkDeclarativeModule(loads[j], loads, loader);
+            
+            depModule = loads[j].exports || loads[j].module;
+          }
+        }
+
+        console.assert(depModule, 'Dependency module not found!');
+        console.assert(depModule.exports, 'Dependency module not found!');
+
+        if (registryEntry.exportStar && indexOf.call(registryEntry.exportStar, load.dependencies[i].key) != -1) {
+          // we are exporting * from this dependency
+          (function(depModuleModule) {
+            for (var p in depModuleModule) (function(p) {
+              // if the property is already defined throw?
+              defineProperty(module, p, {
+                enumerable: true,
+                get: function() {
+                  return depModuleModule[p];
+                },
+                set: function(value) {
+                  depModuleModule[p] = value;
+                }
+              });
+            })(p);
+          })(depModule.exports);
+        }
+
+        moduleDependencies.push(depModule);
+        depMap[i] = depModule.exports;
+      }
+
+      load.status = 'linked';
+    }
+      
+
+
+    // 15.2.5.5.1 LinkImports not implemented
+    // 15.2.5.7 ResolveExportEntries not implemented
+    // 15.2.5.8 ResolveExports not implemented
+    // 15.2.5.9 ResolveExport not implemented
+    // 15.2.5.10 ResolveImportEntries not implemented
+
+    // 15.2.6.1
+    function evaluateLoadedModule(loader, load) {
+      console.assert(load.status == 'linked', 'is linked ' + load.name);
+      ensureEvaluated(load.module, [], loader);
+      return load.module.module;
+    }
+
+    /*
+     * Module Object non-exotic for ES5:
+     *
+     * module.module        bound module object
+     * module.execute       execution function for module
+     * module.dependencies  list of module objects for dependencies
+     * 
+     */
+
+    // 15.2.6.2 EnsureEvaluated adjusted
+    function ensureEvaluated(module, seen, loader) {
+      if (module.evaluated || !module.dependencies)
+        return;
+
+      seen.push(module);
+
+      var deps = module.dependencies;
+
+      for (var i = 0; i < deps.length; i++) {
+        var dep = deps[i];
+        if (indexOf.call(seen, dep) == -1)
+          ensureEvaluated(dep, seen, loader);
+      }
+
+      if (module.evaluated)
+        return;
+
+      module.evaluated = true;
+      module.execute.call(__global);
+      module.module = Module(module.exports);
+      delete module.execute;
+    }
+
+    // Loader
+    function Loader(options) {
+      if (typeof options != 'object')
+        throw new TypeError('Options must be an object');
+
+      if (options.normalize)
+        this.normalize = options.normalize;
+      if (options.locate)
+        this.locate = options.locate;
+      if (options.fetch)
+        this.fetch = options.fetch;
+      if (options.translate)
+        this.translate = options.translate;
+      if (options.instantiate)
+        this.instantiate = options.instantiate;
+
+      this._loader = {
+        loaderObj: this,
+        loads: [],
+        modules: {}
+      };
+
+      defineProperty(this, 'global', {
+        get: function() {
+          return global;
+        }
+      });
+      defineProperty(this, 'realm', {
+        get: function() {
+          throw new TypeError('Realms not implemented in polyfill');
+        }
+      });
+    }
+
+    // NB importPromises hacks ability to import a module twice without error - https://github.com/jorendorff/js-loaders/issues/60
+    var importPromises = {};
+    Loader.prototype = {
+      define: function(name, source, options) {
+        if (importPromises[name])
+          throw new TypeError('Module is already loading.');
+        importPromises[name] = new Promise(asyncStartLoadPartwayThrough({
+          step: options && options.address ? 'fetch' : 'translate',
+          loader: this,
+          moduleName: name,
+          moduleMetadata: options && options.metadata || {},
+          moduleSource: source,
+          moduleAddress: options && options.address
+        }));
+        return importPromises[name].then(function() { delete importPromises[name]; });
+      },
+      load: function(request, options) {
+        if (this._loader.modules[request]) {
+          ensureEvaluated(this._loader.modules[request], [], this._loader);
+          return Promise.resolve(this._loader.modules[request].module);
+        }
+        if (importPromises[request])
+          return importPromises[request];
+        importPromises[request] = loadModule(this._loader);
+        return importPromises[request].then(function() { delete importPromises[request]; })
+      },
+      module: function(source, options) {
+        var load = createLoad();
+        load.address = options && options.address;
+        var linkSet = createLinkSet(this._loader, load);
+        var sourcePromise = Promise.resolve(source);
+        var loader = this._loader;
+        var p = linkSet.done.then(function() {
+          return evaluateLoadedModule(loader, load);
+        });
+        proceedToTranslate(this, load, sourcePromise);
+        return p;
+      },
+      'import': function(name, options) {
+        // run normalize first
+        var loaderObj = this;
+
+        return new Promise(function(resolve) {
+          resolve(loaderObj.normalize.call(this, name, options && options.name, options && options.address))
+        })
+        .then(function(name) {
+          var loader = loaderObj._loader;
+          
+          if (loader.modules[name]) {
+            ensureEvaluated(loader.modules[name], [], loader._loader);
+            return Promise.resolve(loader.modules[name].module);
+          }
+          
+          return (importPromises[name] || (importPromises[name] = loadModule(loader, name, options || {})))
+            .then(function(load) {
+              delete importPromises[name];
+              return evaluateLoadedModule(loader, load);
+            });
+        });
+      },
+      eval: function(source) {
+        throw new TypeError('Eval not implemented in polyfill')
+      },
+      get: function(key) {
+        if (!this._loader.modules[key])
+          return;
+        ensureEvaluated(this._loader.modules[key], [], this);
+        return this._loader.modules[key].module;
+      },
+      has: function(name) {
+        return !!this._loader.modules[name];
+      },
+      set: function(name, module) {
+        if (!(module.__esModule))
+          throw new TypeError('Set must be a module');
+        this._loader.modules[name] = {
+          module: module
+        };
+      },
+      'delete': function(name) {
+        return this._loader.modules[name] ? delete this._loader.modules[name] : false;
+      },
+      // NB implement iterations
+      entries: function() {
+        throw new TypeError('Iteration not yet implemented in the polyfill');
+      },
+      keys: function() {
+        throw new TypeError('Iteration not yet implemented in the polyfill');
+      },
+      values: function() {
+        throw new TypeError('Iteration not yet implemented in the polyfill');
+      },
+      normalize: function(name, referrerName, referrerAddress) {
+        return name;
+      },
+      locate: function(load) {
+        return load.name;
+      },
+      fetch: function(load) {
+        throw new TypeError('Fetch not implemented');
+      },
+      translate: function(load) {
+        return load.source;
+      },
+      instantiate: function(load) {
+      }
+    };
+
+    // tree traversal, NB should use visitor pattern here
+    function traverse(object, iterator, parent, parentProperty) {
+      var key, child;
+      if (iterator(object, parent, parentProperty) === false)
+        return;
+      for (key in object) {
+        if (!object.hasOwnProperty(key))
+          continue;
+        if (key == 'location' || key == 'type')
+          continue;
+        child = object[key];
+        if (typeof child == 'object' && child !== null)
+          traverse(child, iterator, object, key);
+      }
+    }
+
+    // given a syntax tree, return the import list
+    function getImports(moduleTree) {
+      var imports = [];
+
+      function addImport(name) {
+        if (indexOf.call(imports, name) == -1)
+          imports.push(name);
+      }
+
+      traverse(moduleTree, function(node) {
+        // import {} from 'foo';
+        // export * from 'foo';
+        // export { ... } from 'foo';
+        // module x from 'foo';
+        if (node.type == 'EXPORT_DECLARATION') {
+          if (node.declaration.moduleSpecifier)
+            addImport(node.declaration.moduleSpecifier.token.processedValue);
+        }
+        else if (node.type == 'IMPORT_DECLARATION')
+          addImport(node.moduleSpecifier.token.processedValue);
+        else if (node.type == 'MODULE_DECLARATION')
+          addImport(node.expression.token.processedValue);
+      });
+      return imports;
+    }
+    var anonCnt = 0;
+
+    // Module Object
+    function Module(obj) {
+      if (typeof obj != 'object')
+        throw new TypeError('Expected object');
+
+      var self = {
+        __esModule: true
+      };
+
+      for (var key in obj) {
+        (function (key) {
+          defineProperty(self, key, {
+            configurable: false,
+            enumerable: true,
+            get: function () {
+              return obj[key];
+            }
+          });
+        })(key);
+      }
+
+      if (Object.preventExtensions)
+        Object.preventExtensions(self);
+
+      return self;
+    }
+
+
+    if (typeof exports === 'object')
+      module.exports = Loader;
+
+    __global.Reflect = __global.Reflect || {};
+    __global.Reflect.Loader = __global.Reflect.Loader || Loader;
+    __global.LoaderPolyfill = Loader;
+    __global.Module = Module;
+
+  })();
+
+  function __eval(__source, __global, __moduleName) {
+    eval('var __moduleName = "' + (__moduleName || '').replace('"', '\"') + '"; with(__global) { (function() { ' + __source + ' \n }).call(__global); }');
+  }
+
+})(typeof global !== 'undefined' ? global : this);

--- a/third_party/es6-module-loader/system.js
+++ b/third_party/es6-module-loader/system.js
@@ -1,0 +1,273 @@
+/*
+*********************************************************************************************
+
+  System Loader Implementation
+
+    - Implemented to https://github.com/jorendorff/js-loaders/blob/master/browser-loader.js
+
+    - <script type="module"> supported
+
+*********************************************************************************************
+*/
+
+(function (global) {
+  var isBrowser = typeof window != 'undefined';
+  var Loader = global.Reflect && global.Reflect.Loader || require('./loader');
+  var Promise = global.Promise || require('./promise');
+
+  // Helpers
+  // Absolute URL parsing, from https://gist.github.com/Yaffle/1088850
+  function parseURI(url) {
+    var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@]*(?::[^:@]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
+    // authority = '//' + user + ':' + pass '@' + hostname + ':' port
+    return (m ? {
+      href     : m[0] || '',
+      protocol : m[1] || '',
+      authority: m[2] || '',
+      host     : m[3] || '',
+      hostname : m[4] || '',
+      port     : m[5] || '',
+      pathname : m[6] || '',
+      search   : m[7] || '',
+      hash     : m[8] || ''
+    } : null);
+  }
+  function toAbsoluteURL(base, href) {
+    function removeDotSegments(input) {
+      var output = [];
+      input.replace(/^(\.\.?(\/|$))+/, '')
+        .replace(/\/(\.(\/|$))+/g, '/')
+        .replace(/\/\.\.$/, '/../')
+        .replace(/\/?[^\/]*/g, function (p) {
+          if (p === '/..')
+            output.pop();
+          else
+            output.push(p);
+      });
+      return output.join('').replace(/^\//, input.charAt(0) === '/' ? '/' : '');
+    }
+
+    href = parseURI(href || '');
+    base = parseURI(base || '');
+
+    return !href || !base ? null : (href.protocol || base.protocol) +
+      (href.protocol || href.authority ? href.authority : base.authority) +
+      removeDotSegments(href.protocol || href.authority || href.pathname.charAt(0) === '/' ? href.pathname : (href.pathname ? ((base.authority && !base.pathname ? '/' : '') + base.pathname.slice(0, base.pathname.lastIndexOf('/') + 1) + href.pathname) : base.pathname)) +
+      (href.protocol || href.authority || href.pathname ? href.search : (href.search || base.search)) +
+      href.hash;
+  }
+
+  var fetchTextFromURL;
+  if (isBrowser) {
+    fetchTextFromURL = function(url, fulfill, reject) {
+      var xhr = new XMLHttpRequest();
+      var sameDomain = true;
+      if (!('withCredentials' in xhr)) {
+        // check if same domain
+        var domainCheck = /^(\w+:)?\/\/([^\/]+)/.exec(url);
+        if (domainCheck) {
+          sameDomain = domainCheck[2] === window.location.host;
+          if (domainCheck[1])
+            sameDomain &= domainCheck[1] === window.location.protocol;
+        }
+      }
+      if (!sameDomain) {
+        xhr = new XDomainRequest();
+        xhr.onload = load;
+        xhr.onerror = error;
+        xhr.ontimeout = error;
+      }
+      function load() {
+        fulfill(xhr.responseText);
+      }
+      function error() {
+        reject(xhr.statusText + ': ' + url || 'XHR error');
+      }
+
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4) {
+          if (xhr.status === 200 || (xhr.status == 0 && xhr.responseText)) {
+            load();
+          } else {
+            error();
+          }
+        }
+      };
+      xhr.open("GET", url, true);
+      xhr.send(null);
+    }
+  }
+  else {
+    var fs = require('fs');
+    fetchTextFromURL = function(url, fulfill, reject) {
+      return fs.readFile(url, function(err, data) {
+        if (err)
+          return reject(err);
+        else
+          fulfill(data + '');
+      });
+    }
+  }
+
+  var System = new Loader({
+    global: isBrowser ? window : global,
+    strict: true,
+    normalize: function(name, parentName, parentAddress) {
+      if (typeof name != 'string')
+        throw new TypeError('Module name must be a string');
+
+      var segments = name.split('/');
+
+      if (segments.length == 0)
+        throw new TypeError('No module name provided');
+
+      // current segment
+      var i = 0;
+      // is the module name relative
+      var rel = false;
+      // number of backtracking segments
+      var dotdots = 0;
+      if (segments[0] == '.') {
+        i++;
+        if (i == segments.length)
+          throw new TypeError('Illegal module name "' + name + '"');
+        rel = true;
+      }
+      else {
+        while (segments[i] == '..') {
+          i++;
+          if (i == segments.length)
+            throw new TypeError('Illegal module name "' + name + '"');
+        }
+        if (i)
+          rel = true;
+        dotdots = i;
+      }
+
+      for (var j = i; j < segments.length; j++) {
+        var segment = segments[j];
+        if (segment == '' || segment == '.' || segment == '..')
+          throw new TypeError('Illegal module name "' + name + '"');
+      }
+
+      if (!rel)
+        return name;
+
+      // build the full module name
+      var normalizedParts = [];
+      var parentParts = (parentName || '').split('/');
+      var normalizedLen = parentParts.length - 1 - dotdots;
+
+      normalizedParts = normalizedParts.concat(parentParts.splice(0, parentParts.length - 1 - dotdots));
+      normalizedParts = normalizedParts.concat(segments.splice(i, segments.length - i));
+
+      return normalizedParts.join('/');
+    },
+    locate: function(load) {
+      var name = load.name;
+
+      // NB no specification provided for System.paths, used ideas discussed in https://github.com/jorendorff/js-loaders/issues/25
+
+      // most specific (longest) match wins
+      var pathMatch = '', wildcard;
+
+      // check to see if we have a paths entry
+      for (var p in this.paths) {
+        var pathParts = p.split('*');
+        if (pathParts.length > 2)
+          throw new TypeError('Only one wildcard in a path is permitted');
+
+        // exact path match
+        if (pathParts.length == 1) {
+          if (name == p && p.length > pathMatch.length)
+            pathMatch = p;
+        }
+
+        // wildcard path match
+        else {
+          if (name.substr(0, pathParts[0].length) == pathParts[0] && name.substr(name.length - pathParts[1].length) == pathParts[1]) {
+            pathMatch = p;
+            wildcard = name.substr(pathParts[0].length, name.length - pathParts[1].length - pathParts[0].length);
+          }
+        }
+      }
+
+      var outPath = this.paths[pathMatch];
+      if (wildcard)
+        outPath = outPath.replace('*', wildcard);
+
+      return toAbsoluteURL(this.baseURL, outPath);
+    },
+    fetch: function(load) {
+      return new Promise(function(resolve, reject) {
+        fetchTextFromURL(toAbsoluteURL(this.baseURL, load.address), function(source) {
+          resolve(source);
+        }, reject);
+      });
+    }
+  });
+
+  if (isBrowser) {
+    var href = window.location.href.split('#')[0].split('?')[0];
+    System.baseURL = href.substring(0, href.lastIndexOf('/') + 1);
+  }
+  else {
+    System.baseURL = './';
+  }
+  System.paths = { '*': '*.js' };
+
+  if (global.System && global.traceur)
+    global.traceurSystem = global.System;
+
+  if (isBrowser)
+    global.System = System;
+
+  // <script type="module"> support
+  // allow a data-init function callback once loaded
+  if (isBrowser) {
+    var curScript = document.getElementsByTagName('script');
+    curScript = curScript[curScript.length - 1];
+
+    function completed() {
+      document.removeEventListener( "DOMContentLoaded", completed, false );
+      window.removeEventListener( "load", completed, false );
+      ready();
+    }
+
+    function ready() {
+      var scripts = document.getElementsByTagName('script');
+
+      for (var i = 0; i < scripts.length; i++) {
+        var script = scripts[i];
+        if (script.type == 'module') {
+          // <script type="module" name="" src=""> support
+          var name = script.getAttribute('name');
+          var address = script.getAttribute('src');
+          var source = script.innerHTML;
+
+          (name
+            ? System.define(name, source, { address: address })
+            : System.module(source, { address: address })
+          ).then(function() {}, function(err) { nextTick(function() { throw err; }); });
+        }
+      }
+    }
+
+    // DOM ready, taken from https://github.com/jquery/jquery/blob/master/src/core/ready.js#L63
+    if (document.readyState === 'complete') {
+      setTimeout(ready);
+    }
+    else if (document.addEventListener) {
+      document.addEventListener('DOMContentLoaded', completed, false);
+      window.addEventListener('load', completed, false);
+    }
+
+    // run the data-init function on the script tag
+    if (curScript.getAttribute('data-init'))
+      window[curScript.getAttribute('data-init')]();
+  }
+
+  if (typeof exports === 'object')
+    module.exports = System;
+
+})(typeof global !== 'undefined' ? global : this);


### PR DESCRIPTION
Uses two-phase declaration / execution process to separate
  dependency binding from execution.

Includes https://github.com/ModuleLoader/es6-module-loader.git as third-party/, License MIT, for testing circular references.  Adds tests for loading with circular references.

Closes #971, #953, #424, #107
