### PR TITLE
instantiate postfix operator fix

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -136,7 +136,13 @@ class InsertBindingAssignmentTransformer extends ScopeTransformer {
     if (!this.matchesBindingName_(tree.operand))
       return tree;
 
-    return parseExpression `($__export(${this.exportName_}, ${tree.operand} + 1), ${tree})`;
+    var operatorType = tree.operator.type;
+    if (operatorType == PLUS_PLUS)
+      return parseExpression `($__export(${this.exportName_}, ${tree.operand} + 1), ${tree})`;
+    else if (operatorType == MINUS_MINUS)
+      return parseExpression `($__export(${this.exportName_}, ${tree.operand} - 1), ${tree})`;
+    else
+      return tree;
   }
 
   // x = y

--- a/test/instantiate/export-reassignment.js
+++ b/test/instantiate/export-reassignment.js
@@ -38,7 +38,7 @@ export default --a;
 
 a -= 10;
 
---a;
+a--;
 
 export function reassign() {
   a = 10;

--- a/test/instantiate/postfix-operator.js
+++ b/test/instantiate/postfix-operator.js
@@ -1,0 +1,5 @@
+export var a = 5;
+export var b = a++;
+export var c = a--;
+export var d = a;
+

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -65,6 +65,16 @@ suite('instantiate', function() {
     }).catch(done);
   });
 
+  test('Postfix Operator', function(done) {
+    System.import('postfix-operator').then(function(m) {
+      assert.equal(m.a, 5);
+      assert.equal(m.b, 5);
+      assert.equal(m.c, 6);
+      assert.equal(m.d, 5);
+      done();
+    }).catch(done);
+  });
+
   test('Module import', function(done) {
     System.import('module-import').then(function(m) {
       assert.equal(m.default, -6);


### PR DESCRIPTION
Glad to see the new instantiate format in. Any idea on when we could expect the release? No rush at all. I'll send the PR to remove the module loader from `third_party` as soon as we have the module loader release updated.

I forgot to add this other case for the postfix operator, see the correction here.
