### PR TITLE
remove source root for filename

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -210,7 +210,7 @@ export class Compiler {
   }
 
   sourceRootForFilename(filename) {
-    return filename;
+    return;
   }
 
   defaultOptions() {


### PR DESCRIPTION
Currently, this implementation is causing the path to double up - `some/file/url.js` becomes `some/file/url.js/some/file/url.js`.

The source root is optional, and only necessary if there are a number of source files that would benefit from having a common root.
