### PR TITLE
Re-exporting defaults

### DIFF
--- a/test/feature/Modules/ImportReExportDefault.js
+++ b/test/feature/Modules/ImportReExportDefault.js
@@ -1,0 +1,2 @@
+import x from './resources/re-export-default';
+assert.equal(x, 42);

--- a/test/feature/Modules/ImportReExportDefaultAs.js
+++ b/test/feature/Modules/ImportReExportDefaultAs.js
@@ -1,0 +1,2 @@
+import {x} from './resources/re-export-default-as';
+assert.equal(x, 42);

--- a/test/feature/Modules/resources/re-export-default-as.js
+++ b/test/feature/Modules/resources/re-export-default-as.js
@@ -1,0 +1,1 @@
+export {default as x} from './default';

--- a/test/feature/Modules/resources/re-export-default.js
+++ b/test/feature/Modules/resources/re-export-default.js
@@ -1,0 +1,1 @@
+export {default} from './default';


### PR DESCRIPTION
When we parse ExportSpecifier we allow keywords but if we later find
that there is no from token following the ExportSpecifierSet we go
back and report errors for any possible keyword we find.

Fixes #816
