### PR TITLE
Install deps of compat-table to avoid make clean installs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,6 @@ clean: wikiclean
 	@rm -f test/test-list.js
 	@rm -rf test/commonjs-compiled/*
 	@rm -rf test/amd-compiled/*
-	@rm -rf node_modules/es5-compat-table
 	@rm -f bin/*
 	$(NPM_INSTALL)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "semver": "2.x",
     "traceur": "0.0.50",
     "promises-aplus-tests": "2.x",
-    "compat-table": "git+https://github.com/johnjbarton/compat-table.git#traceur"
+    "compat-table": "git+https://github.com/kangax/compat-table.git#gh-pages",
+    "colors": "~0.6.0-1",
+    "cheerio": "~0.10.1"
   },
   "subdomain": "traceur"
 }


### PR DESCRIPTION
With git dev-dependences in package.json, the dependencies of that dependent
seem to be reinstalled every time we run `npm install`; we run `npm install` every time we 
run `make clean`. To avoid these downloads on `make clean` we install the recursive dependencies
directly. 
Switch to kangax repo.
Fixes #1178
