### PR TITLE
Move comprehensions to experimental

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -24,7 +24,7 @@ function enumerableOnlyObject(obj) {
 // Traceur sets these default options and no others for v 0.1.*
 export var optionsV01 = enumerableOnlyObject({
   annotations: false,
-  arrayComprehension: true,
+  arrayComprehension: false,
   arrowFunctions: true,
   script: false,
   asyncFunctions: false,
@@ -39,7 +39,7 @@ export var optionsV01 = enumerableOnlyObject({
   filename: undefined,
   forOf: true,
   freeVariableChecker: false,
-  generatorComprehension: true,
+  generatorComprehension: false,
   generators: true,
   moduleName: false,
   modules: 'register',
@@ -395,14 +395,12 @@ function addBoolOption(name) {
 }
 
 // ON_BY_DEFAULT
-addFeatureOption('arrayComprehension', ON_BY_DEFAULT); // 11.4.1.2
 addFeatureOption('arrowFunctions', ON_BY_DEFAULT);     // 13.2
 addFeatureOption('classes', ON_BY_DEFAULT);            // 13.5
 addFeatureOption('computedPropertyNames', ON_BY_DEFAULT);  // 11.1.5
 addFeatureOption('defaultParameters', ON_BY_DEFAULT);  // Cant find in the spec
 addFeatureOption('destructuring', ON_BY_DEFAULT);      // 11.13.1
 addFeatureOption('forOf', ON_BY_DEFAULT);              // 12.6.4
-addFeatureOption('generatorComprehension', ON_BY_DEFAULT);
 addFeatureOption('generators', ON_BY_DEFAULT); // 13.4
 addFeatureOption('modules', 'SPECIAL');    // 14
 addFeatureOption('numericLiterals', ON_BY_DEFAULT);
@@ -414,9 +412,11 @@ addFeatureOption('templateLiterals', ON_BY_DEFAULT);   // 7.6.8
 
 // EXPERIMENTAL
 addFeatureOption('annotations', EXPERIMENTAL);
+addFeatureOption('arrayComprehension', EXPERIMENTAL); // 11.4.1.2
 addFeatureOption('asyncFunctions', EXPERIMENTAL);
 addFeatureOption('blockBinding', EXPERIMENTAL);       // 12.1
 addFeatureOption('exponentiation', EXPERIMENTAL);
+addFeatureOption('generatorComprehension', EXPERIMENTAL);
 addFeatureOption('symbols', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
 

--- a/test/feature/ArrayComprehension/ArgumentsInComprehension.js
+++ b/test/feature/ArrayComprehension/ArgumentsInComprehension.js
@@ -1,3 +1,4 @@
+// Options: --array-comprehension
 // https://github.com/google/traceur-compiler/issues/1086
 
 function f() {

--- a/test/feature/ArrayComprehension/Closure.js
+++ b/test/feature/ArrayComprehension/Closure.js
@@ -1,4 +1,4 @@
-// Options: --block-binding
+// Options: --array-comprehension --block-binding
 // Block binding is needed to get the right scoping semantics inside the arrow
 // function in the comprehension.
 

--- a/test/feature/ArrayComprehension/Error_NotDefined.js
+++ b/test/feature/ArrayComprehension/Error_NotDefined.js
@@ -1,3 +1,4 @@
+// Options: --array-comprehension
 // Should not compile.
 
 var array = [for (notDefined of [0]) notDefined];

--- a/test/feature/ArrayComprehension/Simple.js
+++ b/test/feature/ArrayComprehension/Simple.js
@@ -1,3 +1,5 @@
+// Options: --array-comprehension
+
 function* range() {
   for (var i = 0; i < 5; i++) {
     yield i;

--- a/test/feature/ArrayComprehension/ThisInComprehension.js
+++ b/test/feature/ArrayComprehension/ThisInComprehension.js
@@ -1,3 +1,4 @@
+// Options: --array-comprehension
 // https://github.com/google/traceur-compiler/issues/1086
 
 var object = {};

--- a/test/feature/GeneratorComprehension/Error_NotDefined.js
+++ b/test/feature/GeneratorComprehension/Error_NotDefined.js
@@ -1,3 +1,4 @@
+// Options: --generator-comprehension
 // Should not compile.
 
 var iter = (for (notDefined of [0]) notDefined);

--- a/test/feature/GeneratorComprehension/Simple.js
+++ b/test/feature/GeneratorComprehension/Simple.js
@@ -1,3 +1,5 @@
+// Options: --generator-comprehension
+
 function accumulate(iterator) {
   var result = '';
   for (var value of iterator) {

--- a/test/feature/GeneratorComprehension/Skip_Closure.js
+++ b/test/feature/GeneratorComprehension/Skip_Closure.js
@@ -1,3 +1,4 @@
+// Options: --generator-comprehension
 // Skip. The sugaring uses var instead of let which leads to wrong closure.
 
 var iter = (for (x of [0, 1]) for (y of [2, 3]) () => [x, y] );

--- a/test/unit/codegeneration/HoistVariablesTransformer.js
+++ b/test/unit/codegeneration/HoistVariablesTransformer.js
@@ -27,15 +27,14 @@ suite('HoistVariablesTransformer.js', function() {
   var options = $traceurRuntime.ModuleStore.
       getForTesting('src/Options').options;
 
-  var currentOption;
-
   setup(function() {
-    currentOption = options.blockBinding;
+    options.arrayComprehension = true;
     options.blockBinding = true;
+    options.generatorComprehension = true;
   });
 
   teardown(function() {
-    options.blockBinding = currentOption;
+    options.reset();
   });
 
   function parseExpression(content) {

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -84,6 +84,7 @@ suite('context test', function() {
 
   test('generator', function(done) {
     var fileName = path.resolve(__dirname, 'resources/generator.js');
+    traceur.options.generatorComprehension = true;
     executeFileWithRuntime(fileName).then(function(value) {
       assert.deepEqual(value, [1, 2, 9, 16]);
       done();
@@ -92,6 +93,7 @@ suite('context test', function() {
 
   test('generator (symbols)', function(done) {
     var fileName = path.resolve(__dirname, 'resources/generator.js');
+    traceur.options.generatorComprehension = true;
     traceur.options.symbols = true;
     executeFileWithRuntime(fileName).then(function(value) {
       assert.deepEqual(value, [1, 2, 9, 16]);

--- a/test/unit/semantics/ConstChecker.js
+++ b/test/unit/semantics/ConstChecker.js
@@ -29,7 +29,9 @@ suite('ConstChecker.js', function() {
 
   function makeTest(name, code, expectedErrors, mode) {
     test(name, function() {
+      traceur.options.arrayComprehension = true;
       traceur.options.blockBinding = true;
+      traceur.options.generatorComprehension = true;
       var reporter = new ErrorReporter();
       var parser = new Parser(new SourceFile('SOURCE', code), reporter);
       var tree = mode === 'script' ?

--- a/test/unit/semantics/FreeVariableChecker.js
+++ b/test/unit/semantics/FreeVariableChecker.js
@@ -38,7 +38,9 @@ suite('FreeVariableChecker.js', function() {
 
   setup(function() {
     traceur.options.reset();
+    traceur.options.arrayComprehension = true;
     traceur.options.blockBinding = true;
+    traceur.options.generatorComprehension = true;
   });
 
   teardown(function() {


### PR DESCRIPTION
Since comprehensions have been post poned to post ES6 we should not
have them enabled by default.

Fixes #1260
