### PR TITLE
Rewrite BlockBindingTransfomer for better performance

### DIFF
--- a/src/codegeneration/BlockBindingTransformer.js
+++ b/src/codegeneration/BlockBindingTransformer.js
@@ -14,24 +14,68 @@
 
 import {AlphaRenamer} from './AlphaRenamer';
 import {
+  ANON_BLOCK,
   BINDING_IDENTIFIER,
   BLOCK,
+  FUNCTION_DECLARATION,
+  RETURN_STATEMENT,
   VARIABLE_DECLARATION_LIST
 } from '../syntax/trees/ParseTreeType';
 import {
+  AnonBlock,
+  ArgumentList,
+  AssignmentElement,
+  BindingElement,
+  BindingIdentifier,
+  Block,
+  BreakStatement,
+  CallExpression,
+  CaseClause,
+  Catch,
+  ContinueStatement,
+  DefaultClause,
+  DoWhileStatement,
+  ExpressionStatement,
+  ForInStatement,
+  ForStatement,
+  FormalParameter,
+  FormalParameterList,
+  FunctionBody,
   FunctionDeclaration,
-  FunctionExpression
+  FunctionExpression,
+  IdentifierExpression,
+  IfStatement,
+  LabelledStatement,
+  LiteralExpression,
+  Module,
+  ParenExpression,
+  ReturnStatement,
+  Script,
+  SwitchStatement,
+  ThisExpression,
+  VariableDeclaration,
+  VariableDeclarationList,
+  VariableStatement,
+  WhileStatement
 } from '../syntax/trees/ParseTrees';
+import {IdentifierToken} from '../syntax/IdentifierToken';
+import {ARGUMENTS} from '../syntax/PredefinedName';
 import {ParseTreeTransformer} from './ParseTreeTransformer';
+import {ParseTreeVisitor} from '../syntax/ParseTreeVisitor';
 import {
+  AND,
   CONST,
   LET,
   VAR
 } from '../syntax/TokenType';
 import {
+  createArgumentList,
   createAssignmentExpression,
+  createAssignmentStatement,
+  createBinaryExpression,
   createBindingIdentifier,
   createBlock,
+  createCallExpression,
   createCatch,
   createEmptyStatement,
   createExpressionStatement,
@@ -41,13 +85,23 @@ import {
   createFunctionBody,
   createIdentifierExpression,
   createIdentifierToken,
+  createMemberExpression,
+  createObjectLiteral,
+  createOperatorToken,
+  createStringLiteral,
   createThrowStatement,
   createTryStatement,
   createUndefinedExpression,
   createVariableDeclaration,
   createVariableDeclarationList,
-  createVariableStatement
+  createVariableStatement,
+  createVoid0
 } from './ParseTreeFactory';
+import {ScopeChainBuilder} from '../semantics/ScopeChainBuilder';
+import {prependStatements} from './PrependStatements';
+import {FindVisitor} from './FindVisitor';
+import {FindIdentifiers} from './FindIdentifiers';
+import {FnExtractAbruptCompletions} from './FnExtractAbruptCompletions';
 
 /**
  * Transforms the block bindings from traceur to js.
@@ -71,42 +125,529 @@ import {
  * The block binding rewrite pass assumes that deconstructing assignments
  * and variable declarations have already been desugared. See getVariableName_.
  *
- * TODO: Implement const support (currently rewritten exactly as 'let')
  */
 
-var ScopeType = {
-  SCRIPT: 'SCRIPT',
-  FUNCTION: 'FUNCTION',
-  BLOCK: 'BLOCK'
-};
 
 /**
- * Represents the link in the scope chain.
+ * Transforms the block bindings from traceur to js.
+ *
+ * In most cases, let can be transformed to var straight away and renamed to
+ * avoid name collisions.
+ *
+ * Making a
+ *
+ * if (true) { let t = 5; }
+ *
+ * Become a
+ *
+ * if (true) { var t$__0 = 5; }
+ *
+ * The only special case is in Iterable statements. For those, we only use a
+ * different strategy if they use let in them and they define functions that use
+ * those block binded variables. In that case, the loop content is extracted to
+ * a function, that gets called on every iteration with its arguments being
+ * any variable declared in the loop initializer.
+ * If the loop contained any break/continue statements, they get extracted and
+ * transformed to return statements of numbers, that correspond to the correct
+ * statement in a switch case.
+ *
+ * Example:
+ *
+ * for (let i = 0; i < 5; i++) {
+ *   if (i === 3) break;
+ *   setTimeout(function () {
+ *     log(i);
+ *   });
+ * }
+ *
+ * Becomes:
+ *
+ * // the loop content extracted to a function
+ * var $__2 = function (i) {
+ *   if (i === 3) return 0;
+ *   setTimeout(function () {
+ *     log(i);
+ *   });
+ * }, $__3;
+ *
+ * // the loop gets labelled if needed (it is here)
+ * $__1:
+ * for (var i$__0 = 0; i$__0 < 5; i$__0++) {
+ *   $__3 = $__2(i$__0);
+ *   switch($__3) {
+ *     case 0:
+ *       break $__1; // breaks the loop
+ *   }
+ * }
+ *
+ * If the loop contained return statements, they get transformed to returning
+ * object which preserver the scope in which the expression get executed.
+ *
+ * Example:
+ *
+ * for (let i = 0; i < 5; i++) {
+ *   if (i === 3) return i + 10;
+ *   // without this the let would just become a var
+ *   setTimeout(function () { log(i) });
+ * }
+ *
+ * Becomes:
+ *
+ * var $__1 = function(i) {
+ *   if (i === 3) return {v: i + 10};
+ *   setTimeout(function() { log(i); });
+ * }, $__2;
+ * for (var i$__0 = 0; i$__0 < 5; i$__0++) {
+ *   $__2 = $__1(i$__0);
+ *   if (typeof $__2 === "object")
+ *     return $__2.v;
+ * }
+ *
+ *
+ * If a loop contained both break/continue and return statements, the if-typeof
+ * statement from the second example would be added as a default clause to the
+ * switch statement of the first example.
+ *
+ *
+ * const variables are handled the same way.
+ *
+ * The block binding rewrite pass assumes that deconstructing assignments
+ * and variable declarations have already been desugared. See getVariableName_.
  */
-class Scope {
-  /**
-   * @param {Scope} parent The parent scope, or null if top level (program)
-   *     scope.
-   * @param {ScopeType} type Scope type: global, function, block.
-   */
-  constructor(parent, type) {
-    this.parent = parent;
-    this.type = type;
-    /** Block scoped variables accumulated within the block. */
-    this.blockVariables = null;
+
+/**
+ * BlockBindingTransformer class takes care of transforming the block bindings
+ * of a function Scope to ES5. It creates a new instance of itself for every
+ * new function/script it encounters.
+ */
+export class BlockBindingTransformer extends ParseTreeTransformer {
+  constructor(idGenerator, reporter, tree,
+              scopeBuilder = undefined, latestScope = undefined) {
+    super();
+    this.idGenerator_ = idGenerator;
+    this.reporter_ = reporter;
+    if (!scopeBuilder) {
+      scopeBuilder = new ScopeChainBuilder();
+      scopeBuilder.visitAny(tree);
+    }
+    this.scopeBuilder_ = scopeBuilder;
+
+    this.labelledLoops_ = new Map() // of {loopTree: labelName};
+    this.prependStatement_ = [];
+    this.blockRenames_ = [];
+    this.rootTree_ = tree;
+    if (latestScope) {
+      this.scope_ = latestScope;
+    } else {
+      this.pushScope(tree);
+    }
   }
 
   /**
-   * Stores a block scoped variable for future processing.
-   * @param {string} value
+   * @param {VariableDeclaration} variable
+   * @return {string}
    */
-  addBlockScopedVariable(value) {
-    if (!this.blockVariables) {
-      this.blockVariables = Object.create(null);
+  getVariableName_(variable) {
+    var lvalue = variable.lvalue;
+    if (lvalue.type == BINDING_IDENTIFIER) {
+      return lvalue.identifierToken.value;
     }
-    this.blockVariables[value] = true;
+    throw new Error('Unexpected destructuring declaration found.');
   }
-};
+
+  flushRenames(tree) {
+    tree = renameAll(this.blockRenames_, tree);
+    this.blockRenames_.length = 0;
+    return tree;
+  }
+
+  /**
+   * Pushes new scope
+   * @param {Scope} scope
+   * @return {Scope}
+   */
+  pushScope(tree) {
+    var scope = this.scopeBuilder_.getScopeForTree(tree);
+    if (!scope) throw new Error('BlockBindingTransformer tree with no scope');
+    if (this.scope_) this.scope_.blockBindingRenames = this.blockRenames_;
+    this.scope_ = scope;
+    this.blockRenames_ = [];
+    return scope;
+  }
+
+  /**
+   * Pops scope, tracks proper matching of push_/pop_ operations.
+   * @param {Scope} scope
+   */
+  popScope(scope) {
+    if (this.scope_ != scope) {
+      throw new Error('BlockBindingTransformer scope mismatch');
+    }
+    this.scope_ = scope.parent;
+    this.blockRenames_ = this.scope_ && this.scope_.blockBindingRenames || [];
+  }
+
+  revisitTreeForScopes(tree) {
+    this.scopeBuilder_.scope = this.scope_;
+    this.scopeBuilder_.visitAny(tree);
+    this.scopeBuilder_.scope = null;
+  }
+
+  // this is a start and end point of this transformer
+  transformFunctionBody(tree) {
+    if (tree === this.rootTree_ || !this.rootTree_) {
+      tree = super(tree);
+      if (this.prependStatement_.length || this.blockRenames_.length) {
+        var statements = prependStatements(tree.statements,
+            ...this.prependStatement_);
+        tree = new FunctionBody(tree.location, statements);
+        tree = this.flushRenames(tree);
+      }
+    } else {
+      var functionTransform = new BlockBindingTransformer(this.idGenerator_,
+          this.reporter_, tree, this.scopeBuilder_, this.scope_);
+      var functionBodyTree = functionTransform.transformAny(tree);
+
+      if (functionBodyTree === tree) {
+        return tree;
+      }
+      tree = new FunctionBody(tree.location, functionBodyTree.statements);
+    }
+    return tree;
+  }
+
+  // this is a start and end point of this transformer
+  transformScript(tree) {
+    if (tree === this.rootTree_ || !this.rootTree_) {
+      tree = super(tree);
+      if (this.prependStatement_.length || this.blockRenames_.length) {
+        var scriptItemList = prependStatements(tree.scriptItemList,
+            ...this.prependStatement_);
+        tree = new Script(tree.location, scriptItemList, tree.moduleName);
+        tree = this.flushRenames(tree);
+      }
+    } else {
+      var functionTransform = new BlockBindingTransformer(this.idGenerator_,
+          this.reporter_, tree, this.scopeBuilder_);
+      var newTree = functionTransform.transformAny(tree);
+
+      if (newTree === tree) {
+        return tree;
+      }
+      tree = new Script(tree.location, newTree.scriptItemList, tree.moduleName);
+    }
+    return tree;
+  }
+
+  // this is a start and end point of this transformer
+  transformModule(tree) {
+    if (tree === this.rootTree_ || !this.rootTree_) {
+      tree = super(tree);
+      if (this.prependStatement_.length || this.blockRenames_.length) {
+        var scriptItemList = prependStatements(tree.scriptItemList,
+            ...this.prependStatement_);
+        tree = new Module(tree.location, scriptItemList, tree.moduleName);
+        tree = this.flushRenames(tree);
+      }
+    } else {
+      var functionTransform = new BlockBindingTransformer(this.idGenerator_,
+          this.reporter_, tree, this.scopeBuilder_);
+      var newTree = functionTransform.transformAny(tree);
+
+      if (newTree === tree) {
+        return tree;
+      }
+      tree = new Module(tree.location, newTree.scriptItemList, tree.moduleName);
+    }
+    return tree;
+  }
+
+  // even if the actual transformations are in the transformVarDeclarationList
+  // the Statement itself might become a AnonBlock
+  transformVariableStatement(tree) {
+    var declarations = this.transformAny(tree.declarations);
+    if (declarations.type === ANON_BLOCK) {
+      return declarations;
+    }
+
+    if (declarations === tree.declarations) {
+      return tree;
+    }
+    return new VariableStatement(tree.location, declarations);
+  }
+
+  transformVariableDeclarationList(tree) {
+    if (tree.declarationType === VAR) {
+      return super(tree);
+    }
+
+    // just switch it to VAR
+    if (this.scope_.isVarScope) {
+      var declarations = this.transformList(tree.declarations);
+      return new VariableDeclarationList(null, VAR, declarations);
+    }
+
+    // hoist variable declarations and assign them a value at the current place
+    var variablesToDeclare = [];
+    var assignments = [];
+    tree.declarations.forEach((variableDeclaration) => {
+      var variableName = this.getVariableName_(variableDeclaration);
+      var uniqueName = variableName +
+          this.idGenerator_.generateUniqueIdentifier();
+
+      this.blockRenames_.push(new Rename(variableName, uniqueName));
+      variableName = uniqueName;
+
+      var lvalue = createIdentifierExpression(variableName);
+      var initializer = super.transformAny(variableDeclaration.initializer);
+
+      variablesToDeclare.push(variableName);
+
+      if (initializer) {
+        assignments.push(createAssignmentStatement(lvalue, initializer));
+      }
+    });
+
+    this.prependStatement_.push(
+        new VariableStatement(null,
+            new VariableDeclarationList(null, VAR,
+                variablesToDeclare.map((variableName) => {
+                  return new VariableDeclaration(null,
+                      createBindingIdentifier(variableName), null, null);
+                })
+            )));
+    return new AnonBlock(null, assignments);
+  }
+
+  transformBlock(tree) {
+    var scope = this.pushScope(tree);
+    tree = super(tree);
+    tree = this.flushRenames(tree);
+    this.popScope(scope);
+    return tree;
+  }
+
+  transformCatch(tree) {
+    var scope = this.pushScope(tree);
+    var binding = this.transformAny(tree.binding);
+    // The catchBody block does not have a scope because the catch itself
+    // has the scope. See ScopeVisitor.transformCatch
+    var statements = this.transformList(tree.catchBody.statements);
+    if (binding !== tree.binding || statements !== tree.catchBody.statements) {
+      tree = new Catch(tree.location, binding,
+          new Block(tree.catchBody.location, statements));
+    }
+    tree = this.flushRenames(tree);
+    this.popScope(scope);
+    return tree;
+  }
+
+  transformFunctionForScope_(func, tree) {
+    var scope = this.pushScope(tree);
+    tree = func();
+    tree = this.flushRenames(tree);
+    this.popScope(scope);
+    return tree;
+  }
+
+  transformGetAccessor(tree) {
+    return this.transformFunctionForScope_(() => super(tree), tree);
+  }
+
+  transformSetAccessor(tree) {
+    return this.transformFunctionForScope_(() => super(tree), tree);
+  }
+
+  transformFunctionExpression(tree) {
+    return this.transformFunctionForScope_(() => super(tree), tree);
+  }
+
+  transformFunctionDeclaration(tree) {
+    // Named function in a block scope is only scoped to the block.
+    // Hoist the function name and assign it in the current location
+    if (!this.scope_.isVarScope) {
+      var fnName = tree.name.getStringValue();
+      var uniqueName = fnName + this.idGenerator_.generateUniqueIdentifier();
+      this.blockRenames_.push(new Rename(fnName, uniqueName));
+      fnName = uniqueName;
+
+      // f = function( ... ) { ... }
+      tree = createExpressionStatement(
+          createAssignmentExpression(
+              createIdentifierExpression(fnName),
+              new FunctionExpression(tree.location, null, tree.functionKind,
+                  tree.parameterList, tree.typeAnnotation,
+                  tree.annotations, tree.body)));
+
+
+      this.prependStatement_.push(
+          new VariableStatement(null,
+              new VariableDeclarationList(null, VAR,
+                  [new VariableDeclaration(null,
+                      createBindingIdentifier(fnName), null, null)]
+              )));
+
+      this.revisitTreeForScopes(tree);
+      return this.transformAny(tree);
+    }
+
+    return this.transformFunctionForScope_(() => super(tree), tree);
+  }
+
+  /**
+   * @param func a function that continues the transform of the loop
+   * @param tree the loop tree
+   * @param loopFactory a function that recreates the loop with a provided
+   *    initializer, a set of renames for the loop headers, and a loop body
+   * @returns {ParseTree}
+   */
+  transformLoop_(func, tree, loopFactory) {
+    var scope, initializerIsBlockBinding;
+    if (tree.initializer &&
+        tree.initializer.type === VARIABLE_DECLARATION_LIST &&
+        tree.initializer.declarationType !== VAR) {
+      initializerIsBlockBinding = true;
+    }
+
+    if (initializerIsBlockBinding) {
+      scope = this.pushScope(tree);
+    }
+
+    // We only create an "iife" if the loop has block bindings and functions
+    // that use those block binded variables
+    var finder = new FindBlockBindingInLoop(tree, this.scopeBuilder_);
+    if (!finder.found) {
+      // just switch it to var
+      if (initializerIsBlockBinding) {
+        var renames = [];
+        var initializer = new VariableDeclarationList(null, VAR,
+            tree.initializer.declarations.map((declaration) => {
+                var variableName = this.getVariableName_(declaration);
+                var uniqueName = variableName +
+                    this.idGenerator_.generateUniqueIdentifier();
+
+                renames.push(new Rename(variableName, uniqueName));
+                return new VariableDeclaration(null,
+                    createBindingIdentifier(uniqueName), null,
+                    declaration.initializer);
+              }
+            ));
+        initializer = renameAll(renames, initializer);
+
+        tree = loopFactory(initializer, renames, renameAll(renames, tree.body));
+        this.scopeBuilder_.scope = this.scope_;
+        this.scopeBuilder_.visitAny(tree);
+        this.scopeBuilder_.scope = null;
+        tree = func(tree);
+      } else {
+        return func(tree);
+      }
+    } else {
+      var iifeParameterList = [];
+      var iifeArgumentList = [];
+      var renames = [];
+      var initializer = null;
+      // switch to var and rename variables, holding them in potential
+      // iife argument/parameter list
+      if (tree.initializer &&
+          tree.initializer.type === VARIABLE_DECLARATION_LIST) {
+        initializer = new VariableDeclarationList(null, VAR,
+            tree.initializer.declarations.map((declaration) => {
+          var variableName = this.getVariableName_(declaration);
+              var uniqueName = variableName +
+                  this.idGenerator_.generateUniqueIdentifier();
+
+
+              iifeArgumentList.push(createIdentifierExpression(uniqueName));
+              iifeParameterList.push(new FormalParameter(null,
+                  new BindingElement(null,
+                      createBindingIdentifier(variableName), null), null, []));
+
+              renames.push(new Rename(variableName, uniqueName));
+              return new VariableDeclaration(null,
+                  createBindingIdentifier(uniqueName), null,
+                  declaration.initializer);
+            }));
+
+        initializer = renameAll(renames, initializer);
+      }
+
+      // the loop might already have a label, let's keep it with us
+      var loopLabel = this.labelledLoops_.get(tree);
+
+      var iifeInfo = FnExtractAbruptCompletions.createIIFE(
+          this.idGenerator_, tree.body, iifeParameterList, iifeArgumentList,
+          () => loopLabel = loopLabel ||
+              this.idGenerator_.generateUniqueIdentifier()
+      );
+
+      tree = loopFactory(initializer, renames, iifeInfo.loopBody);
+
+      if (loopLabel) {
+        tree = new LabelledStatement(tree.location,
+            createIdentifierToken(loopLabel), tree);
+      }
+
+      tree = new AnonBlock(tree.location, [iifeInfo.variableStatements, tree]);
+
+      this.revisitTreeForScopes(tree);
+      tree = this.transformAny(tree);
+    }
+
+    if (initializerIsBlockBinding) {
+      tree = this.flushRenames(tree);
+      this.popScope(scope);
+    }
+    return tree;
+  }
+
+  transformForInStatement(tree) {
+    return this.transformLoop_((t) => super(t), tree,
+        (initializer, renames, body) => new ForInStatement(tree.location,
+            initializer, renameAll(renames, tree.collection), body)
+    );
+  }
+
+  transformForStatement(tree) {
+    return this.transformLoop_((t) => super(t), tree,
+        (initializer, renames, body) => new ForStatement(tree.location,
+            initializer, renameAll(renames, tree.condition),
+            renameAll(renames, tree.increment), body)
+    );
+  }
+
+  transformWhileStatement(tree) {
+    return this.transformLoop_((t) => super(t), tree,
+        (initializer, renames, body) => new WhileStatement(tree.location,
+            renameAll(renames, tree.condition), body)
+    );
+  }
+
+  transformDoWhileStatement(tree) {
+    return this.transformLoop_((t) => super(t), tree,
+        (initializer, renames, body) => new DoWhileStatement(tree.location,
+            body, renameAll(renames, tree.condition))
+    );
+  }
+
+  // We want to keep track of loops with labels.
+  // If transforming them doesn't result in a statement (AnonBlock),
+  // then remove the label from here
+  transformLabelledStatement(tree) {
+    if (tree.statement.isIterationStatement()) {
+      this.labelledLoops_.set(tree.statement, tree.name.value);
+      var statement = this.transformAny(tree.statement);
+      if (!statement.isStatement()) {
+        return statement;
+      }
+      if (statement === tree.statement) {
+        return tree;
+      }
+      return new LabelledStatement(tree.location, tree.name, statement);
+    }
+    return super(tree);
+  }
+}
 
 class Rename {
   /**
@@ -132,651 +673,69 @@ function renameAll(renames, tree) {
 }
 
 /**
- * Wraps a statement in a block if needed.
- * @param {ParseTree} statement
- * @return {Block}
+ * FindBlockBindingInLoop class that finds if a tree contains both a
+ * BlockBinding declaration (i.e. let/const) AND a function that might
+ * depend on them.
  */
-function toBlock(statement) {
-  return statement.type == BLOCK ? statement : createBlock([statement]);
-}
+class FindBlockBindingInLoop extends FindVisitor {
 
-export class BlockBindingTransformer extends ParseTreeTransformer {
-  constructor(stateAllocator) {
-    super();
-    this.scope_ = null;
+  constructor(tree, scopeBuilder) {
+    this.scopeBuilder_ = scopeBuilder;
+    // Not all Loop Statements have a scope, but all their block bodies should.
+    // Example: a For Loop with no initializer, or one that uses 'var' doesn't
+    // have a Scope. Neither does a While Loop.
+    // We still try to get the scope of a Loop if it's available, because
+    // it might have block binding in its initializer that we can't ignore.
+    this.topScope_ = scopeBuilder.getScopeForTree(tree) ||
+        scopeBuilder.getScopeForTree(tree.body);
+    this.outOfScope_ = null;
+    this.acceptLoop_ = tree.isIterationStatement();
+    super(tree, false);
   }
 
-  /**
-   * Creates top level (program) scope.
-   * Inside the scope, let/const become vars (const only temporarily),
-   * functions are unchanged.
-   * @return {Scope}
-   */
-  createScriptScope_() {
-    // program scope is never a block/let scope
-    return new Scope(this.scope_, ScopeType.SCRIPT);
-  }
-
-  /**
-   * Creates function level scope.
-   * let/const is rewritten, function names are not.
-   * @return {Scope}
-   */
-  createFunctionScope_() {
-    if (this.scope_ == null) {
-      throw new Error('Top level function scope found.');
+  visitForInStatement(tree) {this.visitLoop_(tree, () => super(tree));}
+  visitForStatement(tree) {this.visitLoop_(tree, () => super(tree));}
+  visitWhileStatement(tree) {this.visitLoop_(tree, () => super(tree));}
+  visitDoWhileStatement(tree) {this.visitLoop_(tree, () => super(tree));}
+  visitLoop_(tree, func) {
+    if (this.acceptLoop_) {
+      this.acceptLoop_ = false;
+    } else if (!this.outOfScope_) {
+      this.outOfScope_ = this.scopeBuilder_.getScopeForTree(tree) ||
+          this.scopeBuilder_.getScopeForTree(tree.body);
     }
-    // program scope is never a block/let scope
-    return new Scope(this.scope_, ScopeType.FUNCTION);
+    func();
   }
 
-  /**
-   * Creates block scope - inside it let/const/function have limited scope.
-   * @return {Scope}
-   */
-  createBlockScope_() {
-    if (this.scope_ == null) {
-      throw new Error('Top level block scope found.');
-    }
-    // contained within block scope
-    return new Scope(this.scope_, ScopeType.BLOCK);
-  }
-
-  /**
-   * Pushes new scope
-   * @param {Scope} scope
-   * @return {Scope}
-   */
-  push_(scope) {
-    this.scope_ = scope;
-    return scope;
-  }
-
-  /**
-   * Pops scope, tracks proper matching of push_/pop_ operations.
-   * @param {Scope} scope
-   */
-  pop_(scope) {
-    if (this.scope_ != scope) {
-      throw new Error('BlockBindingTransformer scope mismatch');
-    }
-
-    this.scope_ = scope.parent;
-  }
-
-  // The transform methods override from the base.
-
-  /**
-   * Transforms block scope, rewriting all block-scoped variables/functions.
-   * @param {Block} tree
-   * @return {ParseTree}
-   */
-  transformBlock(tree) {
-    // Push new scope.
-    var scope = this.push_(this.createBlockScope_());
-
-    // Transform the block contents
-    var statements = this.transformList(tree.statements);
-
-    if (scope.blockVariables != null) {
-      // rewrite into catch construct
-      tree = createBlock([
-        this.rewriteAsCatch_(scope.blockVariables, createBlock(statements))
-      ]);
-    } else if (statements != tree.statements) {
-      tree = createBlock(statements);
-    }
-
-    this.pop_(scope);
-    return tree;
-  }
-
-  /**
-   * Declares block-scoped variables. Does so by wrapping a block in
-   * a try .. catch for each block scoped variable in the set.
-   *
-   * 'let x = 1;' turns into:
-   *
-   * try {
-   *   throw undefined;
-   * } catch (x) {
-   *   x = 1;   // let x = 1
-   *   ...
-   *   }
-   * }
-   *
-   * @param {Object} blockVariables
-   * @param {ParseTree} statements
-   * @return {ParseTree}
-   */
-  rewriteAsCatch_(blockVariables, statement) {
-    // Build the try .. catch structure from within.
-    // try {
-    //   throw undefined;
-    // } catch (<block scoped variable>) {
-    //   <block>
-    // }
-    for (var variable in blockVariables) {
-      statement =
-          createTryStatement(
-              createBlock([                      // try
-                createThrowStatement(createUndefinedExpression())
-              ]),
-              createCatch(                  // catch
-                  createBindingIdentifier(variable),
-                  createBlock([statement])),
-              null);                       // finally
-    }
-
-    return statement;
-  }
-
-  /** Class declarations should have been transformed away. */
-  /**
-   * @param {ClassDeclaration} tree
-   * @return {ParseTree}
-   */
-  transformClassDeclaration(tree) {
-    throw new Error('ClassDeclaration should be transformed away.');
-  }
-
-  /**
-   * Transforms for .. in statement.
-   */
-  /**
-   * @param {ForInStatement} tree
-   * @return {ParseTree}
-   */
-  transformForInStatement(tree) {
-    // Save it here because tree may change in the variable rewrite
-    var treeBody = tree.body;
-
-    var initializer;
-    if (tree.initializer != null &&
-        tree.initializer.type == VARIABLE_DECLARATION_LIST) {
-
-      // for (var/let/const x [ = ...] in ...)
-      var variables = tree.initializer;
-
-      // Only one declaration allowed.
-      if (variables.declarations.length != 1) {
-        throw new Error('for .. in has != 1 variables');
-      }
-
-      var variable = variables.declarations[0];
-      var variableName = this.getVariableName_(variable);
-
-      switch (variables.declarationType) {
-        case LET:
-        case CONST: {
-          // initializer is illegal in for (const/let x in ...)
-          // this should have been caught in the parser.
-          if (variable.initializer != null) {
-            throw new Error(
-                'const/let in for-in may not have an initializer');
+  visitFunctionDeclaration(tree) {this.visitFunction_(tree);}
+  visitFunctionExpression(tree) {this.visitFunction_(tree);}
+  visitSetAccessor(tree) {this.visitFunction_(tree);}
+  visitGetAccessor(tree) {this.visitFunction_(tree);}
+  visitPropertyMethodAssignment(tree) {this.visitFunction_(tree);}
+  visitArrowFunctionExpression(tree) {this.visitFunction_(tree);}
+  visitFunction_(tree) {
+    this.found = new FindIdentifiers(tree,
+        (identifierToken, identScope) => {
+          identScope = this.scopeBuilder_.getScopeForTree(identScope);
+          var fnScope = this.outOfScope_ ||
+              this.scopeBuilder_.getScopeForTree(tree);
+          if (identScope.hasLexicalBindingName(identifierToken)) {
+            return false;
           }
 
-          // Build the result
-          // for (var $x in ...) {
-          //   let x = $x;
-          //   ...
-          // }
-          // TODO: Use temp allocator.
-          initializer = createVariableDeclarationList(
-              VAR, `$${variableName}`, null);
-
-          // Add the let statement into the block and rewrite it next.
-          // It is easier than creating the catch block manually etc.
-          treeBody = this.prependToBlock_(
-              createVariableStatement(
-                  LET,
-                  variableName,
-                  createIdentifierExpression(`$${variableName}`)),
-              treeBody);
-          break;
-        }
-
-        case VAR:
-          // No special work for var
-          initializer = this.transformVariables_(variables);
-          break;
-
-        default:
-          throw new Error('Unreachable.');
-      }
-    } else {
-      initializer = this.transformAny(tree.initializer);
-    }
-
-    var result = tree;
-    var collection = this.transformAny(tree.collection);
-    var body = this.transformAny(treeBody);
-
-    if (initializer != tree.initializer ||
-        collection != tree.collection ||
-        body != tree.body) {
-      result = createForInStatement(initializer, collection, body);
-    }
-
-    return result;
-  }
-
-  /**
-   * TODO: Use non-scoped blocks (statement comma) when available.
-   * @param {ParseTree} statement
-   * @param {ParseTree} body
-   * @return {Block}
-   */
-  prependToBlock_(statement, body) {
-    if (body.type == BLOCK) {
-      return createBlock([statement, ... body.statements]);
-    } else {
-      return createBlock([statement, body]);
-    }
-  }
-
-  /**
-   * Transforms the for ( ... ; ... ; ... ) { ... } statement.
-   * @param {ForStatement} tree
-   * @return {ParseTree}
-   */
-  transformForStatement(tree) {
-    var initializer;
-    if (tree.initializer != null &&
-        tree.initializer.type == VARIABLE_DECLARATION_LIST) {
-
-      // for (var/let/const ... ; ; ) { ... }
-      var variables = tree.initializer;
-
-      switch (variables.declarationType) {
-        case LET:
-        case CONST:
-          // let/const are rewritten differently so the code below doesn't apply
-          return this.transformForLet_(tree, variables);
-
-        case VAR:
-          // No special work for var.
-          initializer = this.transformVariables_(variables);
-          break;
-
-        default:
-          throw new Error('Reached unreachable.');
-      }
-    } else {
-      // The non-var case: for (x = ...; ; ) { ... }
-      initializer = this.transformAny(tree.initializer);
-    }
-
-    // Finish transforming the body.
-    var condition = this.transformAny(tree.condition);
-    var increment = this.transformAny(tree.increment);
-    var body = this.transformAny(tree.body);
-
-    var result = tree;
-
-    if (initializer != tree.initializer ||
-        condition != tree.condition ||
-        increment != tree.increment ||
-        body != tree.body) {
-      // Create new for statement.
-      result = createForStatement(initializer, condition, increment, body);
-    }
-
-    return result;
-  }
-
-  /*
-   * Transforms the for (let ...; ...; ...) { ... } statement. There are few
-   * steps to this:
-   *
-   * 1. Hoist the declaration out of the for loop (keep as let for further
-   *    rewrite)
-   * 2. Rename the hoisted declared variables
-   * 3. Wrap the for loop body in a try..finally block
-   * 4. Before the try block, copy all variables into new block scoped
-   *    variables (using original names)
-   * 5. In the finally, write-back the to the hoisted variables
-   *
-   * For example:
-   *
-   * for (let x = 1, y = x + 2; x + y < 10, x ++, y ++) {
-   *  if (condition) {
-   *    continue;
-   *  }
-   * }
-   *
-   * translates into:
-   *
-   * {
-   *   let $x = 1, $y = $x + 2;     // initializer dependencies
-   *   for ( ; $x + $y < 10; $x++, $y++) {
-   *     let x = $x, y = $y;
-   *     try {
-   *       // for loop body
-   *       if (condition) {
-   *         continue;
-   *       }
-   *
-   *     } finally {
-   *       $x = x;    // write-backs into the hoisted variables
-   *       $y = y;
-   *     }
-   *   }
-   * }
-   * @param {ForStatement} tree
-   * @param {VariableDeclarationList} variables
-   * @return {ParseTree}
-   */
-  transformForLet_(tree, variables) {
-
-    // Accumulator for 'let x = $x;'
-    var copyFwd = [];
-
-    // Accumulator for '$x = x' copybacks
-    var copyBak = [];
-
-    // Accumulator for the hoisted declaration: let $x = 1, ...;
-    var hoisted = [];
-
-    var renames = [];
-
-    variables.declarations.forEach((variable) => {
-      var variableName = this.getVariableName_(variable);
-      var hoistedName = `$${variableName}`;
-
-      // perform renames in the initializer
-      var initializer = renameAll(renames, variable.initializer);
-
-      // hoisted declaration: let $x = 1
-      hoisted.push(createVariableDeclaration(hoistedName, initializer));
-
-      // copy forward: let x = $x;
-      copyFwd.push(
-          createVariableDeclaration(
-              variableName,
-              createIdentifierExpression(hoistedName)));
-
-      // copy back: $x = x;
-      copyBak.push(
-          createExpressionStatement(
-              createAssignmentExpression(
-                  createIdentifierExpression(hoistedName),
-                  createIdentifierExpression(variableName))));
-
-      // Remember rename for the subsequent initializers
-      renames.push(new Rename(variableName, hoistedName));
-    });
-
-    // 'tree.condition' with renamed variables
-    var condition = renameAll(renames, tree.condition);
-    // 'tree.increment' with renamed variables
-    var increment = renameAll(renames, tree.increment);
-
-    // package it all up
-    var transformedForLoop = createBlock([
-      // hoisted declaration
-      createVariableStatement(
-          createVariableDeclarationList(
-              LET, hoisted)),
-      // for loop
-      createForStatement(
-          null,
-          condition,
-          increment,
-          // body
-          createBlock([
-            createVariableStatement(
-                // let x = $x;
-                createVariableDeclarationList(LET, copyFwd)),
-            // try { ... } finally { copyBak }
-            createTryStatement(
-                // try - the original for loop body
-                toBlock(tree.body),
-                // catch (none)
-                null,
-                // finally - the writebacks
-                createFinally(createBlock(copyBak)))
-          ]))
-      ]);
-
-    // Now transform the rewritten for loop! This is safe to do because the
-    return this.transformAny(transformedForLoop);
-  }
-
-  /**
-   * Transforms a function declaration statement. Function name in the block
-   * scope is scoped to the block only, so the same rewrite applies.
-   *
-   * @param {FunctionDeclaration} tree
-   * @return {ParseTree}
-   */
-  transformFunctionDeclaration(tree) {
-    var body = this.transformFunctionBody(tree.body);
-    var parameterList = this.transformAny(tree.parameterList);
-
-    if (this.scope_.type === ScopeType.BLOCK) {
-      // Named function in a block scope is only scoped to the block.
-      // Add function name into variable hash to later 'declare' the
-      // block scoped variable for it.
-      this.scope_.addBlockScopedVariable(tree.name.identifierToken.value);
-
-      // f = function( ... ) { ... }
-      return createExpressionStatement(
-          createAssignmentExpression(
-              createIdentifierExpression(tree.name.identifierToken),
-              new FunctionExpression(tree.location, null, tree.functionKind,
-                                     parameterList, tree.typeAnnotation,
-                                     tree.annotations, body)));
-    }
-
-    if (body === tree.body &&
-        parameterList === tree.parameterList) {
-      return tree;
-    }
-
-    return new FunctionDeclaration(tree.location, tree.name, tree.functionKind,
-                                   parameterList, tree.typeAnnotation,
-                                   tree.annotations, body);
-  }
-
-  /**
-   * Transforms the whole program.
-   * @param {Script} tree
-   * @return {ParseTree}
-   */
-  transformScript(tree) {
-    // Push new scope
-    var scope = this.push_(this.createScriptScope_());
-
-    var result = super.transformScript(tree);
-
-    this.pop_(scope);
-    return result;
-  }
-
-  /**
-   * Variable declarations are detected earlier and handled elsewhere.
-   * @param {VariableDeclaration} tree
-   * @return {ParseTree}
-   */
-  transformVariableDeclaration(tree) {
-    throw new Error('Should never see variable declaration tree.');
-  }
-
-  /**
-   * Variable declarations are detected earlier and handled elsewhere.
-   * @param {VariableDeclarationList} tree
-   * @return {ParseTree}
-   */
-  transformVariableDeclarationList(tree) {
-    throw new Error('Should never see variable declaration list.');
-  }
-
-  /**
-   * Transforms the variable statement. Inside a block const and let
-   * are transformed into block-scoped variables.
-   * Outside of the block, const and let becomes regular variables.
-   * @param {VariableStatement} tree
-   * @return {ParseTree}
-   */
-  transformVariableStatement(tree) {
-    if (this.scope_.type == ScopeType.BLOCK) {
-      // let/const have block scoped meaning only in block scope.
-      switch (tree.declarations.declarationType) {
-        case CONST:
-        case LET:
-          return this.transformBlockVariables_(tree.declarations);
-
-        default:
-          break;
-      }
-    }
-
-    // Default handling.
-    var variables = this.transformVariables_(tree.declarations);
-
-    if (variables != tree.declarations) {
-      tree = createVariableStatement(variables);
-    }
-
-    return tree;
-  }
-
-  /**
-   * Transforms block scoped variables.
-   * Series of declarations become a comma of assignment expressions
-   * which is later turned into a statement, minimizing block creation
-   * overhead.
-   * @param {VariableDeclarationList} tree
-   * @return {ParseTree}
-   */
-  transformBlockVariables_(tree) {
-    var variables = tree.declarations;
-    var commaExpressions = [];
-
-    variables.forEach((variable) => {
-      switch (tree.declarationType) {
-        case LET:
-        case CONST:
-          break;
-        default:
-          throw new Error('Only let/const allowed here.');
-      }
-
-      var variableName = this.getVariableName_(variable);
-
-      // Store the block scoped variable for future 'declaration'.
-      this.scope_.addBlockScopedVariable(variableName);
-      var initializer = this.transformAny(variable.initializer);
-
-      if (initializer != null) {
-        // varname = initializer, ...
-        commaExpressions.push(
-            createAssignmentExpression(
-                createIdentifierExpression(variableName),
-                initializer));
-      }
-    });
-
-    switch (commaExpressions.length) {
-      case 0:
-        return createEmptyStatement();
-      case 1:
-        return createExpressionStatement(commaExpressions[0]);
-      default:
-        // Turn commaExpressions into statements
-        for (var i = 0; i < commaExpressions.length; i++) {
-          commaExpressions[i] = createExpressionStatement(commaExpressions[i]);
-        }
-        return createBlock(commaExpressions);
-    }
-  }
-
-  /**
-   * Transforms variables unaffected by block scope.
-   * @param {VariableDeclarationList} tree
-   * @return {VariableDeclarationList}
-   */
-  transformVariables_(tree) {
-
-    var variables = tree.declarations;
-    var transformed = null;
-
-    for (var index = 0; index < variables.length; index++) {
-      var variable = variables[index];
-      var variableName = this.getVariableName_(variable);
-
-      // Transform the initializer.
-      var initializer = this.transformAny(variable.initializer);
-
-      if (transformed != null || initializer != variable.initializer) {
-        // Variable was rewritten.
-        if (transformed == null) {
-          transformed = variables.slice(0, index);
-        }
-
-        // var/const x = <initializer>;
-        transformed.push(
-            createVariableDeclaration(
-                createIdentifierToken(variableName), initializer));
-      }
-    }
-
-    // Package up in the declaration list.
-    if (transformed != null || tree.declarationType != VAR) {
-      var declarations = transformed != null ? transformed : tree.declarations;
-      var declarationType = tree.declarationType != VAR ?
-          VAR :
-          tree.declarationType;
-
-      tree = createVariableDeclarationList(declarationType, declarations);
-    }
-    return tree;
-  }
-
-  /**
-   * @param {FunctionBody} tree
-   * @return {FunctionBody}
-   */
-  transformFunctionBody(body) {
-    // Push new function context
-    var scope = this.push_(this.createFunctionScope_());
-
-    body = this.transformFunctionBodyStatements_(body);
-
-    this.pop_(scope);
-    return body;
-  }
-
-  /**
-   * @param {FunctionBody} tree
-   * @return {FunctionBody}
-   */
-  transformFunctionBodyStatements_(tree) {
-    var statements = this.transformList(tree.statements);
-
-    if (this.scope_.blockVariables != null) {
-      // rewrite into catch construct
-      tree = this.rewriteAsCatch_(
-          this.scope_.blockVariables,
-          createBlock(statements));
-    } else if (statements != tree.statements) {
-      tree = createFunctionBody(statements);
-    }
-
-    return tree;
-  }
-
-  /**
-   * @param {VariableDeclaration} variable
-   * @return {string}
-   */
-  getVariableName_(variable) {
-    // TODO(arv): This should just be a visitor visiting BindingIdentifier
-    var lvalue = variable.lvalue;
-    if (lvalue.type == BINDING_IDENTIFIER) {
-      return lvalue.identifierToken.value;
-    }
-    throw new Error('Unexpected destructuring declaration found.');
+          while (identScope !== fnScope && (identScope = identScope.parent)) {
+            if (identScope.hasLexicalBindingName(identifierToken)) {
+              return false;
+            }
+          }
+
+          while (fnScope = fnScope.parent) {
+            if (fnScope.hasLexicalBindingName(identifierToken)) {
+              return true;
+            }
+            if (fnScope === this.topScope_) break;
+          }
+          return false;
+        }).found;
   }
 }

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -229,8 +229,6 @@ export class DestructuringTransformer extends TempVarTransformer {
       return super.transformVariableDeclarationList(tree);
     }
 
-    this.pushTempScope();
-
     // Desugar one level of patterns.
     var desugaredDeclarations = [];
     tree.declarations.forEach((declaration) => {
@@ -247,8 +245,6 @@ export class DestructuringTransformer extends TempVarTransformer {
         createVariableDeclarationList(
             tree.declarationType,
             desugaredDeclarations));
-
-    this.popTempScope();
 
     return transformedTree;
   }

--- a/src/codegeneration/FindIdentifiers.js
+++ b/src/codegeneration/FindIdentifiers.js
@@ -1,0 +1,54 @@
+import {ScopeVisitor} from '../semantics/ScopeVisitor';
+
+/**
+ * FindIdentifiers class traverses a tree searching for identifier
+ * expressions till it finds one that passes the filter function. The logic of
+ * the filter function is provided by the caller of the class.
+ *
+ * This is used by FindBlockBindingInLoop to check if a function in a loop uses
+ * any block variables that are declared in the surrounding loop.
+ *
+ * This class wants to both be a ScopeVisitor and a FindVisitor,
+ * so FindVisitor's methods were copied and slightly modified here.
+ */
+export class FindIdentifiers extends ScopeVisitor {
+  constructor(tree, filterFunction) {
+    super();
+    this.filterFunction_ = filterFunction;
+    this.found_ = false;
+    this.visitAny(tree);
+  }
+
+  visitIdentifierExpression(tree) {
+    if (this.filterFunction_(tree.identifierToken.value, this.scope.tree)) {
+      this.found = true;
+    }
+  }
+
+  /**
+   * Whether the searched for tree was found. Setting this to true aborts the
+   * search.
+   * @type {boolean}
+   */
+  get found() {
+    return this.found_;
+  }
+
+  set found(v) {
+    if (v) {
+      this.found_ = true;
+    }
+  }
+
+  visitAny(tree) {
+    !this.found_ && tree && tree.visit(this);
+  }
+
+  visitList(list) {
+    if (list) {
+      for (var i = 0; !this.found_ && i < list.length; i++) {
+        this.visitAny(list[i]);
+      }
+    }
+  }
+}

--- a/src/codegeneration/FnExtractAbruptCompletions.js
+++ b/src/codegeneration/FnExtractAbruptCompletions.js
@@ -1,0 +1,215 @@
+import {ParseTreeTransformer} from './ParseTreeTransformer';
+import alphaRenameThisAndArguments from './alphaRenameThisAndArguments';
+import {parseStatement} from './PlaceholderParser';
+import {
+  BreakStatement,
+  ContinueStatement,
+  FormalParameterList,
+  ReturnStatement
+} from '../syntax/trees/ParseTrees';
+import {
+  createArgumentList,
+  createAssignmentExpression,
+  createBlock,
+  createCallExpression,
+  createCaseClause,
+  createDefaultClause,
+  createExpressionStatement,
+  createFunctionBody,
+  createFunctionExpression,
+  createIdentifierExpression,
+  createNumberLiteral,
+  createObjectLiteral,
+  createSwitchStatement,
+  createThisExpression,
+  createVariableDeclaration,
+  createVariableDeclarationList,
+  createVariableStatement,
+  createVoid0
+} from './ParseTreeFactory';
+
+import {
+  VAR
+} from '../syntax/TokenType';
+
+
+/**
+ * Givens a list of statements, this extracts all the needed `return`s,
+ * `break`s and `continue`s (abrupt completions statements).
+ * It returns an object containing
+ * - variableStatement: Might contain aliases to `this` and `arguments`,
+ *    and also a function
+ * - loopBody: Might contain a call to the function defined above, and also
+ *    a switch statement for the abrupt completions
+ */
+export class FnExtractAbruptCompletions extends ParseTreeTransformer {
+
+  constructor(idGenerator, requestParentLabel) {
+    this.idGenerator_ = idGenerator;
+    this.inLoop_ = 0;
+    this.inBreakble_ = 0;
+    this.variableDeclarations_ = [];
+    this.extractedStatements_ = [];
+    this.requestParentLabel_ = requestParentLabel;
+    this.labelledStatements_ = {};
+  }
+
+  createIIFE(body, paramList, argsList) {
+    body = this.transformAny(body);
+
+    body = alphaRenameThisAndArguments(this, body);
+    var tmpFnName = this.idGenerator_.generateUniqueIdentifier();
+    // function (...) { ... }
+    var functionExpression = createFunctionExpression(
+        new FormalParameterList(null, paramList),
+        createFunctionBody(body.statements || [body]));
+    // var $tmpFn = ${functionExpression}
+    this.variableDeclarations_.push(
+        createVariableDeclaration(tmpFnName, functionExpression));
+    // $tmpFn(...)
+    var functionCall = createCallExpression(
+        createIdentifierExpression(tmpFnName),
+        createArgumentList(argsList));
+
+    var loopBody = null;
+    if (this.extractedStatements_.length || this.hasReturns) {
+      var tmpVarName = createIdentifierExpression(
+          this.idGenerator_.generateUniqueIdentifier());
+      // hoist declaration
+      this.variableDeclarations_.push(
+          createVariableDeclaration(tmpVarName, null));
+
+      var maybeReturn;
+      if (this.hasReturns) {
+        // ${tmpVarName} is either a number of an object
+        // this check is enough since it's never null
+        maybeReturn = parseStatement `if (typeof ${tmpVarName} === "object")
+            return ${tmpVarName}.v;`;
+      }
+
+      if (this.extractedStatements_.length) {
+        // handle each extractedStatement as a case clause
+        var caseClauses = this.extractedStatements_.map(
+            (statement, index) => createCaseClause(
+                createNumberLiteral(index), [statement])
+        );
+
+        // default clause is the return statement, if it's needed
+        if (maybeReturn) {
+          caseClauses.push(createDefaultClause([maybeReturn]));
+        }
+
+        // $tmpVar = $tmpFn(...); switch($tmpVar) {...}
+        loopBody = createBlock([
+          createExpressionStatement(
+              createAssignmentExpression(tmpVarName, functionCall)),
+          createSwitchStatement(tmpVarName, caseClauses)
+        ]);
+      } else {
+        // $tmpVar = $tmpFn(...); ${maybeReturn}
+        loopBody = createBlock( [
+          createExpressionStatement(
+              createAssignmentExpression(tmpVarName, functionCall)),
+          maybeReturn
+        ]);
+      }
+    } else {
+      // $tmpFn(...)
+      loopBody = createBlock([createExpressionStatement(functionCall)]);
+    }
+
+
+    return {
+      variableStatements: createVariableStatement(
+          createVariableDeclarationList(VAR, this.variableDeclarations_)),
+      loopBody: loopBody
+    };
+  }
+
+  // alphaRenameThisAndArguments
+  addTempVarForArguments() {
+    var tmpVarName = this.idGenerator_.generateUniqueIdentifier();
+    this.variableDeclarations_.push(createVariableDeclaration(
+        tmpVarName, createThisExpression()));
+    return tmpVarName;
+  }
+  // alphaRenameThisAndArguments
+  addTempVarForThis() {
+    var tmpVarName = this.idGenerator_.generateUniqueIdentifier();
+    this.variableDeclarations_.push(createVariableDeclaration(
+        tmpVarName, createIdentifierExpression(ARGUMENTS)));
+    return tmpVarName;
+  }
+
+  transformAny(tree) {
+    if (tree) {
+      if (tree.isBreakableStatement()) this.inBreakble_++;
+      if (tree.isIterationStatement()) this.inLoop_++;
+      tree = super(tree);
+      if (tree.isBreakableStatement()) this.inBreakble_--;
+      if (tree.isIterationStatement()) this.inLoop_--;
+    }
+    return tree;
+  }
+
+  transformReturnStatement(tree) {
+    this.hasReturns = true;
+    return new ReturnStatement(tree.location, createObjectLiteral({
+      v: tree.expression || createVoid0()
+    }));
+  }
+
+  transformAbruptCompletion_(tree) {
+    this.extractedStatements_.push(tree);
+
+    var index = this.extractedStatements_.length - 1;
+    return parseStatement `return ${index};`
+  }
+
+  transformBreakStatement(tree) {
+    if (!tree.name) {
+      if (this.inBreakble_) {
+        return super(tree);
+      } else {
+        tree = new BreakStatement(tree.location,
+            this.requestParentLabel_());
+      }
+    } else if (this.labelledStatements_[tree.name]) {
+      return super(tree);
+    }
+    return this.transformAbruptCompletion_(tree);
+  }
+
+  transformContinueStatement(tree) {
+    if (!tree.name) {
+      if (this.inLoop_) {
+        return super(tree);
+      } else {
+        tree = new ContinueStatement(tree.location,
+            this.requestParentLabel_());
+      }
+    } else if (this.labelledStatements_[tree.name]) {
+      return super(tree);
+    }
+    return this.transformAbruptCompletion_(tree);
+  }
+
+  // keep track of labels in the tree
+  transformLabelledStatement(tree) {
+    this.labelledStatements_[tree.name] = true;
+    return super(tree);
+  }
+
+  // don't transform children functions
+  transformFunctionDeclaration(tree) {return tree;}
+  transformFunctionExpression(tree) {return tree;}
+  transformSetAccessor(tree) {return tree;}
+  transformGetAccessor(tree) {return tree;}
+  transformPropertyMethodAssignment(tree) {return tree;}
+  transformArrowFunctionExpression(tree) {return tree;}
+
+  static createIIFE(idGenerator, body, paramList, argsList, requestParentLabel) {
+    return new FnExtractAbruptCompletions(idGenerator, requestParentLabel)
+        .createIIFE(body, paramList, argsList);
+  }
+}

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -174,8 +174,13 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (transformOptions.spread)
       append(SpreadTransformer);
 
-    if (transformOptions.blockBinding)
-      append(BlockBindingTransformer);
+    if (transformOptions.blockBinding) {
+      this.append((tree) => {
+        // this transformer need to be aware of the tree it will be working on
+        var transformer = new BlockBindingTransformer(idGenerator, reporter, tree);
+        return transformer.transformAny(tree);
+      });
+    }
 
     // generator must come after for of and rest parameters
     if (transformOptions.generators || transformOptions.asyncFunctions)

--- a/src/codegeneration/ParseTreeFactory.js
+++ b/src/codegeneration/ParseTreeFactory.js
@@ -592,7 +592,7 @@ export function createObjectCreate(protoExpression, descriptors) {
  *     may be true, false or a ParseTree.
  * @return {ObjectLiteralExpression}
  */
-export function createPropertyDescriptor(descr) {
+export function createObjectLiteral(descr) {
   var propertyNameAndValues = Object.keys(descr).map(function(name) {
     var value = descr[name];
     if (!(value instanceof ParseTree))
@@ -620,7 +620,7 @@ export function createDefineProperty(tree, name, descr) {
       createArgumentList([
         tree,
         name,
-        createPropertyDescriptor(descr)
+        createObjectLiteral(descr)
       ]));
 }
 

--- a/src/semantics/Scope.js
+++ b/src/semantics/Scope.js
@@ -115,6 +115,18 @@ export class Scope {
     return null;
   }
 
+  getAllBindingNames() {
+    var names = Object.create(null);
+    var name;
+    for (name in this.variableDeclarations) {
+      names[name] = true;
+    }
+    for (name in this.lexicalDeclarations) {
+      names[name] = true;
+    }
+    return names;
+  }
+
   getVariableBindingNames() {
     var names = Object.create(null);
     for (var name in this.variableDeclarations) {
@@ -129,5 +141,17 @@ export class Scope {
       names[name] = true;
     }
     return names;
+  }
+
+  hasBindingName(name) {
+    return this.lexicalDeclarations[name] || this.variableDeclarations[name];
+  }
+
+  hasLexicalBindingName(name) {
+    return this.lexicalDeclarations[name];
+  }
+
+  hasVariableBindingName(name) {
+    return this.variableDeclarations[name];
   }
 }

--- a/src/semantics/VariableBinder.js
+++ b/src/semantics/VariableBinder.js
@@ -95,5 +95,5 @@ export function variablesInFunction(tree) {
   var builder = new ScopeChainBuilder(null);
   builder.visitAny(tree);
   var scope = builder.getScopeForTree(tree);
-  return scope.getVariableBindingNames();
+  return scope.getAllBindingNames();
 }

--- a/test/unit/codegeneration/BlockBindingTransformer.js
+++ b/test/unit/codegeneration/BlockBindingTransformer.js
@@ -1,0 +1,153 @@
+suite('BlockBindingTransformer.js', function() {
+  var BlockBindingTransformer = $traceurRuntime.ModuleStore.
+    getForTesting('src/codegeneration/BlockBindingTransformer').BlockBindingTransformer;
+  var UniqueIdentifierGenerator = $traceurRuntime.ModuleStore.
+    getForTesting('src/codegeneration/UniqueIdentifierGenerator').UniqueIdentifierGenerator;
+  var Parser = $traceurRuntime.ModuleStore.
+    getForTesting('src/syntax/Parser').Parser;
+  var SourceFile = $traceurRuntime.ModuleStore.
+    getForTesting('src/syntax/SourceFile').SourceFile;
+  var write = $traceurRuntime.ModuleStore.
+    getForTesting('src/outputgeneration/TreeWriter').write;
+  var ParseTreeValidator = $traceurRuntime.ModuleStore.
+    getForTesting('src/syntax/ParseTreeValidator').ParseTreeValidator;
+  var options = $traceurRuntime.ModuleStore.
+    getForTesting('src/Options').options;
+
+  var currentOption;
+
+  setup(function() {
+    currentOption = options.blockBinding;
+    options.blockBinding = true;
+  });
+
+  teardown(function() {
+    options.blockBinding = currentOption;
+  });
+
+  function parseExpression(content) {
+    var file = new SourceFile('test', content);
+    var parser = new Parser(file);
+    return parser.parseExpression();
+  }
+
+  function parseFunction(content) {
+    return parseExpression('function() {' + content + '}');
+  }
+
+  function normalize(content) {
+    var tree = parseExpression('function() {' + content + '}').body;
+    return write(tree);
+  }
+
+  function makeTest(name, code, expected) {
+    test(name, function() {
+      var tree = parseFunction(code);
+      var transformer = new BlockBindingTransformer(new UniqueIdentifierGenerator(), null, tree);
+      var transformed = transformer.transformAny(tree);
+      new ParseTreeValidator().visitAny(transformed);
+      assert.equal(normalize(expected), write(transformed.body));
+    });
+  }
+
+  makeTest('Let to Var', 'let x;', 'var x;');
+  makeTest('Let to Var In Block', '1; { 2; let x; }',
+    'var x$__0; 1; { 2; }');
+  makeTest('Let to Var In Block', '1; if (true) { 2; let x = 5; }',
+    'var x$__0; 1; if(true) { 2; x$__0 = 5; }');
+
+
+  makeTest('Let to Var In ForLoop', 'for(let i = 0; i < 5; i++);',
+    'for(var i$__0 = 0; i$__0 < 5; i$__0++);');
+  makeTest('Let to Var In ForLoop', 'for(let i = 0; i < 5; i++){ log(i); function t(){} }',
+    'var t$__1;' +
+    'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
+    '  log(i$__0);' +
+    '  t$__1 = function() {};' +
+    '}');
+
+
+  makeTest('Let to Var In ForLoop with Fn using local var', 'for(let i = 0; i < 5; i++){ function t(){alert(i); let i = 5;} }',
+    'var t$__1;' +
+    'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
+    '  t$__1 = function() {alert(i); var i = 5;};' +
+    '}');
+
+  suite('Loops with Fns using block variables', function() {
+    makeTest('Let to Var in',
+      'for(let i = 0; i < 5; i++){ function t(){log(i)} }',
+      // ======
+      'var $__1 = function(i) {' +
+      '  function t() {' +
+      '    log(i);' +
+      '  }' +
+      '};' +
+      'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
+        '$__1(i$__0);' +
+      '}');
+
+    makeTest('Return in Fn', 'for(let i = 0; i < 5; i++) { return function t(){return i;} }',
+        'var $__1 = function(i) {' +
+        '  return {v: function t() {' +
+        '    return i;' +
+        '  }};' +
+        '}, $__2;' +
+        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
+        '  $__2 = $__1(i$__0);' +
+        '  if (typeof $__2 === "object") ' +
+        '    return $__2.v;' +
+        '}');
+
+    makeTest('Return nothing in Fn', 'for(let i = 0; i < 5; i++) { return; function t(){return i;} } }',
+        'var $__1 = function(i) {' +
+        '  return {v: (void 0)};' +
+        '  function t(){return i;}' +
+        '}, $__2;' +
+        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
+        '  $__2 = $__1(i$__0);' +
+        '  if (typeof $__2 === "object") ' +
+        '    return $__2.v;' +
+        '}');
+
+    makeTest('Break and Continue in Fn',
+        'outer: while(true) {' +
+        ' for(let i = 0; i < 5; i++){ ' +
+        '   inner: while(true) {' +
+        '     break;' +
+        '     break outer;' +
+        '     break inner;' +
+        '     continue;' +
+        '     continue outer;' +
+        '     continue inner;' +
+        '     function t(){return i;} }' +
+        '   }' +
+        ' }',
+        // ======
+        'outer: while (true) {' +
+        '  var $__1 = function (i) {' +
+        '    var t$__3;' +
+        '    inner: while (true) {' +
+        '      break;' +
+        '      return 0;' +
+        '      break inner;' +
+        '      continue;' +
+        '      return 1;' +
+        '      continue inner;' +
+        '      t$__3 = function () {' +
+        '        return i;' +
+        '      };' +
+        '    }' +
+        '  }, $__2;' +
+        '  for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
+        '    $__2 = $__1(i$__0);' +
+        '    switch ($__2) {' +
+        '      case 0:' +
+        '        break outer;' +
+        '      case 1:' +
+        '        continue outer;' +
+        '    }' +
+        '  }' +
+        '}');
+    
+  })
+});


### PR DESCRIPTION
This is my proposition to optimize the BlockBindingTransfomer

The general idea behind it is:
- No longer use try-catch
- In variable declarations, transform any `let/const` to `var` and rename the variable to avoid name collisions.
- In loops, check if it contains any block bindings AND function declarations that use those block binded variables. 
  If that's the case, then extract the loopBody to a function (~iife), and transform the final loopBody to invoke that function. 
  The loopBody could have had `break`s, `continue`s and `return`s in it. These are handled by `if` statements and `switch` cases in the resulting transformed loopBody. Labels are accounted for (see tests)
- If the loop doesn't contain block bindings that are used in function declarations, then everything is transformed to `var` and renamed to avoid name collisions.

The PR isn't perfect and does have some rough edges. Please do comment on them and bash anything wrong that you see. It's my first contribution to traceur :-)
It does pass all the tests.

It's a significant change.
I'm free most days if anyone wants to pair up for quicker review
