### PR TITLE
Update make script to build gh-pages branch w/o rebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,8 @@ git-gh-rebase: git-update-version
 	cp gh-pages.gitignore .gitignore # tell git to commit built files.
 	$(MAKE) clean # trees.json may have changed.
 	$(MAKE) test # build binaries for VERSION
+	git add src/
+	git add bin/
 	./traceur -v | xargs -I VERSION git commit -a -m "Commit binaries for VERSION"
 	git push -f upstream upstream_gh_pages:gh-pages
 


### PR DESCRIPTION
TBR=@arv

(Half of this patch landed in 89407c5c62caccace33671df8db6bbaadddcbe83. Scripts commited to git to manipulate git branches... )
