### PR TITLE
Remove Promise.cast; update Promise.resolve

### DIFF
--- a/src/runtime/polyfills/Promise.js
+++ b/src/runtime/polyfills/Promise.js
@@ -125,6 +125,9 @@ export class Promise {
 
   static resolve(x) {
     if (this === $Promise) {
+      if (isPromise(x)) {
+        return x;
+      }
       // Optimized case, avoid extra closure.
       return promiseSet(new $Promise(promiseRaw), +1, x);
     } else {
@@ -142,18 +145,6 @@ export class Promise {
   }
 
   // Combinators.
-
-  static cast(x) {
-    if (x instanceof this)
-      return x;
-    if (isPromise(x)) {
-      var result = getDeferred(this);
-      chain(x, result.resolve, result.reject);
-      return result.promise;
-    }
-    return this.resolve(x);
-
-  }
 
   static all(values) {
     var deferred = getDeferred(this);

--- a/test/feature/PromiseResolve.js
+++ b/test/feature/PromiseResolve.js
@@ -1,0 +1,3 @@
+var p = Promise.resolve(42);
+
+assert.equal(p, Promise.resolve(p));


### PR DESCRIPTION
A while ago Promise.resolve took on Promise.cast's behavior, and Promise.cast then died. This bit me pretty hard today when switching between Node 0.11's promises (for which that change is present) and Traceur's under Node 0.10 (which still have the old resolve).
