### PR TITLE
Add rsvp to depencencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "commander": "2.x",
     "glob": "4.x",
-    "semver": "2.x"
+    "semver": "2.x",
+    "rsvp": "3.x"
   },
   "devDependencies": {
     "source-map": "0.1.34",


### PR DESCRIPTION
My devDependencies look like this:

``` json
"devDependencies": {
    "grunt": "^0.4.5",
    "grunt-contrib-concat": "^0.5.0",
    "grunt-contrib-connect": "^0.8.0",
    "grunt-contrib-jshint": "^0.10.0",
    "grunt-contrib-watch": "^0.6.1",
    "grunt-karma": "^0.8.3",
    "grunt-ng-annotate": "^0.3.2",
    "grunt-phpunit": "^0.3.4",
    "grunt-protractor-runner": "^1.1.4",
    "grunt-protractor-webdriver": "^0.1.8",
    "grunt-traceur": "^0.2.4",
    "grunt-wrap": "^0.3.0",
    "karma": "^0.12.23",
    "karma-chrome-launcher": "^0.1.4",
    "karma-coverage": "^0.2.6",
    "karma-firefox-launcher": "^0.1.3",
    "karma-jasmine": "^0.1.5",
    "karma-phantomjs-launcher": "^0.1.4",
    "karma-traceur-preprocessor": "^0.3.1",
    "traceur": "^0.0.59"
  }
```

Now when i run **npm install** it installs all the deps but when I try to run my grunt traceur task it complains about missing rsvp lib:

```
$ grunt
Loading "traceur.js" tasks...ERROR
>> Error: Cannot find module 'rsvp'
Warning: Task "traceur" not found. Use --force to continue.

Aborted due to warnings.
```

Running **npm install rsvp** fixes the issue so I think it's correct to put rsvp into the dependencies section
