### PR TITLE
1088 Extend API to allow access to compiler

### DIFF
--- a/src/node/api.js
+++ b/src/node/api.js
@@ -21,6 +21,13 @@
 
 var path = require('path');
 var traceur = require('./traceur.js');
+// require compiler so we can export it for consumers that want to do a single file concatenation using the
+// traceur es6 module based topological sort.  for instance, gulp-traceur
+var compiler = require('./compiler');
+// The System object requires traceur, but we want it set for everything that
+// follows. The module sets global.System as a side-effect.
+// load this to avoid getting an error about not setting the baseURL.
+require('./System.js');
 
 var ToCommonJSCompiler = traceur.ToCommonJSCompiler;
 
@@ -59,5 +66,8 @@ var RUNTIME_PATH = path.join(__dirname, '../../bin/traceur-runtime.js');
 module.exports = {
   __proto__: traceur,
   compile: compile,
+  // export this for consumers that want to do a single file concatenation using the
+  // traceur es6 module based topological sort.  for instance, gulp-traceur
+  compiler: compiler,
   RUNTIME_PATH: RUNTIME_PATH
 };


### PR DESCRIPTION
I ran the test suite and I didn't see any errors.  There was some strange output though.  Here is what make test output:

node test/unit/runtime/traceur-runtime.js
rm -f -r test/amd-compiled/*
node src/node/to-amd-compiler.js test/amd test/amd-compiled
rm -f -r test.commonjs-compiled/*
node src/node/to-commonjs-compiler.js test/commonjs test/commonjs-compiled
./traceur test/unit/runtime/test_interpret.js
./traceur /Users/david/workspace/traceur-compiler/test/unit/runtime/test_interpret.js
./traceur --out not-written.js \
        test/feature/Modules/Error_ImportDefault.js  2>&1 | sed '1d'
./traceur -v | grep '[0-9]_.[0-9_.[0-9]*'
0.0.45
node_modules/.bin/mocha --ignore-leaks --ui tdd --require test/node-env.js bin/traceur-runtime.js src/node/System.js test/unit/tools/SourceMapMapping.generated.js

  ․․

  2 passing (29ms)

node_modules/.bin/mocha --ignore-leaks --ui tdd --require test/node-env.js test/node-commonjs-test.js test/node-amd-test.js test/node-instantiate-test.js test/node-feature-test.js test/node-api-test.js test/unit/runtime/Loader.js test/unit/runtime/Object.js test/unit/runtime/System.js test/unit/codegeneration/ test/unit/node/ test/unit/semantics/ test/unit/syntax/ test/unit/system/ test/unit/util/

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1134 passing (7s)

/Applications/Xcode.app/Contents/Developer/usr/bin/make test-interpret-throw
./traceur test/unit/runtime/throwsError.js 2>&1 | wc -l | grep '11'
      11
