### PR TITLE
Tag git with traceur's npm version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/compiled-by-previous-traceur.js
 build/currentSemVer.mk
 build/local.mk
 build/node
+build/npm-version-number
 build/previous-commit-traceur.js
 node_modules
 out

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ bin/traceur.ugly.js: bin/traceur.js
 	uglifyjs bin/traceur.js --compress -m -o $@
 
 updateSemver: # unless the package.json has been manually edited.
+	node build/printSemver.js > build/npm-version-number
 	git diff --quiet -- package.json && node build/incrementSemver.js
 
 # --- Targets that push upstream.
@@ -280,8 +281,8 @@ update-version-number: npm-publish updateSemver
 	$(MAKE) test  # build version N+1
 
 git-update-version: update-version-number
-	./traceur -v | xargs -I VERSION git commit -a -m "VERSION"
-	./traceur -v | xargs -I VERSION git tag -a VERSION -m "Tagged version VERSION "
+	cat build/npm-version-number | xargs -I VERSION git commit -a -m "VERSION"
+	cat build/npm-version-number | xargs -I VERSION git tag -a VERSION -m "Tagged version VERSION "
 	git push --tags upstream upstream_master:master
 	git push upstream upstream_master:master  # Push source for version N+1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traceur",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "ES6 to ES5 compiler",
   "keywords": [
     "javascript",
@@ -47,7 +47,7 @@
     "rsvp": "3.x",
     "requirejs": "2.x",
     "semver": "2.x",
-    "traceur": "0.0.56",
+    "traceur": "0.0.57",
     "promises-aplus-tests": "2.x",
     "compat-table": "git+https://github.com/kangax/compat-table.git#gh-pages",
     "colors": "~0.6.0-1",


### PR DESCRIPTION
rather than the version on bin/traceur.js
Update the version (and publish to npm)
one time without a tag to get in sync.

Fixes #1261

TBR=@arv
