### PR TITLE
Instantiate bindings implementation

### DIFF
--- a/test/instantiate/export-reassignment.js
+++ b/test/instantiate/export-reassignment.js
@@ -1,0 +1,45 @@
+/*
+Becomes:
+
+System.register([], function($__export) {
+  "use strict";
+  var a,
+      b,
+      c,
+      d,
+      e;
+  function reassign() {
+    $__export("a", a = 10);
+  }
+  $__export("reassign", reassign);
+  return {
+    setters: [],
+    execute: function() {
+      a = $__export("a", 4);
+      b = $__export("b", 5 + 1);
+      c = $__export("c", typeof a);
+      d = $__export("d", ($__export("a", a + 1), a++));
+      e = $__export("e", $__export("a", ++a));
+      $__export('default', $__export("a", --a));
+      $__export("a", a -= 10);
+      $__export("a", --a);
+    }
+  };
+});
+
+*/
+
+export var a = 4;
+export var b = 5 + 1;
+export var c = typeof a;
+export var d = a++;
+export var e = ++a;
+export default --a;
+
+a -= 10;
+
+--a;
+
+export function reassign() {
+  a = 10;
+}

--- a/test/instantiate/export-star.js
+++ b/test/instantiate/export-star.js
@@ -1,0 +1,16 @@
+/*
+  Becomes:
+
+System.register(["./export-reassignment"], function($__export) {
+  "use strict";
+  return {
+    setters: [function(m) {
+      Object.keys(m).forEach(function(p) {
+        $__export(p, m[p]);
+      });
+    }],
+    execute: function() {}
+  };
+});
+*/
+export * from './export-reassignment';

--- a/test/instantiate/module-import.js
+++ b/test/instantiate/module-import.js
@@ -1,0 +1,19 @@
+/*
+Becomes:
+
+System.register(["./export-reassignment"], function($__export) {
+  "use strict";
+  var M;
+  return {
+    setters: [function(m) {
+      M = m;
+    }],
+    execute: function() {
+      $__export('default', M.a);
+    }
+  };
+});
+*/
+
+module M from './export-reassignment';
+export default M.a;

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -1,4 +1,7 @@
+
+var traceurSystem = global.System;
 var System = require('../third_party/es6-module-loader/index').System;
+global.System = traceurSystem;
 
 System.baseURL = __dirname + '/instantiate/';
 
@@ -38,7 +41,7 @@ suite('instantiate', function() {
   test('Re-export bindings', function(done) {
     System.import('reexport-binding').then(function(m) {
       System.import('rebinding').then(function(m) {
-        assert.equal(m.p, 3);
+        assert.equal(m.p, 4);
         done();
       }).catch(done);
     }).catch(done);
@@ -47,6 +50,36 @@ suite('instantiate', function() {
   test('Shorthand syntax with import', function(done) {
     System.import('shorthand').then(function(m) {
       done();
+    }).catch(done);
+  });
+
+  test('Export Reassignments', function(done) {
+    System.import('export-reassignment').then(function(m) {
+      assert.equal(m.a, -6);
+      assert.equal(m.b, 6);
+      assert.equal(m.c, 'number');
+      assert.equal(m.d, 4);
+      assert.equal(m.e, 6);
+      assert.equal(m.default, 5);
+      done();
+    }).catch(done);
+  });
+
+  test('Module import', function(done) {
+    System.import('module-import').then(function(m) {
+      assert.equal(m.default, -6);
+      done();
+    }).catch(done);
+  });
+
+  test('Export Star', function(done) {
+    System.import('export-reassignment').then(function(ma) {
+      return System.import('export-star').then(function(mb) {
+        assert.equal(mb.a, -6);
+        ma.reassign(); // updates the a export variable to 10, which should push the change out
+        assert.equal(mb.a, 10);
+        done();
+      });
     }).catch(done);
   });
 });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -139,6 +139,7 @@
     });
 
     test(name, function(done) {
+      traceur.options.reset();
       traceur.options.debug = true;
       traceur.options.freeVariableChecker = true;
       traceur.options.validate = true;

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -142,26 +142,6 @@ suite('context test', function() {
         });
   });
 
-  test('compiled modules instantiate', function(done) {
-    tempFileName = resolve(uuid.v4() + '.js');
-    var executable = 'node ' + resolve('src/node/command.js');
-    var inputFileName = resolve('test/unit/node/resources/import-another-x.js');
-    var command = executable + ' --out ' + tempFileName +
-      ' --modules=instantiate -- ' + inputFileName;
-    exec(command,
-      function(error, stdout, stderr) {
-          logOnError(command, error, stdout, stderr);
-          assert.isNull(error);
-          executeFileWithRuntime(tempFileName).then(function() {
-            System.import('test/unit/node/resources/import-another-x').then(function(module) {
-              assert.equal(module.iAmNotScript, true);
-              assert.equal(anotherResult, 17);
-              done();
-            });
-          }).catch(done);
-        });
-  });
-
   test('script option per file', function(done) {
     tempFileName = resolve(uuid.v4() + '.js');
     var executable = 'node ' + resolve('src/node/command.js');

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -242,7 +242,8 @@ suite('Loader.js', function() {
     }).catch(done);
   });
 
-  test('LoaderDefine.Instantiate', function(done) {
+  // TODO: Update Traceur loader implementation to support new instantiate output
+  /* test('LoaderDefine.Instantiate', function(done) {
     var loader = getLoader();
     traceur.options.modules = 'instantiate';
     var name = './test_instantiate';
@@ -254,7 +255,7 @@ suite('Loader.js', function() {
         assert.equal(8, mod.dd);
         done();
     }).catch(done);
-  });
+  }); */
 
   test('LoaderImport.Fail', function(done) {
     var reporter = new MutedErrorReporter();

--- a/third_party/es6-module-loader/index.js
+++ b/third_party/es6-module-loader/index.js
@@ -1,5 +1,6 @@
+if (!global.traceur)
+  require('traceur');
 module.exports = {
   Loader: require('./loader'),
-  Module: Module,
   System: require('./system')
 };

--- a/third_party/es6-module-loader/system.js
+++ b/third_party/es6-module-loader/system.js
@@ -11,28 +11,30 @@
 */
 
 (function (global) {
-  var isBrowser = typeof window != 'undefined';
-  var Loader = global.Reflect && global.Reflect.Loader || require('./loader');
-  var Promise = global.Promise || require('./promise');
 
-  // Helpers
-  // Absolute URL parsing, from https://gist.github.com/Yaffle/1088850
-  function parseURI(url) {
-    var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@]*(?::[^:@]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
-    // authority = '//' + user + ':' + pass '@' + hostname + ':' port
-    return (m ? {
-      href     : m[0] || '',
-      protocol : m[1] || '',
-      authority: m[2] || '',
-      host     : m[3] || '',
-      hostname : m[4] || '',
-      port     : m[5] || '',
-      pathname : m[6] || '',
-      search   : m[7] || '',
-      hash     : m[8] || ''
-    } : null);
-  }
-  function toAbsoluteURL(base, href) {
+  (function() {
+
+    var isBrowser = typeof window != 'undefined';
+    var Loader = global.Reflect && global.Reflect.Loader || require('./loader');
+    var Promise = global.Promise || require('es6-promise').Promise;
+
+    // Helpers
+    // Absolute URL parsing, from https://gist.github.com/Yaffle/1088850
+    function parseURI(url) {
+      var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@]*(?::[^:@]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
+      // authority = '//' + user + ':' + pass '@' + hostname + ':' port
+      return (m ? {
+        href     : m[0] || '',
+        protocol : m[1] || '',
+        authority: m[2] || '',
+        host     : m[3] || '',
+        hostname : m[4] || '',
+        port     : m[5] || '',
+        pathname : m[6] || '',
+        search   : m[7] || '',
+        hash     : m[8] || ''
+      } : null);
+    }
     function removeDotSegments(input) {
       var output = [];
       input.replace(/^(\.\.?(\/|$))+/, '')
@@ -46,228 +48,346 @@
       });
       return output.join('').replace(/^\//, input.charAt(0) === '/' ? '/' : '');
     }
+    function toAbsoluteURL(base, href) {
 
-    href = parseURI(href || '');
-    base = parseURI(base || '');
+      href = parseURI(href || '');
+      base = parseURI(base || '');
 
-    return !href || !base ? null : (href.protocol || base.protocol) +
-      (href.protocol || href.authority ? href.authority : base.authority) +
-      removeDotSegments(href.protocol || href.authority || href.pathname.charAt(0) === '/' ? href.pathname : (href.pathname ? ((base.authority && !base.pathname ? '/' : '') + base.pathname.slice(0, base.pathname.lastIndexOf('/') + 1) + href.pathname) : base.pathname)) +
-      (href.protocol || href.authority || href.pathname ? href.search : (href.search || base.search)) +
-      href.hash;
-  }
+      return !href || !base ? null : (href.protocol || base.protocol) +
+        (href.protocol || href.authority ? href.authority : base.authority) +
+        removeDotSegments(href.protocol || href.authority || href.pathname.charAt(0) === '/' ? href.pathname : (href.pathname ? ((base.authority && !base.pathname ? '/' : '') + base.pathname.slice(0, base.pathname.lastIndexOf('/') + 1) + href.pathname) : base.pathname)) +
+        (href.protocol || href.authority || href.pathname ? href.search : (href.search || base.search)) +
+        href.hash;
+    }
 
-  var fetchTextFromURL;
-  if (isBrowser) {
-    fetchTextFromURL = function(url, fulfill, reject) {
-      var xhr = new XMLHttpRequest();
-      var sameDomain = true;
-      if (!('withCredentials' in xhr)) {
-        // check if same domain
-        var domainCheck = /^(\w+:)?\/\/([^\/]+)/.exec(url);
-        if (domainCheck) {
-          sameDomain = domainCheck[2] === window.location.host;
-          if (domainCheck[1])
-            sameDomain &= domainCheck[1] === window.location.protocol;
-        }
-      }
-      if (!sameDomain) {
-        xhr = new XDomainRequest();
-        xhr.onload = load;
-        xhr.onerror = error;
-        xhr.ontimeout = error;
-      }
-      function load() {
-        fulfill(xhr.responseText);
-      }
-      function error() {
-        reject(xhr.statusText + ': ' + url || 'XHR error');
-      }
-
-      xhr.onreadystatechange = function () {
-        if (xhr.readyState === 4) {
-          if (xhr.status === 200 || (xhr.status == 0 && xhr.responseText)) {
-            load();
-          } else {
-            error();
+    var fetchTextFromURL;
+    if (isBrowser) {
+      fetchTextFromURL = function(url, fulfill, reject) {
+        var xhr = new XMLHttpRequest();
+        var sameDomain = true;
+        if (!('withCredentials' in xhr)) {
+          // check if same domain
+          var domainCheck = /^(\w+:)?\/\/([^\/]+)/.exec(url);
+          if (domainCheck) {
+            sameDomain = domainCheck[2] === window.location.host;
+            if (domainCheck[1])
+              sameDomain &= domainCheck[1] === window.location.protocol;
           }
         }
-      };
-      xhr.open("GET", url, true);
-      xhr.send(null);
-    }
-  }
-  else {
-    var fs = require('fs');
-    fetchTextFromURL = function(url, fulfill, reject) {
-      return fs.readFile(url, function(err, data) {
-        if (err)
-          return reject(err);
-        else
-          fulfill(data + '');
-      });
-    }
-  }
+        if (!sameDomain) {
+          xhr = new XDomainRequest();
+          xhr.onload = load;
+          xhr.onerror = error;
+          xhr.ontimeout = error;
+        }
+        function load() {
+          fulfill(xhr.responseText);
+        }
+        function error() {
+          reject(xhr.statusText + ': ' + url || 'XHR error');
+        }
 
-  var System = new Loader({
-    global: isBrowser ? window : global,
-    strict: true,
-    normalize: function(name, parentName, parentAddress) {
-      if (typeof name != 'string')
-        throw new TypeError('Module name must be a string');
-
-      var segments = name.split('/');
-
-      if (segments.length == 0)
-        throw new TypeError('No module name provided');
-
-      // current segment
-      var i = 0;
-      // is the module name relative
-      var rel = false;
-      // number of backtracking segments
-      var dotdots = 0;
-      if (segments[0] == '.') {
-        i++;
-        if (i == segments.length)
-          throw new TypeError('Illegal module name "' + name + '"');
-        rel = true;
+        xhr.onreadystatechange = function () {
+          if (xhr.readyState === 4) {
+            if (xhr.status === 200 || (xhr.status == 0 && xhr.responseText)) {
+              load();
+            } else {
+              error();
+            }
+          }
+        };
+        xhr.open("GET", url, true);
+        xhr.send(null);
       }
-      else {
-        while (segments[i] == '..') {
+    }
+    else {
+      var fs;
+      fetchTextFromURL = function(url, fulfill, reject) {
+        fs = fs || require('fs');
+        return fs.readFile(url, function(err, data) {
+          if (err)
+            return reject(err);
+          else
+            fulfill(data + '');
+        });
+      }
+    }
+
+    // IE8 support
+    var indexOf = Array.prototype.indexOf || function(item) {
+      for (var i = 0, thisLen = this.length; i < thisLen; i++) {
+        if (this[i] === item) {
+          return i;
+        }
+      }
+      return -1;
+    };
+
+    // given a syntax tree, return the import list
+    function getImports(moduleTree) {
+      var imports = [];
+
+      function addImport(name) {
+        if (indexOf.call(imports, name) == -1)
+          imports.push(name);
+      }
+
+      // tree traversal, NB should use visitor pattern here
+      function traverse(object, iterator, parent, parentProperty) {
+        var key, child;
+        if (iterator(object, parent, parentProperty) === false)
+          return;
+        for (key in object) {
+          if (!object.hasOwnProperty(key))
+            continue;
+          if (key == 'location' || key == 'type')
+            continue;
+          child = object[key];
+          if (typeof child == 'object' && child !== null)
+            traverse(child, iterator, object, key);
+        }
+      }
+
+      traverse(moduleTree, function(node) {
+        // import {} from 'foo';
+        // export * from 'foo';
+        // export { ... } from 'foo';
+        // module x from 'foo';
+        if (node.type == 'EXPORT_DECLARATION') {
+          if (node.declaration.moduleSpecifier)
+            addImport(node.declaration.moduleSpecifier.token.processedValue);
+        }
+        else if (node.type == 'IMPORT_DECLARATION')
+          addImport(node.moduleSpecifier.token.processedValue);
+        else if (node.type == 'MODULE_DECLARATION')
+          addImport(node.expression.token.processedValue);
+      });
+      return imports;
+    }
+
+    var System = new Loader({
+      global: isBrowser ? window : global,
+      strict: true,
+      normalize: function(name, parentName, parentAddress) {
+        if (typeof name != 'string')
+          throw new TypeError('Module name must be a string');
+
+        var segments = name.split('/');
+
+        if (segments.length == 0)
+          throw new TypeError('No module name provided');
+
+        // current segment
+        var i = 0;
+        // is the module name relative
+        var rel = false;
+        // number of backtracking segments
+        var dotdots = 0;
+        if (segments[0] == '.') {
           i++;
           if (i == segments.length)
             throw new TypeError('Illegal module name "' + name + '"');
-        }
-        if (i)
           rel = true;
-        dotdots = i;
-      }
-
-      for (var j = i; j < segments.length; j++) {
-        var segment = segments[j];
-        if (segment == '' || segment == '.' || segment == '..')
-          throw new TypeError('Illegal module name "' + name + '"');
-      }
-
-      if (!rel)
-        return name;
-
-      // build the full module name
-      var normalizedParts = [];
-      var parentParts = (parentName || '').split('/');
-      var normalizedLen = parentParts.length - 1 - dotdots;
-
-      normalizedParts = normalizedParts.concat(parentParts.splice(0, parentParts.length - 1 - dotdots));
-      normalizedParts = normalizedParts.concat(segments.splice(i, segments.length - i));
-
-      return normalizedParts.join('/');
-    },
-    locate: function(load) {
-      var name = load.name;
-
-      // NB no specification provided for System.paths, used ideas discussed in https://github.com/jorendorff/js-loaders/issues/25
-
-      // most specific (longest) match wins
-      var pathMatch = '', wildcard;
-
-      // check to see if we have a paths entry
-      for (var p in this.paths) {
-        var pathParts = p.split('*');
-        if (pathParts.length > 2)
-          throw new TypeError('Only one wildcard in a path is permitted');
-
-        // exact path match
-        if (pathParts.length == 1) {
-          if (name == p && p.length > pathMatch.length)
-            pathMatch = p;
+        }
+        else {
+          while (segments[i] == '..') {
+            i++;
+            if (i == segments.length)
+              throw new TypeError('Illegal module name "' + name + '"');
+          }
+          if (i)
+            rel = true;
+          dotdots = i;
         }
 
-        // wildcard path match
-        else {
-          if (name.substr(0, pathParts[0].length) == pathParts[0] && name.substr(name.length - pathParts[1].length) == pathParts[1]) {
-            pathMatch = p;
-            wildcard = name.substr(pathParts[0].length, name.length - pathParts[1].length - pathParts[0].length);
+        for (var j = i; j < segments.length; j++) {
+          var segment = segments[j];
+          if (segment == '' || segment == '.' || segment == '..')
+            throw new TypeError('Illegal module name "' + name + '"');
+        }
+
+        if (!rel)
+          return name;
+
+        // build the full module name
+        var normalizedParts = [];
+        var parentParts = (parentName || '').split('/');
+        var normalizedLen = parentParts.length - 1 - dotdots;
+
+        normalizedParts = normalizedParts.concat(parentParts.splice(0, parentParts.length - 1 - dotdots));
+        normalizedParts = normalizedParts.concat(segments.splice(i, segments.length - i));
+
+        return normalizedParts.join('/');
+      },
+      locate: function(load) {
+        var name = load.name;
+
+        // NB no specification provided for System.paths, used ideas discussed in https://github.com/jorendorff/js-loaders/issues/25
+
+        // most specific (longest) match wins
+        var pathMatch = '', wildcard;
+
+        // check to see if we have a paths entry
+        for (var p in this.paths) {
+          var pathParts = p.split('*');
+          if (pathParts.length > 2)
+            throw new TypeError('Only one wildcard in a path is permitted');
+
+          // exact path match
+          if (pathParts.length == 1) {
+            if (name == p && p.length > pathMatch.length)
+              pathMatch = p;
+          }
+
+          // wildcard path match
+          else {
+            if (name.substr(0, pathParts[0].length) == pathParts[0] && name.substr(name.length - pathParts[1].length) == pathParts[1]) {
+              pathMatch = p;
+              wildcard = name.substr(pathParts[0].length, name.length - pathParts[1].length - pathParts[0].length);
+            }
+          }
+        }
+
+        var outPath = this.paths[pathMatch];
+        if (wildcard)
+          outPath = outPath.replace('*', wildcard);
+
+        return toAbsoluteURL(this.baseURL, outPath);
+      },
+      fetch: function(load) {
+        return new Promise(function(resolve, reject) {
+          fetchTextFromURL(toAbsoluteURL(this.baseURL, load.address), function(source) {
+            resolve(source);
+          }, reject);
+        });
+      },
+    });
+      // --- <Specific Traceur Parsing Code> ---
+
+    // System.traceurOptions = {modules: 'instantiate'};
+
+    // parse function is used to parse a load record
+    // Returns an array of ModuleSpecifiers
+    System.parse = function(load) {
+      if (!traceur) {
+        if (typeof window == 'undefined')
+          traceur = require('traceur');
+        else if (global.traceur)
+          traceur = global.traceur;
+        else
+          throw new TypeError('Include Traceur for module syntax support');
+      }
+
+      console.assert(load.source, 'Non-empty source');
+
+      function checkForErrors(output) {
+        if (output.errors.length) {
+          output.errors.map(function(error) {
+            console.error(error);
+          });
+          throw new Error('Parse failed, ' + output.errors.length);
+        }
+      }
+
+      var depsList;
+      (function () {
+        try {
+          load.kind = 'declarative';
+
+          var compiler = new traceur.Compiler();
+          var options = { modules: 'instantiate' };
+          var output = compiler.stringToTree({content: load.source, options: options});
+          checkForErrors(output);
+
+          depsList = getImports(output.tree);
+          output = compiler.treeToTree(output);
+          checkForErrors(output);
+
+          output = compiler.treeToString(output);
+          checkForErrors(output);
+          var source = output.js;
+          var sourceMap = output.generatedSourceMap;
+
+          if (global.btoa && sourceMap)
+            source += '\n//# sourceMappingURL=data:application/json;base64,' + btoa(unescape(encodeURIComponent(sourceMap))) + '\n';
+
+          __eval(source, global, load);
+        }
+        catch(e) {
+          if (e.name == 'SyntaxError' || e.name == 'TypeError')
+            e.message = 'Evaluating ' + (load.name || load.address) + '\n\t' + e.message;
+          throw e;
+        }
+      }());
+      return depsList;
+    }
+
+    if (isBrowser) {
+      var href = window.location.href.split('#')[0].split('?')[0];
+      System.baseURL = href.substring(0, href.lastIndexOf('/') + 1);
+    }
+    else {
+      System.baseURL = './';
+    }
+    System.paths = { '*': '*.js' };
+
+    // <script type="module"> support
+    // allow a data-init function callback once loaded
+    if (isBrowser) {
+      var curScript = document.getElementsByTagName('script');
+      curScript = curScript[curScript.length - 1];
+
+      function completed() {
+        document.removeEventListener( "DOMContentLoaded", completed, false );
+        window.removeEventListener( "load", completed, false );
+        ready();
+      }
+
+      function ready() {
+        var scripts = document.getElementsByTagName('script');
+
+        for (var i = 0; i < scripts.length; i++) {
+          var script = scripts[i];
+          if (script.type == 'module') {
+            var source = script.innerHTML;
+            System.module(source)['catch'](function(err) { setTimeout(function() { throw err; }); });
           }
         }
       }
 
-      var outPath = this.paths[pathMatch];
-      if (wildcard)
-        outPath = outPath.replace('*', wildcard);
-
-      return toAbsoluteURL(this.baseURL, outPath);
-    },
-    fetch: function(load) {
-      return new Promise(function(resolve, reject) {
-        fetchTextFromURL(toAbsoluteURL(this.baseURL, load.address), function(source) {
-          resolve(source);
-        }, reject);
-      });
-    }
-  });
-
-  if (isBrowser) {
-    var href = window.location.href.split('#')[0].split('?')[0];
-    System.baseURL = href.substring(0, href.lastIndexOf('/') + 1);
-  }
-  else {
-    System.baseURL = './';
-  }
-  System.paths = { '*': '*.js' };
-
-  if (global.System && global.traceur)
-    global.traceurSystem = global.System;
-
-  if (isBrowser)
-    global.System = System;
-
-  // <script type="module"> support
-  // allow a data-init function callback once loaded
-  if (isBrowser) {
-    var curScript = document.getElementsByTagName('script');
-    curScript = curScript[curScript.length - 1];
-
-    function completed() {
-      document.removeEventListener( "DOMContentLoaded", completed, false );
-      window.removeEventListener( "load", completed, false );
-      ready();
-    }
-
-    function ready() {
-      var scripts = document.getElementsByTagName('script');
-
-      for (var i = 0; i < scripts.length; i++) {
-        var script = scripts[i];
-        if (script.type == 'module') {
-          // <script type="module" name="" src=""> support
-          var name = script.getAttribute('name');
-          var address = script.getAttribute('src');
-          var source = script.innerHTML;
-
-          (name
-            ? System.define(name, source, { address: address })
-            : System.module(source, { address: address })
-          ).then(function() {}, function(err) { nextTick(function() { throw err; }); });
-        }
+      // DOM ready, taken from https://github.com/jquery/jquery/blob/master/src/core/ready.js#L63
+      if (document.readyState === 'complete') {
+        setTimeout(ready);
       }
+      else if (document.addEventListener) {
+        document.addEventListener('DOMContentLoaded', completed, false);
+        window.addEventListener('load', completed, false);
+      }
+
+      // run the data-init function on the script tag
+      if (curScript.getAttribute('data-init'))
+        window[curScript.getAttribute('data-init')]();
     }
 
-    // DOM ready, taken from https://github.com/jquery/jquery/blob/master/src/core/ready.js#L63
-    if (document.readyState === 'complete') {
-      setTimeout(ready);
-    }
-    else if (document.addEventListener) {
-      document.addEventListener('DOMContentLoaded', completed, false);
-      window.addEventListener('load', completed, false);
-    }
+    if (typeof exports === 'object')
+      module.exports = System;
 
-    // run the data-init function on the script tag
-    if (curScript.getAttribute('data-init'))
-      window[curScript.getAttribute('data-init')]();
+    global.System = System;
+  })();
+
+  // Define our eval outside of the scope of any other reference defined in this
+  // file to avoid adding those references to the evaluation scope.
+  function __eval(__source, __global, load) {
+    // Hijack System.register to set declare function
+    System.__curRegister = System.register;
+    System.register = function(name, deps, declare) {
+      // store the registered declaration as load.declare
+      load.declare = typeof name == 'string' ? declare : deps;
+    }
+    eval('var __moduleName = "' + (load.name || '').replace('"', '\"') + '"; (function() { ' + __source + ' \n }).call(__global);');
+
+    System.register = System.__curRegister;
+    delete System.__curRegister;
   }
-
-  if (typeof exports === 'object')
-    module.exports = System;
 
 })(typeof global !== 'undefined' ? global : this);


### PR DESCRIPTION
This updates instantiate to the new bindings system as discussed with @caridy and @matthewrobb.

This is not passing the tests yet, as we need to first create the corresponding implementation in the ES6 Module Loader. The code can be reviewed initially in the mean time.

@arv is there any chance you can assist with working out how to ensure EmptyStatements don't display on as an empty line statement?
