### PR TITLE
Pass options from Compiler.script to .compile.

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -94,14 +94,14 @@ export class Compiler {
   }
 
   /**
-   * Use Traceur to compile ES6 module source code, using default options
+   * Use Traceur to compile ES6 module source code
    *
    * @param  {string} content ES6 source code.
    * @param  {Object=} options Traceur options to override defaults.
    * @return {Promise<{js: string, errors: Array, sourceMap: string}>} Transpiled code.
    */
-  compile(content, options) {
-    return this.parse({content: content, options: {}}).
+  compile(content, options = {}) {
+    return this.parse({content: content, options: options}).
         then((result) => this.transform(result)).
         then((result) => this.write(result));
   }

--- a/test/unit/Compiler.js
+++ b/test/unit/Compiler.js
@@ -69,6 +69,18 @@ suite('Compiler', function() {
     });
   });
 
+  test('Compiler script', function(done) {
+    var compiler = new Compiler();
+    var content = 'var x = 42;\n';
+
+    var result = compiler.script(content).
+      then(function(result) {
+        assert.equal(result.js, content);
+        assert.equal(result.errors.length, 0);
+        done();
+      }).catch(done);
+  });
+  
   test('Compiler options locked', function() {
     Object.keys(traceur.options).forEach(function(key) {
       var mismatches = [];
@@ -84,4 +96,5 @@ suite('Compiler', function() {
       assert.equal(mismatches.length, 0);
     });
   });
+
 });


### PR DESCRIPTION
Test Compiler.script.
Fixes #1107
