### PR TITLE
Add support for the exponentiation operator

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -23,38 +23,39 @@ function enumerableOnlyObject(obj) {
 
 // Traceur sets these default options and no others for v 0.1.*
 export var optionsV01 = enumerableOnlyObject({
+  annotations: false,
   arrayComprehension: true,
   arrowFunctions: true,
-  classes: true,
-  computedPropertyNames: true,
-  defaultParameters: true,
-  destructuring: true,
-  forOf: true,
-  generatorComprehension: true,
-  generators: true,
-  modules: 'register',
-  numericLiterals: true,
-  propertyMethods: true,
-  propertyNameShorthand: true,
-  restParameters: true,
-  spread: true,
-  templateLiterals: true,
   asyncFunctions: false,
   blockBinding: false,
-  symbols: false,
-  types: false,
-  annotations: false,
+  classes: true,
   commentCallback: false,
+  computedPropertyNames: true,
   debug: false,
+  defaultParameters: true,
+  destructuring: true,
+  exponentiation: false,
+  filename: undefined,
+  forOf: true,
   freeVariableChecker: false,
-  sourceMaps: false,
-  typeAssertions: false,
-  validate: false,
-  referrer: '',
-  typeAssertionModule: null,
+  generatorComprehension: true,
+  generators: true,
   moduleName: false,
+  modules: 'register',
+  numericLiterals: true,
   outputLanguage: 'es5',
-  filename: undefined
+  propertyMethods: true,
+  propertyNameShorthand: true,
+  referrer: '',
+  restParameters: true,
+  sourceMaps: false,
+  spread: true,
+  symbols: false,
+  templateLiterals: true,
+  typeAssertionModule: null,
+  typeAssertions: false,
+  types: false,
+  validate: false
 });
 
 export var versionLockedOptions = optionsV01;
@@ -391,11 +392,12 @@ addFeatureOption('spread', ON_BY_DEFAULT);             // 11.1.4, 11.2.5
 addFeatureOption('templateLiterals', ON_BY_DEFAULT);   // 7.6.8
 
 // EXPERIMENTAL
+addFeatureOption('annotations', EXPERIMENTAL);
 addFeatureOption('asyncFunctions', EXPERIMENTAL);
 addFeatureOption('blockBinding', EXPERIMENTAL);       // 12.1
+addFeatureOption('exponentiation', EXPERIMENTAL);
 addFeatureOption('symbols', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
-addFeatureOption('annotations', EXPERIMENTAL);
 
 addBoolOption('commentCallback');
 addBoolOption('debug');

--- a/src/codegeneration/ExponentiationTransformer.js
+++ b/src/codegeneration/ExponentiationTransformer.js
@@ -1,0 +1,39 @@
+// Copyright 2014 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ExplodeExpressionTransformer} from './ExplodeExpressionTransformer';
+import {TempVarTransformer} from './TempVarTransformer';
+import {
+  STAR_STAR,
+  STAR_STAR_EQUAL
+} from '../syntax/TokenType';
+import {parseExpression} from './PlaceholderParser';
+
+export class ExponentiationTransformer extends TempVarTransformer {
+  transformBinaryExpression(tree) {
+    switch (tree.operator.type) {
+      case STAR_STAR:
+        var left = this.transformAny(tree.left);
+        var right = this.transformAny(tree.right);
+        return parseExpression `Math.pow(${left}, ${right})`;
+
+      case STAR_STAR_EQUAL:
+        var exploded =
+            new ExplodeExpressionTransformer(this).transformAny(tree);
+        return this.transformAny(exploded);
+    }
+
+    return super(tree);
+  }
+}

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -19,6 +19,7 @@ import {ArrowFunctionTransformer} from './ArrowFunctionTransformer';
 import {BlockBindingTransformer} from './BlockBindingTransformer';
 import {ClassTransformer} from './ClassTransformer';
 import {CommonJsModuleTransformer} from './CommonJsModuleTransformer';
+import {ExponentiationTransformer} from './ExponentiationTransformer';
 import {validate as validateConst} from '../semantics/ConstChecker';
 import {DefaultParametersTransformer} from './DefaultParametersTransformer';
 import {DestructuringTransformer} from './DestructuringTransformer';
@@ -80,6 +81,8 @@ export class FromOptionsTransformer extends MultiTransformer {
 
     // TODO: many of these simple, local transforms could happen in the same
     // tree pass
+    if (transformOptions.exponentiation)
+      append(ExponentiationTransformer);
 
     if (transformOptions.numericLiterals)
       append(NumericLiteralTransformer);

--- a/src/codegeneration/assignmentOperatorToBinaryOperator.js
+++ b/src/codegeneration/assignmentOperatorToBinaryOperator.js
@@ -33,6 +33,8 @@ import {
   SLASH_EQUAL,
   STAR,
   STAR_EQUAL,
+  STAR_STAR,
+  STAR_STAR_EQUAL,
   UNSIGNED_RIGHT_SHIFT,
   UNSIGNED_RIGHT_SHIFT_EQUAL
 } from '../syntax/TokenType';
@@ -45,6 +47,8 @@ function assignmentOperatorToBinaryOperator(type) {
   switch (type) {
     case STAR_EQUAL:
       return STAR;
+    case STAR_STAR_EQUAL:
+      return STAR_STAR;
     case SLASH_EQUAL:
       return SLASH;
     case PERCENT_EQUAL:

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -51,6 +51,8 @@ import {
   SLASH_EQUAL,
   STAR,
   STAR_EQUAL,
+  STAR_STAR,
+  STAR_STAR_EQUAL,
   STRING,
   UNSIGNED_RIGHT_SHIFT,
   UNSIGNED_RIGHT_SHIFT_EQUAL
@@ -217,6 +219,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
       // assignment
       case EQUAL:
       case STAR_EQUAL:
+      case STAR_STAR_EQUAL:
       case SLASH_EQUAL:
       case PERCENT_EQUAL:
       case PLUS_EQUAL:
@@ -270,6 +273,9 @@ export class ParseTreeValidator extends ParseTreeVisitor {
       case STAR:
       case SLASH:
       case PERCENT:
+
+      // exponentiation
+      case STAR_STAR:
         this.check_(tree.left.isAssignmentExpression(), tree.left,
             'assignment expression expected');
         this.check_(tree.right.isAssignmentExpression(), tree.right,

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -127,6 +127,7 @@ import {
   SLASH,
   SLASH_EQUAL,
   STAR,
+  STAR_STAR,
   STATIC,
   STRING,
   SUPER,
@@ -2770,8 +2771,19 @@ export class Parser {
    */
   parseMultiplicativeExpression_() {
     var start = this.getTreeStartLocation_();
-    var left = this.parseUnaryExpression_();
+    var left = this.parseExponentiationExpression_();
     while (this.peekMultiplicativeOperator_(this.peekType_())) {
+      var operator = this.nextToken_();
+      var right = this.parseExponentiationExpression_();
+      left = this.newBinaryExpression_(start, left, operator, right);
+    }
+    return left;
+  }
+
+  parseExponentiationExpression_() {
+    var start = this.getTreeStartLocation_();
+    var left = this.parseUnaryExpression_();
+    while (this.peekExponentiationExpression_(this.peekType_())) {
       var operator = this.nextToken_();
       var right = this.parseUnaryExpression_();
       left = this.newBinaryExpression_(start, left, operator, right);
@@ -2792,6 +2804,10 @@ export class Parser {
       default:
         return false;
     }
+  }
+
+  peekExponentiationExpression_(type) {
+    return type === STAR_STAR;
   }
 
   // 11.4 Unary Operator

--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -80,6 +80,8 @@ import {
   SLASH_EQUAL,
   STAR,
   STAR_EQUAL,
+  STAR_STAR,
+  STAR_STAR_EQUAL,
   STRING,
   TEMPLATE_HEAD,
   TEMPLATE_MIDDLE,
@@ -722,6 +724,14 @@ function scanToken() {
       if (currentCharCode === 61) {  // =
         next();
         return createToken(STAR_EQUAL, beginIndex);
+      }
+      if (parseOptions.exponentiation && currentCharCode === 42) {
+        next();
+        if (currentCharCode === 61) {  // =
+          next();
+          return createToken(STAR_STAR_EQUAL, beginIndex);
+        }
+        return createToken(STAR_STAR, beginIndex);
       }
       return createToken(STAR, beginIndex);
     case 37:  // %

--- a/src/syntax/Token.js
+++ b/src/syntax/Token.js
@@ -24,6 +24,7 @@ import {
   RIGHT_SHIFT_EQUAL,
   SLASH_EQUAL,
   STAR_EQUAL,
+  STAR_STAR_EQUAL,
   UNSIGNED_RIGHT_SHIFT_EQUAL
 } from './TokenType';
 
@@ -74,6 +75,7 @@ export function isAssignmentOperator(type) {
     case RIGHT_SHIFT_EQUAL:
     case SLASH_EQUAL:
     case STAR_EQUAL:
+    case STAR_STAR_EQUAL:
     case UNSIGNED_RIGHT_SHIFT_EQUAL:
       return true;
   }

--- a/src/syntax/TokenType.js
+++ b/src/syntax/TokenType.js
@@ -100,6 +100,8 @@ export var SLASH = '/';
 export var SLASH_EQUAL = '/=';
 export var STAR = '*';
 export var STAR_EQUAL = '*=';
+export var STAR_STAR = '**';
+export var STAR_STAR_EQUAL = '**=';
 export var STATIC = 'static';
 export var STRING = 'string literal';
 export var SUPER = 'super';

--- a/test/feature/Exponentiation/Basics.js
+++ b/test/feature/Exponentiation/Basics.js
@@ -1,0 +1,22 @@
+// Options: --exponentiation
+
+(function() {
+  assert.equal(8, 2 ** 3);
+  assert.equal(24, 3 * 2 ** 3);
+  var x = 2;
+  assert.equal(8, 2 ** ++x);
+  assert.equal(1, 2 ** -1 * 2);
+
+  var calls = 0;
+  var q = {q: 3};
+  var o = {
+    get p() {
+      calls++;
+      return q;
+    }
+  };
+
+  o.p.q **= 2;
+  assert.equal(1, calls);
+  assert.equal(9, o.p.q);
+})();


### PR DESCRIPTION
x *\* y is now short for Math.pow(x, y)

Similar for x **= y.

https://gist.github.com/rwaldron/ebe0f4d2d267370be882
