### PR TITLE
Add support for --inline-sourcemap

### DIFF
--- a/src/node/command.js
+++ b/src/node/command.js
@@ -28,6 +28,7 @@ commandLine.setMaxListeners(100);
 
 var traceur = require('./traceur.js');
 var interpret = require('./interpreter.js');
+var compiler = require('./compiler.js');
 
 // The System object requires traceur, but we want it set for everything that
 // follows. The module sets global.System as a side-effect.
@@ -45,9 +46,17 @@ commandLine.option('--module <fileName>', 'Parse as Module', function(fileName) 
 commandLine.option('--out <FILE>', 'Compile all input files into a single file');
 commandLine.option('--dir <INDIR> <OUTDIR>', 'Compile an input directory of modules into an output directory');
 
+commandLine.sourceMapType = compiler.SourceMapType.NONE;
 commandLine.option('--sourcemap', 'Generate source maps');
 commandLine.on('sourcemap', function() {
-  commandLine.sourceMaps = traceur.options.sourceMaps = true;
+  commandLine.sourceMapType = compiler.SourceMapType.EXTERNAL;
+  traceur.options.sourceMaps = true;
+});
+
+commandLine.option('--inline-sourcemap', 'Generate inline source maps');
+commandLine.on('inline-sourcemap', function() {
+  commandLine.sourceMapType = compiler.SourceMapType.INLINE;
+  traceur.options.sourceMaps = true;
 });
 
 commandLine.option('--longhelp', 'Show all known options');
@@ -115,7 +124,6 @@ if (!shouldExit && !rootSources.length) {
   process.exit(1);
 }
 
-var compiler = require('./compiler.js');
 var compileToSingleFile = compiler.compileToSingleFile;
 var compileToDirectory = compiler.compileToDirectory;
 var out = commandLine.out;
@@ -124,9 +132,9 @@ if (!shouldExit) {
   if (out) {
     var isSingleFileCompile = /\.js$/.test(out);
     if (isSingleFileCompile)
-      compileToSingleFile(out, rootSources, commandLine.sourceMaps);
+      compileToSingleFile(out, rootSources, commandLine.sourceMapType);
     else
-      compileToDirectory(out, rootSources, commandLine.sourceMaps);
+      compileToDirectory(out, rootSources, commandLine.sourceMapType);
   } else if (dir) {
     if (rootSources.length !== 1)
       throw new Error('Compile all in directory requires exactly one input filename');


### PR DESCRIPTION
This changeset add support for the `--inline-sourcemap` option. When specified, it adds the source-map as a base64-encoded string at the end of a compiled file `foo.js`, instead of writing it in a separate `foo.map` file.

Notably, this enables the use of traceur's source-maps with browserify, that only supports merging inline source-maps (that's my initial use case). Moreover, inline source-maps are much easier to manipulate since a single stream contains all the information (compiled JS + source-map). If we can at some point output to stdout, we could have fancy all-in-one command-lines:

```
cat es6-foo.js | traceur | do-smth-else > es5-foo.bar
```

Where `do-smth-else` do more transformations, including on the source map; without any intermediary disk file.

This changeset is not breaking the API.

Seems to be related with #892.
