### PR TITLE
Node API: add options parameter to require.makeDefault()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Ulrik de Muelenaere <ulrikdem@gmail.com>
 Maël Nison <nison.mael@gmail.com>
 Shinnosuke Watanabe <snnskwtnb@gmail.com>
 Vyacheslav Shebanov <terminal2010@gmail.com>
+Fabrício Matté <ultcombo@gmail.com>

--- a/src/node/require.js
+++ b/src/node/require.js
@@ -25,11 +25,11 @@ Module._extensions[ext] = function(module, filename) {
   module._compile(module.compiledCode, module.filename);
 };
 
-function compile(filename) {
+function compile(filename, options) {
   var contents = fs.readFileSync(filename, 'utf-8');
-  var results = traceurAPI.compile(contents);
+  var results = traceurAPI.compile(contents, options);
   if (!results.js)
-    console.error(results.errors);
+    throw new Error(results.errors[0]);
 
   return results.js;
 }
@@ -55,7 +55,7 @@ function shouldCompile(filename) {
   return false;
 }
 
-traceurRequire.makeDefault = function(filter) {
+traceurRequire.makeDefault = function(filter, options) {
   if (!filter)
     filters = [];
   else
@@ -63,7 +63,7 @@ traceurRequire.makeDefault = function(filter) {
 
   Module._extensions['.js'] = function(module, filename) {
     if (shouldCompile(filename)) {
-      var source = compile(filename)
+      var source = compile(filename, options);
       return module._compile(source, filename);
     }
     return originalRequireJs(module, filename);

--- a/test/unit/node/require.js
+++ b/test/unit/node/require.js
@@ -23,6 +23,32 @@ suite('require.js', function() {
     assert.equal(x, 'x');
   });
 
+  test('traceurRequire.makeDefault options', function() {
+    var traceurRequire = require('../../../src/node/require'),
+        // TODO(arv): The path below is sucky...
+        fixturePath = path.join(__dirname, './resources/async-function.js'),
+        experimentalOption = {asyncFunctions: true};
+
+    // traceur.require must throw without the experimentalOption
+    try {
+      traceurRequire(fixturePath);
+      assert.notOk(true);
+    } catch(e) {
+      assert.ok(true);
+    }
+
+    traceurRequire.makeDefault(undefined, experimentalOption);
+    assert.equal(typeof require(fixturePath).foo, 'function');
+
+    // reset traceur.makeDefault options
+    traceurRequire.makeDefault();
+    try {
+      require(fixturePath);
+      assert.notOk(true);
+    } catch(e) {
+      assert.ok(true);
+    }
+  });
 
   test('traceurRequire.makeDefault with nested dependencies', function() {
     require('../../../src/node/require').makeDefault(function(filename) {

--- a/test/unit/node/resources/async-function.js
+++ b/test/unit/node/resources/async-function.js
@@ -1,0 +1,2 @@
+async function foo() {}
+export {foo};


### PR DESCRIPTION
Closes #1162.

I've signed the CLA using my email ( ultcombo [\at] gmail {!dot!} com )

I'm unsure how to properly add a test for `require.makeDefault()`, as there is no way to "resetDefault()". Should we create a method for that as well?
