### PR TITLE
Change make-driven commit message to add (npm now has version-1).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ update-version-number: npm-publish updateSemver
 	$(MAKE) test  # build version N+1
 
 git-update-version: update-version-number
-	./traceur -v | xargs -I VERSION git commit -a -m "VERSION"
+	./traceur -v | xargs -I VERSION git commit -a -m "VERSION (npm now has version-1)"
 	./traceur -v | xargs -I VERSION git tag -a VERSION -m "Tagged version VERSION "
 	git push --tags upstream upstream_master:master
 	git push upstream upstream_master:master  # Push source for version N+1


### PR DESCRIPTION
Some users have been confused by npm being back level by one;
I hit that myself by seeing the commit message in the log.
Here is a built-in reminder
