### PR TITLE
Fix Node API's `options`

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -210,7 +210,7 @@ export class Compiler {
   }
 
   defaultOptions() {
-    return traceurOptions.versionLockedOptions;
+    return traceurOptions;
   }
 
   promise(method, input) {

--- a/src/options.js
+++ b/src/options.js
@@ -394,6 +394,7 @@ addBoolOption('validate');
 
 defaultValues.referrer = '';
 options.referrer = null;
+options.outputLanguage = 'es5';
 
 defaultValues.typeAssertionModule = null;
 options.typeAssertionModule = null;


### PR DESCRIPTION
Attempt to fix `traceur.options` Node.js API (#1162).

(I don't have Make locally, mostly just checking if this breaks existing tests)
