### PR TITLE
Ensure traceur System is exported not the global

### DIFF
--- a/src/traceur.js
+++ b/src/traceur.js
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import './runtime/System';
+export {System} from './runtime/System';
 
 // Used by unit tests only
 import './util/MutedErrorReporter';
 
 export {ModuleStore} from '@traceur/src/runtime/ModuleStore';
-export {System};
 export {WebPageTranscoder} from './WebPageTranscoder';
 export {options} from './Options';
 import {addOptions, CommandOptions} from './Options';


### PR DESCRIPTION
If `global.System` is re-assigned, it is possible for `traceur.System` to reference the wrong `System`.

This fixes that by ensuring only the internal Traceur `System` is exported.
