### PR TITLE
Hoist function declarations in generator functions

### DIFF
--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -95,11 +95,19 @@ function needsStateMachine(tree) {
 }
 
 class HoistVariables extends HoistVariablesTransformer {
+  constructor() {
+    super(true);  // Hoist functions.
+  }
+
   /**
    * Override to not inject the hoisted variables. We will manually inject them
    * later.
    */
   prependVariables(statements) {
+    return statements;
+  }
+
+  prependFunctions(statements) {
     return statements;
   }
 }
@@ -1039,6 +1047,8 @@ export class CPSTransformer extends TempVarTransformer {
         replaceStartState(State.START_STATE);
 
     var statements = [];
+    if (this.hoistVariablesTransformer_.hasFunctions())
+      statements.push(...this.hoistVariablesTransformer_.getFunctions());
     if (this.hoistVariablesTransformer_.hasVariables())
       statements.push(this.hoistVariablesTransformer_.getVariableStatement());
     if (hasArguments)

--- a/test/feature/Yield/FunctionDeclaration.js
+++ b/test/feature/Yield/FunctionDeclaration.js
@@ -1,0 +1,12 @@
+(function() {
+
+  function* f() {
+    function g() {
+      return 42;
+    }
+    yield g;
+  }
+
+  assert.equal(42, f().next().value());
+
+})();


### PR DESCRIPTION
This is so that we do not add a function where it isn't allowed
in ES5 strict mode, due to the CPS transformer.

Fixes #1172
