### PR TITLE
Fix regression of free var checker in accessors

### DIFF
--- a/src/semantics/ScopeVisitor.js
+++ b/src/semantics/ScopeVisitor.js
@@ -106,11 +106,11 @@ export class ScopeVisitor extends ParseTreeVisitor {
   }
 
   visitGetAccessor(tree) {
-    this.visitFunctionBodyForScope(tree, null);
+    this.visitFunctionBodyForScope(tree, null, tree.body);
   }
 
   visitSetAccessor(tree) {
-    this.visitFunctionBodyForScope(tree);
+    this.visitFunctionBodyForScope(tree, undefined, tree.body);
   }
 
   visitPropertyMethodAssignment(tree) {

--- a/test/unit/semantics/FreeVariableChecker.js
+++ b/test/unit/semantics/FreeVariableChecker.js
@@ -121,4 +121,26 @@ suite('FreeVariableChecker.js', function() {
       ['CODE:1:16: x is not defined']);
 
   makeTest('spread', 'var x = [1, 2]; var y = [0, ...x, 3]', []);
+
+  makeTest('getter',
+      '({\n' +
+      '  get p() { return x; }\n' +
+      '})',
+      ['CODE:2:20: x is not defined']);
+  makeTest('getter',
+      '({\n' +
+      '  get x() { return x; }\n' +
+      '})',
+      ['CODE:2:20: x is not defined']);
+
+  makeTest('setter',
+      '({\n' +
+      '  set p(_) { x; }\n' +
+      '})',
+      ['CODE:2:14: x is not defined']);
+  makeTest('setter',
+      '({\n' +
+      '  set x(_) { x; }\n' +
+      '})',
+      ['CODE:2:14: x is not defined']);
 });


### PR DESCRIPTION
With the recent change to the new ScopeVisitor a "typo" sneaked in
preventing us from visiting the body of accessors.
