### PR TITLE
Fixes #1142: select appropriate '@@iterator' in runtime for `for of` statements in Firefox

### DIFF
--- a/src/runtime/polyfills/polyfills.js
+++ b/src/runtime/polyfills/polyfills.js
@@ -83,10 +83,30 @@ function polyfillPromise(global) {
 }
 
 function polyfillCollections(global) {
+  var SymbolIterator = $traceurRuntime.toProperty(global.Symbol.iterator);
   if (!global.Map)
     global.Map = Map;
   if (!global.Set)
     global.Set = Set;
+
+  var map = new global.Map();
+  var set = new global.Set();
+  var mapIterator = map.entries().constructor;
+  var setIterator = set.values().constructor;
+  if (undefined === mapIterator.prototype[SymbolIterator]) {
+    mapIterator.prototype[SymbolIterator] = function() {
+      return this;
+    };
+  }
+  if (undefined === setIterator.prototype[SymbolIterator]) {
+    setIterator.prototype[SymbolIterator] = function() {
+      return this;
+    };
+  }
+  if (undefined === global.Map.prototype[SymbolIterator])
+    global.Map.prototype[SymbolIterator] = global.Map.prototype.entries;
+  if (undefined === global.Set.prototype[SymbolIterator])
+    global.Set.prototype[SymbolIterator] = global.Set.prototype.values;
 }
 
 function polyfillString(String) {


### PR DESCRIPTION
[[Work in progress - not for merging]]:

This CL "works" in the browser (Chrome stable, Firefox Nightly) --- http://jsfiddle.net/j4J7B/ (build from this CL + a slightly modified (console.log rather than assertions) compiled version of one of the failing tests, with options from test-utils.js and the options from the head of the file), but, as mentioned above, fails two tests in mocha.

Perhaps this can be improved by someone who knows the traceur internals better.
