### PR TITLE
Make sure async-functions work without generators.

### DIFF
--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -178,7 +178,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       append(BlockBindingTransformer);
 
     // generator must come after for of and rest parameters
-    if (transformOptions.generators || transformOptions.asyncFuntions)
+    if (transformOptions.generators || transformOptions.asyncFunctions)
       append(GeneratorTransformPass);
 
     if (transformOptions.symbols)

--- a/test/feature/AsyncFunctions/Basics.js
+++ b/test/feature/AsyncFunctions/Basics.js
@@ -1,5 +1,7 @@
-// Options: --async-functions
+// Options: --async-functions --generators=false
 // Async.
+//
+// The --generators=false part is to test #1231
 
 var f = (x, y) => ({x, y});
 


### PR DESCRIPTION
This was due to a typo.

Fixes #1231
