### PR TITLE
Use string for Node version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"


### PR DESCRIPTION
The node version is currently written as a number in `.travis.yml`, which is an issue as `0.10 === 0.1`. The version should be a string.

Fixes this [Travis build error](https://travis-ci.org/google/traceur-compiler/builds/31250700):

> $ nvm use 0.1
> N/A version is not installed yet
