### PR TITLE
add failing tests for default function export

### DIFF
--- a/test/feature/Modules/ImportDefault.js
+++ b/test/feature/Modules/ImportDefault.js
@@ -9,3 +9,12 @@ assert.equal(D, 4);
 
 import f from './resources/default-function';
 assert.equal(f(), 123);
+
+import f from './resources/default-function2';
+assert.equal(f(), 123);
+
+import f from './resources/default-function3';
+assert.equal(f(), 123);
+
+import f from './resources/default-function4';
+assert.equal(f(), 123);

--- a/test/feature/Modules/resources/default-function2.js
+++ b/test/feature/Modules/resources/default-function2.js
@@ -1,0 +1,3 @@
+export default function() {
+  return 123;
+}

--- a/test/feature/Modules/resources/default-function3.js
+++ b/test/feature/Modules/resources/default-function3.js
@@ -1,0 +1,3 @@
+export var default = function() {
+  return 123;
+}

--- a/test/feature/Modules/resources/default-function4.js
+++ b/test/feature/Modules/resources/default-function4.js
@@ -1,0 +1,3 @@
+export function default() {
+  return 123;
+}


### PR DESCRIPTION
The first one seems to be a bug.

The second two are to do with allowing the default token, so perhaps these are not as urgent and could be omitted.
