### PR TITLE
Add support for export default FunctionExpression

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -466,7 +466,7 @@ export class Parser {
   parseImportDeclaration_() {
     var start = this.getTreeStartLocation_();
     this.eat_(IMPORT);
-    
+
     // import * as m from './m.js'
     if (this.peek_(STAR)) {
       this.eat_(STAR);
@@ -601,11 +601,28 @@ export class Parser {
     var exportValue;
     switch (this.peekType_()) {
       case FUNCTION:
-        exportValue = this.parseFunctionDeclaration_();
+        // Use FunctionExpression as a cover grammar. If it has a name it is
+        // treated as a declaration.
+        var tree = this.parseFunctionExpression_();
+        if (tree.name) {
+          tree = new FunctionDeclaration(tree.location, tree.name,
+                                         tree.functionKind, tree.parameterList,
+                                         tree.typeAnnotation, tree.annotations,
+                                         tree.body);
+        }
+        exportValue = tree;
         break;
       case CLASS:
         if (parseOptions.classes) {
-          exportValue = this.parseClassDeclaration_();
+          // Use ClassExpression as a cover grammar. If it has a name it is
+          // treated as a declaration.
+          var tree = this.parseClassExpression_();
+          if (tree.name) {
+            tree = new ClassDeclaration(tree.location, tree.name,
+                                        tree.superClass, tree.elements,
+                                        tree.annotations);
+          }
+          exportValue = tree;
           break;
         }
         // Fall through.

--- a/test/feature/Annotations/resources/exported-default-class.js
+++ b/test/feature/Annotations/resources/exported-default-class.js
@@ -1,7 +1,7 @@
 import {Anno} from './setup';
 
 @Anno
-export default (class {
+export default class {
   @Anno
   annotatedMethod() {}
-});
+};

--- a/test/feature/Annotations/resources/exported-default-function.js
+++ b/test/feature/Annotations/resources/exported-default-function.js
@@ -1,4 +1,4 @@
 import {Anno} from './setup';
 
 @Anno
-export default (function (@Anno x) {});
+export default function (@Anno x) {};

--- a/test/feature/Modules/ImportDefault.js
+++ b/test/feature/Modules/ImportDefault.js
@@ -9,3 +9,9 @@ assert.equal(D, 4);
 
 import f from './resources/default-function';
 assert.equal(f(), 123);
+
+import E from './resources/default-class-expression';
+assert.equal(new E().n(), 'n');
+
+import g from './resources/default-function-expression';
+assert.equal(g(), 456);

--- a/test/feature/Modules/resources/default-class-expression.js
+++ b/test/feature/Modules/resources/default-class-expression.js
@@ -1,0 +1,5 @@
+export default class {
+  n() {
+    return 'n';
+  }
+}

--- a/test/feature/Modules/resources/default-function-expression.js
+++ b/test/feature/Modules/resources/default-function-expression.js
@@ -1,0 +1,3 @@
+export default function() {
+  return 456;
+}


### PR DESCRIPTION
and export default ClassExpression

We parse the expression as a FunctionExpression and if it has a name
we change it into a FunctionDeclaration. Same goes for ClassExpression.

Fixes #1208
