### PR TITLE
Enable console and log transcoded source for generated-code-dependencies...

### DIFF
--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -116,7 +116,7 @@ suite('context test', function() {
           assert.isNull(error);
           executeFileWithRuntime(tempFileName);
           var module = System.get('test/unit/node/resources/import-another-x');
-          assert.equal(global.another_result, 17);
+          assert.equal(global.anotherResult, 17);
           done();
         });
   });

--- a/test/unit/node/resources/import-another-x.js
+++ b/test/unit/node/resources/import-another-x.js
@@ -1,2 +1,2 @@
 export var iAmNotScript = true;
-this.another_result = 17;  // To verify execution, test this global value.
+this.anotherResult = 17;  // To verify execution, test this global value.


### PR DESCRIPTION
When running generated-code-dependencies, the transcoded source and 
the traceur-runtime are combined and executed in a new JS sandbox. The 
sandbox does not contain the `console` object so console logging fails.  

Add flag true to executeFileWithRuntime() in generated-code-dependencies.js
to add the console for logging.
