### PR TITLE
Expose traceur.get

### DIFF
--- a/src/traceur.js
+++ b/src/traceur.js
@@ -20,6 +20,12 @@ export {WebPageTranscoder} from './WebPageTranscoder';
 export {options} from './Options';
 import {addOptions, CommandOptions} from './Options';
 
+import {ModuleStore} from '@traceur/src/runtime/ModuleStore';
+
+export function get(name) {
+  return ModuleStore.get(ModuleStore.normalize('./' + name, __moduleName));
+}
+
 export {Compiler} from './Compiler';
 
 import {ErrorReporter} from './util/ErrorReporter';


### PR DESCRIPTION
I'm writing a NodeJS project which is doing custom transformations on Traceur parse trees.

I don't want to write in ES6, so if I want access to various exports, it can be tricky.

This PR exposes `require('traceur').get('codegeneration/ModuleTransformer')` etc to allow easy loading of the various modules.

Happy to consider alternative APIs but this seemed the simplest to me.
