### PR TITLE
Fix string decoding in LiteralToken.js

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ James Lal <james@lightsofapollo.com>
 Galimzyanov Dmitry <dmt021@gmail.com>
 Rick Waldron <waldron.rick@gmail.com>
 A. Matías Quezada <amatiasq@gmail.com>
+Sam Day <sday@atlassian.com>

--- a/bin/traceur.js
+++ b/bin/traceur.js
@@ -5750,7 +5750,7 @@ System.register("traceur@0.0.40/src/syntax/LiteralToken", [], function() {
     writable: true
   }), Object.defineProperty($__31, "parseEscapeSequence", {
     value: function() {
-      var ch = this.next();
+      var ch = this.next().value;
       switch (ch) {
         case '\n':
         case '\r':
@@ -5772,9 +5772,9 @@ System.register("traceur@0.0.40/src/syntax/LiteralToken", [], function() {
         case 'v':
           return '\v';
         case 'x':
-          return String.fromCharCode(parseInt(this.next() + this.next(), 16));
+          return String.fromCharCode(parseInt(this.next().value + this.next().value, 16));
         case 'u':
-          return String.fromCharCode(parseInt(this.next() + this.next() + this.next() + this.next(), 16));
+          return String.fromCharCode(parseInt(this.next().value + this.next().value + this.next().value + this.next().value, 16));
         default:
           if (Number(ch) < 8)
             throw new Error('Octal literals are not supported');

--- a/src/syntax/LiteralToken.js
+++ b/src/syntax/LiteralToken.js
@@ -72,7 +72,7 @@ class StringParser {
   }
 
   parseEscapeSequence() {
-    var ch = this.next();
+    var ch = this.next().value;
     switch (ch) {
       case '\n':  // <LF>
       case '\r':  // <CR>
@@ -95,11 +95,11 @@ class StringParser {
         return '\v';
       case 'x':
         // 2 hex digits
-        return String.fromCharCode(parseInt(this.next() + this.next(), 16));
+        return String.fromCharCode(parseInt(this.next().value + this.next().value, 16));
       case 'u':
         // 4 hex digits
-        return String.fromCharCode(parseInt(this.next() + this.next() +
-                                            this.next() + this.next(), 16));
+        return String.fromCharCode(parseInt(this.next().value + this.next().value +
+                                            this.next().value + this.next().value, 16));
       default:
         if (Number(ch) < 8)
           throw new Error('Octal literals are not supported');

--- a/test/unit/syntax/LiteralToken.js
+++ b/test/unit/syntax/LiteralToken.js
@@ -1,0 +1,39 @@
+// Copyright 2011 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+suite('LiteralToken.js', function() {
+
+  var LiteralToken =
+      $traceurRuntime.ModuleStore.getForTesting('src/syntax/LiteralToken').LiteralToken;
+
+  var TokenType = 
+      $traceurRuntime.ModuleStore.getForTesting('src/syntax/TokenType');
+
+  test('Decode newline', function() {
+    var token = new LiteralToken(TokenType.STRING, '"hello\nworld"');
+    assert.equal(token.processedValue, "hello\nworld");
+
+  });
+
+  test('Decode hex escape', function() {
+    var token = new LiteralToken(TokenType.STRING, '"\x21\"');
+    assert.equal(token.processedValue, "!");    
+  });
+
+  test('Decode unicode escape', function() {
+    var token = new LiteralToken(TokenType.STRING, '"\u2713"');
+    assert.equal(token.processedValue, "✓");    
+  });
+
+});


### PR DESCRIPTION
`StringParser.parseEscapeSequence` was switching on the result of `StringParser.next` as if it were a raw value, but it's actually a generator result (`{value: foo, done: false}`). This meant that it was failing to decode escape sequences properly. i.e a string like `hello\nworld` was actually being parsed into `hello[Object object]world`. I have no idea how this ever worked. I wrote a couple of tests so you can see what I mean.
