### PR TITLE
Improve error messages from getProtoParent.

### DIFF
--- a/src/runtime/classes.js
+++ b/src/runtime/classes.js
@@ -96,10 +96,11 @@
       var prototype = superClass.prototype;
       if ($Object(prototype) === prototype || prototype === null)
         return superClass.prototype;
+      throw new $TypeError('super prototype must be an Object or null');
     }
     if (superClass === null)
       return null;
-    throw new $TypeError();
+    throw new $TypeError('Super expression must either be null or a function');
   }
 
   function defaultSuperCall(self, homeObject, args) {

--- a/test/feature/Classes/ExtendNonConstructableFunction.js
+++ b/test/feature/Classes/ExtendNonConstructableFunction.js
@@ -1,11 +1,11 @@
 
 assert.throw(function() {
-  class C extends Math.pow {}
-}, TypeError);
+  class C extends Math {}
+}, 'Super expression must either be null or a function');
 
 assert.throw(function() {
   function f() {}
   // prototype needs to be an Object or null.
   f.prototype = 42;
   class C extends f {}
-}, TypeError);
+}, 'super prototype must be an Object or null');


### PR DESCRIPTION
Extend coverage to cover super prototype not an object.
