### PR TITLE
Remove Loader.options.

### DIFF
--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -18,6 +18,7 @@ import {ObjectMap} from '../util/ObjectMap';
 import {canonicalizeUrl, isAbsolute, resolveUrl} from '../util/url';
 import {getUid} from '../util/uid';
 import {toSource} from '../outputgeneration/toSource';
+import {options} from '../options';
 
 var NOT_STARTED = 0;
 var LOADING = 1;
@@ -285,10 +286,6 @@ export class InternalLoader {
     return codeUnit.promise;
   }
 
-  get options() {
-    return this.loaderHooks.options;
-  }
-
   sourceMapInfo(normalizedName, type) {
     var key = this.getKey(normalizedName, type);
     var codeUnit = this.cache.get(key);
@@ -448,7 +445,7 @@ export class InternalLoader {
     codeUnit.state = TRANSFORMED;
     var filename = codeUnit.address || codeUnit.normalizedName;
     [metadata.transcoded, metadata.sourceMap] =
-        toSource(metadata.transformedTree, this.options, filename);
+        toSource(metadata.transformedTree, options, filename);
     if (codeUnit.address && metadata.transcoded)
       metadata.transcoded += '//# sourceURL=' + codeUnit.address;
     codeUnit.instantiate();

--- a/src/runtime/LoaderHooks.js
+++ b/src/runtime/LoaderHooks.js
@@ -225,10 +225,6 @@ export class LoaderHooks {
     this.checkForErrors((reporter) => buildExportList(deps, loader, reporter));
   }
 
-  get options() {
-    return options;
-  }
-
   bundledModule(name) {
     return this.moduleStore_.bundleStore[name];
   }

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -123,13 +123,6 @@ export class TraceurLoader extends Loader {
   }
 
   /**
-  * @return {Object} traceur-specific options object
-  */
-  get options() {
-    return this.internalLoader_.options;
-  }
-
-  /**
    * @param {string} normalizedName
    * @param {string} 'module' or 'script'
    */

--- a/test/unit/es6/tools/SourceMapMapping.js
+++ b/test/unit/es6/tools/SourceMapMapping.js
@@ -16,8 +16,11 @@
 import {SourceMapConsumer}
     from '../../../../src/outputgeneration/SourceMapIntegration';
 import {OriginalSourceMapMapping} from '../../../../demo/SourceMapMapping';
+var options = traceur.options;
 
-System.options.sourceMaps = true;
+// Force sourceMaps on for test.
+options.sourceMaps = true;
+
 var testModuleName = System.normalize('./test/unit/runtime/test_a');
 var whenSourceMapMapping = System.import(testModuleName).then(() => {
   var mapInfo = System.sourceMapInfo(testModuleName, 'module');

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -30,8 +30,7 @@ suite('Loader.js', function() {
 
   teardown(function() {
     assert.isFalse(reporter.hadError());
-    var loader = getLoader();
-    loader.options.modules = 'register';
+    traceur.options.modules = 'register';
     System.baseURL = baseURL;
   });
 
@@ -97,11 +96,11 @@ suite('Loader.js', function() {
 
   test('Loader.Script.Named', function(done) {
     var loader = getLoader();
-    loader.options.sourceMaps = true;
+    traceur.options.sourceMaps = true;
     var name = '43';
     loader.script('(function(x = 43) { return x; })()', {name: name}).then(
       function(result) {
-        loader.options.sourceMaps = false;
+        traceur.options.sourceMaps = false;
         var normalizedName = System.normalize(name);
         var sourceMapInfo = loader.sourceMapInfo(normalizedName, 'script');
         assert(sourceMapInfo.sourceMap);
@@ -245,7 +244,7 @@ suite('Loader.js', function() {
 
   test('LoaderDefine.Instantiate', function(done) {
     var loader = getLoader();
-    loader.options.modules = 'instantiate';
+    traceur.options.modules = 'instantiate';
     var name = './test_instantiate';
     var src = 'export {name as a} from \'./test_a\';\n' +
     'export var dd = 8;\n';
@@ -316,7 +315,7 @@ suite('Loader.js', function() {
   test('Loader.defineWithSourceMap', function(done) {
     var normalizedName = System.normalize('./test_define_with_source_map');
     var loader = getLoader();
-    loader.options.sourceMaps = true;
+    traceur.options.sourceMaps = true;
     var src = 'export {name as a} from \'./test_a\';\nexport var d = 4;\n';
     loader.define(normalizedName, src, {}).then(function() {
       var sourceMapInfo = loader.sourceMapInfo(normalizedName, 'module');
@@ -375,7 +374,7 @@ suite('Loader.js', function() {
     var src = "  import {name} from './test_a';";
 
     var loader = getLoader();
-    loader.options.sourceMap = true;
+    traceur.options.sourceMap = true;
 
     loader.module(src, {}).then(function (mod) {
       assert(mod);


### PR DESCRIPTION
Switch to global traceur.options for now.
Later we should use loader hooks with options to avoid passing via global.
