### PR TITLE
Support CommonJS loading from ES6

### DIFF
--- a/test/commonjs/node-require.js
+++ b/test/commonjs/node-require.js
@@ -1,0 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
+assert.equal('"use strict";\nvar $__fs__,\n    $__path__;', 
+    fs.readFileSync(path.resolve(__dirname, 'node-require.js'))
+    .toString().substr(0, 41));

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -232,7 +232,7 @@ suite('context test', function() {
       assert.isNull(error);
       var fileContents = fs.readFileSync(path.resolve(outDir, 'file.js'));
       var depContents = fs.readFileSync(path.resolve(outDir, 'dep.js'));
-      assert.equal(fileContents + '', "\"use strict\";\nObject.defineProperties(exports, {\n  p: {get: function() {\n      return p;\n    }},\n  __esModule: {value: true}\n});\nvar q = require('./dep').q;\nvar p = 'module';\n");
+      assert.equal(fileContents + '', "\"use strict\";\nObject.defineProperties(exports, {\n  p: {get: function() {\n      return p;\n    }},\n  __esModule: {value: true}\n});\nvar $__dep__;\nvar q = ($__dep__ = require(\"./dep\"), $__dep__ && $__dep__.__esModule && $__dep__ || {default: $__dep__}).q;\nvar p = 'module';\n");
       assert.equal(depContents + '', "\"use strict\";\nObject.defineProperties(exports, {\n  q: {get: function() {\n      return q;\n    }},\n  __esModule: {value: true}\n});\nvar q = 'q';\n");
       done();
     });


### PR DESCRIPTION
This resolves https://github.com/google/traceur-compiler/issues/818.

The following use cases become possible:
- Compiling a NodeJS project from ES6 into CommonJS for hosting on npm.
- Writing ES6 that imports from NodeJS builtins
- Writing ES6 and compiling into CommonJS to be browserified into the browser, sharing dependencies with browserify modules.
- Running `traceur app.js` and running an ES6 app that loads both CommonJS through the node module system and ES6. (correction - actually I'm not sure if this use case applies, but it is a related compatibility).

The benefit of combining CommonJS loading through ES6 imports, is that this is what the dynamic module loader is designed to handle. The way this implementation runs, it is fully-compatible with the dynamic module loader as well.

Since CommonJS already uses the runtime for destructuring, this is implemented with a runtime function. It also allows the implementation to be improved when a `Reflect.isModule` function is available or similar for true ES6 environments.

I feel pretty happy this is the right direction for this interop, and note that this interop exists regardless of our support, but as a broken interop otherwise, as discussed in https://github.com/google/traceur-compiler/issues/818.
