### PR TITLE
Compile kangax's es6 tests and verify the compat-table entries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ test-runtime: bin/traceur-runtime.js $(RUNTIME_TESTS)
 	@echo 'Open test/runtime.html to test runtime only'
 
 test: test/test-list.js bin/traceur.js $(COMPILE_BEFORE_TEST) \
-		test/unit/runtime/traceur-runtime \
-		wiki test/amd-compiled test/commonjs-compiled test-interpret \
-		test-interpret-absolute test-inline-module-error \
-		test-version test/unit/tools/SourceMapMapping \
-		test-compat-table
+	  test/unit/runtime/traceur-runtime \
+	  wiki test/amd-compiled test/commonjs-compiled test-interpret \
+	  test-interpret-absolute test-inline-module-error \
+	  test-version test/unit/tools/SourceMapMapping \
+	  test-compat-table
 	node_modules/.bin/mocha $(MOCHA_OPTIONS) $(TESTS)
 	$(MAKE) test-interpret-throw
 

--- a/test/verify-compat.js
+++ b/test/verify-compat.js
@@ -52,10 +52,9 @@ System.loadAsScript('./test/compat-table/data-es6.js').then((tests) => {
 
       var m = /eval\(([^\)]*)\)/.exec(src);
       if (m) {
-        var parse = compiler.stringToTree({content:src});
-        var tree = parse.tree;
+        var {tree} = compiler.stringToTree({content: src});
         var visitor = new FindEvalVisitor();
-        visitor.visit(tree);
+        visitor.visitAny(tree);
         if (visitor.found) {
           try {
             (0, eval)(compiler.module(visitor.found).js);


### PR DESCRIPTION
The compat-table data-es6.js file builds the web page showing compatiblity results.
Reading that file and extracting the tests allows tracuer results to be verified.
