### PR TITLE
Use template literals when logging an invalid superClass

### DIFF
--- a/src/runtime/classes.js
+++ b/src/runtime/classes.js
@@ -101,8 +101,8 @@
     if (superClass === null)
       return null;
     throw new $TypeError(
-        'Super expression must either be null or a function, not ' +
-        typeof superClass + '.');
+      `Super expression must either be null or a function, not ${
+        typeof superClass}.`);
   }
 
   function defaultSuperCall(self, homeObject, args) {


### PR DESCRIPTION
PR prompted by @arv's [comment](https://github.com/google/traceur-compiler/pull/1242#discussion_r15962463) and impatience
