### PR TITLE
traceur.compile moduleName fix

### DIFF
--- a/src/node/api.js
+++ b/src/node/api.js
@@ -80,6 +80,8 @@ function compile(content, options) {
   if (moduleName === true || options.modules == 'register' || options.modules == 'inline') {
     moduleName = options.filename.replace(/\.js$/, '');
     moduleName = path.relative(options.cwd, moduleName).replace(/\\/g,'/');
+  }
+  if (moduleName) {
     transformer = new AttachModuleNameTransformer(moduleName);
     tree = transformer.transformAny(tree);
   }

--- a/test/node-api-test.js
+++ b/test/node-api-test.js
@@ -31,4 +31,29 @@ suite('node public api', function() {
       'module defines its path'
     );
   });
+
+  test('named amd', function() {
+    var compiled = traceur.compile(contents, {
+      // absolute path is important
+      filename: path,
+
+      // build ES6 style modules rather then cjs
+      modules: 'amd',
+
+      // enforce a module name in the AMD define
+      moduleName: 'test-module'
+    });
+
+    assert.deepEqual(compiled.errors, []);
+    assert.ok(compiled.js, 'can compile');    
+
+    var gotName;
+    var define = function(name) {
+      gotName = name;
+    }
+
+    eval(compiled.js);
+
+    assert.ok(gotName == 'test-module', 'module defines into named AMD');
+  });
 });


### PR DESCRIPTION
The `moduleName` option isn't currently being added when compiling a module into AMD or instantiate with the NodeJS APi. This fixes that allowing the `moduleName` to be set.
