### PR TITLE
Option --inline <filename> to compile one module using module='inline'

### DIFF
--- a/src/node/command.js
+++ b/src/node/command.js
@@ -44,7 +44,7 @@ commandLine.option('--module <fileName>', 'Parse as Module', function(fileName) 
 
 commandLine.option('--inline <fileName>', 'Parse as Module, format \'inline\'',
   function(fileName) {
-   rootSources.push({name: fileName, type: 'inline'});
+   rootSources.push({name: fileName, type: 'module', format: 'inline'});
   }
 );
 

--- a/src/node/recursiveModuleCompile.js
+++ b/src/node/recursiveModuleCompile.js
@@ -183,7 +183,7 @@ function recursiveModuleCompile(fileNamesAndTypes, options, callback, errback) {
       loadFunction = loader.loadAsScript;
     } else {
       name = name.replace(/\.js$/,'');
-      if (input.type === 'inline')
+      if (input.format === 'inline')
         options.modules = 'inline';
       else if (options.modules === 'register')
         doEvaluateModule = true;

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -190,13 +190,9 @@ suite('context test', function() {
           assert.isNull(error);
           executeFileWithRuntime(tempFileName).then(function() {
             assert.equal(global.aGlobal, 'iAmGlobal');
-            try {
-              ('global', eval)(source);
-              assert.equal(global.sandwich, 'iAmGlobal pastrami');
-              done();
-            } catch(ex) {
-              done(ex);
-            }
+            ('global', eval)(source);
+            assert.equal(global.sandwich, 'iAmGlobal pastrami');
+            done();
           }).catch(done);
         });
   });


### PR DESCRIPTION
This special purpose option supports bootstrapping with
module-based source that sets global values as side-effects.
