### PR TITLE
Add support for "import * as m from 'm'"

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -458,6 +458,19 @@ export class Parser {
   parseImportDeclaration_() {
     var start = this.getTreeStartLocation_();
     this.eat_(IMPORT);
+    
+    // import * as m from './m.js'
+    if (this.peek_(STAR)) {
+      this.eat_(STAR);
+      this.eatId_(AS);
+      var binding = this.parseImportedBinding_();
+      this.eatId_(FROM);
+      var moduleSpecifier = this.parseModuleSpecifier_();
+      this.eatPossibleImplicitSemiColon_();
+      return new ModuleDeclaration(this.getTreeLocation_(start), binding,
+                                   moduleSpecifier);
+    }
+
     var importClause = null;
     if (this.peekImportClause_(this.peekType_())) {
       importClause = this.parseImportClause_();

--- a/test/feature/Modules/Error_ImportStar.js
+++ b/test/feature/Modules/Error_ImportStar.js
@@ -1,5 +1,5 @@
 // Should not compile.
-// Error: :4:8: Unexpected token *
+// Error: :4:10: Unexpected token from
 
 import * from './resources/m';
 assert.equal(3, a + b);

--- a/test/feature/Modules/Error_InvalidModuleDeclaration.js
+++ b/test/feature/Modules/Error_InvalidModuleDeclaration.js
@@ -6,4 +6,4 @@
 // Error: LoaderHooks.locate resolved against base './'
 
 
-module b from './resources/no_such_file';
+import * as b from './resources/no_such_file';

--- a/test/feature/Modules/Error_InvalidModuleDeclaration2.js
+++ b/test/feature/Modules/Error_InvalidModuleDeclaration2.js
@@ -1,4 +1,4 @@
 // Should not compile.
-// Error: 4:33: Unexpected token .
+// Error: 4:38: Unexpected token .
 
-module b from './resources/a.js'.c;
+import * as b from './resources/a.js'.c;

--- a/test/feature/Modules/Error_ModuleNoNewline.js
+++ b/test/feature/Modules/Error_ModuleNoNewline.js
@@ -1,5 +1,0 @@
-// Should not compile.
-// Error: :5:3: Semi-colon expected
-
-module
-m from 'm';

--- a/test/feature/Modules/ExportStar.js
+++ b/test/feature/Modules/ExportStar.js
@@ -1,4 +1,4 @@
-module o from './resources/o';
+import * as o from './resources/o';
 
 assert.equal(1, o.a);
 assert.equal(2, o.b);

--- a/test/feature/Modules/Exports.js
+++ b/test/feature/Modules/Exports.js
@@ -1,4 +1,4 @@
-module a from './resources/i';
+import * as a from './resources/i';
 
 (function() {
   'use strict';
@@ -13,5 +13,5 @@ module a from './resources/i';
 
 assert.equal(1, a.i);
 
-module d from './resources/d';
+import * as d from './resources/d';
 assert.equal('A', d.a);

--- a/test/feature/Modules/ImportAsExportAs.js
+++ b/test/feature/Modules/ImportAsExportAs.js
@@ -1,2 +1,2 @@
-module m from './resources/m3';
+import * as m from './resources/m3';
 assert.equal(m.x, 'z');

--- a/test/feature/Modules/ImportFromModule.js
+++ b/test/feature/Modules/ImportFromModule.js
@@ -1,17 +1,17 @@
 import {a as renamedX, b} from './resources/m';
 import {a} from './resources/m';
-module m2 from './resources/m';
+import * as m2 from './resources/m';
 
 assert.equal(1, a);
 assert.equal(1, renamedX);
 assert.equal(2, b);
 
-module m from './resources/m';
+import * as m from './resources/m';
 
 assert.equal(a, renamedX);
 assert.equal(a, m.a);
 
-module m3 from './resources/m';
+import * as m3 from './resources/m';
 
 assert.isTrue(m === m3);
 assert.equal(b, m.b);

--- a/test/feature/Modules/ModuleDefault.js
+++ b/test/feature/Modules/ModuleDefault.js
@@ -1,3 +1,3 @@
-module m from './resources/default';
+import * as m from './resources/default';
 
 assert.equal(m.default, 42);

--- a/test/feature/Modules/ThisInModules.js
+++ b/test/feature/Modules/ThisInModules.js
@@ -1,4 +1,4 @@
 var global = this;
 
-module m from './resources/f';
+import * as m from './resources/f';
 assert.equal(global, m.f());

--- a/test/feature/Modules/resources/b.js
+++ b/test/feature/Modules/resources/b.js
@@ -1,1 +1,1 @@
-module c from './c';
+import * as c from './c';

--- a/test/feature/TemplateLiterals/InModule.js
+++ b/test/feature/TemplateLiterals/InModule.js
@@ -1,2 +1,2 @@
-module m from './resources/m';
-module n from './resources/n';
+import * as m from './resources/m';
+import * as n from './resources/n';

--- a/test/instantiate/module-import.js
+++ b/test/instantiate/module-import.js
@@ -15,5 +15,5 @@ System.register(["./export-reassignment"], function($__export) {
 });
 */
 
-module M from './export-reassignment';
+import * as M from './export-reassignment';
 export default M.a;

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -123,9 +123,9 @@ suite('Loader.js', function() {
 
   test('LoaderModule', function(done) {
     var code =
-        'module a from "./test_a";\n' +
-        'module b from "./test_b";\n' +
-        'module c from "./test_c";\n' +
+        'import * as a from "./test_a";\n' +
+        'import * as b from "./test_b";\n' +
+        'import * as c from "./test_c";\n' +
         '\n' +
         'export var arr = [\'test\', a.name, b.name, c.name];\n';
 
@@ -142,7 +142,7 @@ suite('Loader.js', function() {
 
   test('LoaderModuleWithSubdir', function(done) {
     var code =
-        'module d from "./subdir/test_d";\n' +
+        'import * as d from "./subdir/test_d";\n' +
         '\n' +
         'export var arr = [d.name, d.e.name];\n';
 
@@ -156,9 +156,9 @@ suite('Loader.js', function() {
 
   test('LoaderModuleFail', function(done) {
     var code =
-        'module a from "./test_a";\n' +
-        'module b from "./test_b";\n' +
-        'module c from "./test_c";\n' +
+        'import * as a from "./test_a";\n' +
+        'import * as b from "./test_b";\n' +
+        'import * as c from "./test_c";\n' +
         '\n' +
         '[\'test\', SYNTAX ERROR a.name, b.name, c.name];\n';
 

--- a/test/unit/runtime/subdir/test_d.js
+++ b/test/unit/runtime/subdir/test_d.js
@@ -1,3 +1,3 @@
-module e from './test_e';
+import * as e from './test_e';
 export {e};
 export var name = 'D';

--- a/test/unit/runtime/test_b.js
+++ b/test/unit/runtime/test_b.js
@@ -1,3 +1,3 @@
-module c from './test_c';
+import * as c from './test_c';
 
 export var name = 'B';

--- a/test/unit/semantics/FreeVariableChecker.js
+++ b/test/unit/semantics/FreeVariableChecker.js
@@ -105,7 +105,7 @@ suite('FreeVariableChecker.js', function() {
 
   makeTest('module', 'import {x} from "x"; x', [], undefined, 'module');
   makeTest('module', 'import x from "x"; x', [], undefined, 'module');
-  makeTest('module', 'module x from "x"; x', [], undefined, 'module');
+  makeTest('module', 'import * as x from "x"; x', [], undefined, 'module');
   makeTest('module', 'import {y as x} from "x"; x', [], undefined, 'module');
   makeTest('module', 'import {x as y} from "x"; x',
       ['CODE:1:27: x is not defined'], undefined, 'module');

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -25,7 +25,7 @@ suite('parser.js', function() {
 
   test('Module', function() {
     var program = 'export var x = 42;\n' +
-                  'module M from \'url\';\n' +
+                  'import * as M from \'url\';\n' +
                   'import {z} from \'x\';\n' +
                   'import {a as b, c} from \'M\';\n';
     var sourceFile = new traceur.syntax.SourceFile('Name', program);

--- a/third_party/es6-module-loader/system.js
+++ b/third_party/es6-module-loader/system.js
@@ -152,7 +152,7 @@
         // import {} from 'foo';
         // export * from 'foo';
         // export { ... } from 'foo';
-        // module x from 'foo';
+        // import * as x from 'foo';
         if (node.type == 'EXPORT_DECLARATION') {
           if (node.declaration.moduleSpecifier)
             addImport(node.declaration.moduleSpecifier.token.processedValue);


### PR DESCRIPTION
This keeps the old syntx in place. It will be removed in a seperate
PR since self hosting requires this two step process.

Partial fix for #1119
