### PR TITLE
Fix issue with temp variable transformer and multiple this

### DIFF
--- a/src/codegeneration/ArrayComprehensionTransformer.js
+++ b/src/codegeneration/ArrayComprehensionTransformer.js
@@ -47,7 +47,7 @@ import {parseStatement} from './PlaceholderParser';
 export class ArrayComprehensionTransformer extends ComprehensionTransformer {
 
   transformArrayComprehension(tree) {
-    this.pushTempVarState();
+    this.pushTempScope();
 
     var expression = this.transformAny(tree.expression);
 
@@ -62,7 +62,7 @@ export class ArrayComprehensionTransformer extends ComprehensionTransformer {
     var result = this.transformComprehension(tree, statement, functionKind,
                                              tempVarsStatatement,
                                              returnStatement);
-    this.popTempVarState();
+    this.popTempScope();
     return result;
   }
 }

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -262,7 +262,7 @@ export class ClassTransformer extends TempVarTransformer{
   }
 
   transformClassExpression(tree) {
-    this.pushTempVarState();
+    this.pushTempScope();
 
     var name;
     if (tree.name)
@@ -301,7 +301,7 @@ export class ClassTransformer extends TempVarTransformer{
       expression = classCall(func, object, staticObject, superClass);
     }
 
-    this.popTempVarState();
+    this.popTempScope();
 
     return createParenExpression(this.makeStrict_(expression));
   }
@@ -341,7 +341,7 @@ export class ClassTransformer extends TempVarTransformer{
   }
 
   transformSuperInFunctionBody_(methodTree, tree, internalName) {
-    this.pushTempVarState();
+    this.pushTempScope();
     var thisName = this.getTempIdentifier();
     var thisDecl = createVariableStatement(VAR, thisName,
                                            createThisExpression());
@@ -354,7 +354,7 @@ export class ClassTransformer extends TempVarTransformer{
     if (superTransformer.hasSuper)
       this.state_.hasSuper = true;
 
-    this.popTempVarState();
+    this.popTempScope();
 
     if (superTransformer.nestedSuper)
       return createFunctionBody([thisDecl].concat(transformedTree.statements));

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -205,7 +205,7 @@ export class DestructuringTransformer extends TempVarTransformer {
    * @return {ParseTree}
    */
   transformBinaryOperator(tree) {
-    this.pushTempVarState();
+    this.pushTempScope();
 
     var rv;
     if (tree.operator.type == EQUAL && tree.left.isPattern()) {
@@ -214,7 +214,7 @@ export class DestructuringTransformer extends TempVarTransformer {
       rv = super(tree);
     }
 
-    this.popTempVarState();
+    this.popTempScope();
     return rv;
   }
 
@@ -256,7 +256,7 @@ export class DestructuringTransformer extends TempVarTransformer {
       return super.transformVariableDeclarationList(tree);
     }
 
-    this.pushTempVarState();
+    this.pushTempScope();
 
     // Desugar one level of patterns.
     var desugaredDeclarations = [];
@@ -275,7 +275,7 @@ export class DestructuringTransformer extends TempVarTransformer {
             tree.declarationType,
             desugaredDeclarations));
 
-    this.popTempVarState();
+    this.popTempScope();
 
     return transformedTree;
   }
@@ -309,7 +309,7 @@ export class DestructuringTransformer extends TempVarTransformer {
       return superMethod.call(this, tree);
     }
 
-    this.pushTempVarState();
+    this.pushTempScope();
 
     var declarationType, lvalue;
     if (tree.initializer.isPattern()) {
@@ -349,7 +349,7 @@ export class DestructuringTransformer extends TempVarTransformer {
     statements.push(...body.statements);
     body = createBlock(statements);
 
-    this.popTempVarState();
+    this.popTempScope();
 
     return new constr(tree.location, initializer, collection, body);
   }
@@ -379,7 +379,7 @@ export class DestructuringTransformer extends TempVarTransformer {
 
     if (this.parameterDeclarations === null) {
       this.parameterDeclarations = [];
-      this.pushTempVarState();  // Popped in the function body.
+      this.pushTempScope();  // Popped in the function body.
     }
 
     var varName = this.getTempIdentifier();
@@ -404,7 +404,7 @@ export class DestructuringTransformer extends TempVarTransformer {
     this.parameterDeclarations = null;
 
     var result = super(newBody);
-    this.popTempVarState();
+    this.popTempScope();
     return result;
   }
 

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -80,13 +80,13 @@ export class ModuleTransformer extends TempVarTransformer {
   transformModule(tree) {
     this.moduleName = tree.moduleName;
 
-    this.pushTempVarState();
+    this.pushTempScope();
 
     var statements = this.transformList(tree.scriptItemList);
 
     statements = this.appendExportStatement(statements);
 
-    this.popTempVarState();
+    this.popTempScope();
 
     statements = this.wrapModule(this.moduleProlog().concat(statements));
 

--- a/src/codegeneration/SpreadTransformer.js
+++ b/src/codegeneration/SpreadTransformer.js
@@ -98,7 +98,7 @@ export class SpreadTransformer extends TempVarTransformer {
     var operand = this.transformAny(tree.operand);
     var functionObject, contextObject;
 
-    this.pushTempVarState();
+    this.pushTempScope();
 
     if (operand.type == MEMBER_EXPRESSION) {
       // expr.fun(a, ...b, c)
@@ -137,7 +137,7 @@ export class SpreadTransformer extends TempVarTransformer {
       functionObject = operand;
     }
 
-    this.popTempVarState();
+    this.popTempScope();
 
     // functionObject.apply(contextObject, expandedArgs)
     var arrayExpression = this.createArrayFromElements_(tree.args.args);

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -205,7 +205,7 @@ export class CPSTransformer extends TempVarTransformer {
   }
 
   transformFunctionBody(tree) {
-    this.pushTempVarState();
+    this.pushTempScope();
 
     // NOTE: tree may contain state machines already ...
     var oldLabels = this.clearLabels_();
@@ -215,7 +215,7 @@ export class CPSTransformer extends TempVarTransformer {
 
     this.restoreLabels_(oldLabels);
 
-    this.popTempVarState();
+    this.popTempScope();
     return machine == null ? transformedTree : machine;
   }
 

--- a/test/feature/ArrayComprehension/ArgumentsInComprehension.js
+++ b/test/feature/ArrayComprehension/ArgumentsInComprehension.js
@@ -1,0 +1,11 @@
+// https://github.com/google/traceur-compiler/issues/1086
+
+function f() {
+  var a = [for (x of [1]) arguments[0]];
+  var b = [for (x of [1]) arguments[0]];
+  assert.deepEqual(a, [arguments[0]]);
+  assert.deepEqual(a, [42]);
+  assert.deepEqual(a, b);
+}
+
+f(42);

--- a/test/feature/ArrayComprehension/ThisInComprehension.js
+++ b/test/feature/ArrayComprehension/ThisInComprehension.js
@@ -1,0 +1,13 @@
+// https://github.com/google/traceur-compiler/issues/1086
+
+var object = {};
+
+function f() {
+  var a = [for (x of [1]) this];
+  var b = [for (x of [1]) this];
+  assert.deepEqual(a, [this]);
+  assert.deepEqual(a, [object]);
+  assert.deepEqual(a, b);
+}
+
+f.call(object);


### PR DESCRIPTION
The temp var transformer was storing the this temp bindings on the
wrong scope object.

This renames the methods to make the two different scopes clearer.

Fixes #1086
