### PR TITLE
Bug in async function try/finally: never reaches finally

### DIFF
--- a/test/feature/AsyncFunctions/Finally2.js
+++ b/test/feature/AsyncFunctions/Finally2.js
@@ -1,0 +1,23 @@
+// Options: --async-functions
+// Async.
+
+var finallyVisited = false;
+
+var resolve;
+var p = new Promise((r) => {
+  resolve = r;
+});
+
+async function test() {
+  try {
+    await p;
+  } finally {
+    finallyVisited = true;
+  }
+  assert.isTrue(finallyVisited);
+  done();
+}
+
+test();
+assert.isFalse(finallyVisited);
+resolve();


### PR DESCRIPTION
Found an odd error in the wild today. If you await on an expression inside a try/finally block, but do not assign the result to a variable, you will never reach the finally clause. That is, code of the form

```
    try {
      await p;
    } finally {
      ...
    }
```

will not reach the finally clause, but if you make the slight tweak to

```
    try {
      var v = await p;
    } finally {
      ...
    }
```

it will. (This latter test is what is in the test suite)

This PR adds a (failing) test to catch this error. Hopefully someone with more experience than I can actually fix this bug.
