### PR TITLE
Use the `files` directive in `package.json` instead of `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-*
-!src/node/*.js
-!bin/traceur.js
-!bin/traceur-runtime.js
-!traceur
-!demo
-!README.md

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
   "bin": {
     "traceur": "./traceur"
   },
+  "files": [
+    "src/node/*.js",
+    "bin/traceur.js",
+    "bin/traceur-runtime.js",
+    "traceur"
+  ],
   "scripts": {
     "test": "make test",
     "start": "make && node ./demo/expressServer.js"


### PR DESCRIPTION
`.npmignore` is a blacklist, while `files` is a whitelist-based approach. The latter is much easier to maintain. See https://www.npmjs.org/doc/files/package.json.html#files for more info.

This patch does not affect the files that are included in the package:
#### Before

``` bash
$ tarball="$(npm pack .)"; wc -c "${tarball}"; tar tvf "${tarball}"; rm "${tarball}";
  186600 traceur-0.0.61.tgz
-rw-r--r--  0 501    20       1310 Sep  5 17:11 package/package.json
-rw-r--r--  0 501    20       2045 Aug 24 22:57 package/README.md
-rw-r--r--  0 501    20      73977 Sep  5 17:38 package/bin/traceur-runtime.js
-rw-r--r--  0 501    20    1029605 Sep  5 17:51 package/bin/traceur.js
-rw-r--r--  0 501    20       2918 Aug 24 22:57 package/src/node/NodeCompiler.js
-rw-r--r--  0 501    20       1890 Aug 24 22:57 package/src/node/compileAllJsFilesInDir.js
-rw-r--r--  0 501    20       3351 Aug 24 22:57 package/src/node/deferred.js
-rw-r--r--  0 501    20       2203 Aug 24 22:57 package/src/node/file-util.js
-rw-r--r--  0 501    20       5052 Sep  3 16:23 package/src/node/command.js
-rwxr-xr-x  0 501    20       1148 Sep  5 16:28 package/src/node/interpreter.js
-rw-r--r--  0 501    20       1149 Aug 24 22:57 package/src/node/nodeLoader.js
-rw-r--r--  0 501    20       6788 Sep  5 16:28 package/src/node/recursiveModuleCompile.js
-rw-r--r--  0 501    20       2006 Aug 24 22:57 package/src/node/require.js
-rw-r--r--  0 501    20        984 Aug 24 22:57 package/src/node/to-amd-compiler.js
-rw-r--r--  0 501    20       2003 Aug 24 22:57 package/src/node/api.js
-rw-r--r--  0 501    20        994 Aug 24 22:57 package/src/node/to-commonjs-compiler.js
-rw-r--r--  0 501    20        977 Sep  5 16:28 package/src/node/System.js
-rw-r--r--  0 501    20       1026 Sep  3 11:41 package/src/node/traceur.js
-rw-r--r--  0 501    20       4000 Aug 24 22:57 package/src/node/getopt.js
-rwxr-xr-x  0 501    20         55 Aug 24 22:57 package/traceur
```
#### After

``` bash
$ tarball="$(npm pack .)"; wc -c "${tarball}"; tar tvf "${tarball}"; rm "${tarball}";
  186619 traceur-0.0.61.tgz
-rw-r--r--  0 501    20       1415 Sep  5 21:37 package/package.json
-rw-r--r--  0 501    20       2045 Aug 24 22:57 package/README.md
-rw-r--r--  0 501    20      73977 Sep  5 17:38 package/bin/traceur-runtime.js
-rw-r--r--  0 501    20    1029605 Sep  5 17:51 package/bin/traceur.js
-rw-r--r--  0 501    20       2918 Aug 24 22:57 package/src/node/NodeCompiler.js
-rw-r--r--  0 501    20       1890 Aug 24 22:57 package/src/node/compileAllJsFilesInDir.js
-rw-r--r--  0 501    20       3351 Aug 24 22:57 package/src/node/deferred.js
-rw-r--r--  0 501    20       2203 Aug 24 22:57 package/src/node/file-util.js
-rw-r--r--  0 501    20       5052 Sep  3 16:23 package/src/node/command.js
-rwxr-xr-x  0 501    20       1148 Sep  5 16:28 package/src/node/interpreter.js
-rw-r--r--  0 501    20       1149 Aug 24 22:57 package/src/node/nodeLoader.js
-rw-r--r--  0 501    20       6788 Sep  5 16:28 package/src/node/recursiveModuleCompile.js
-rw-r--r--  0 501    20       2006 Aug 24 22:57 package/src/node/require.js
-rw-r--r--  0 501    20        984 Aug 24 22:57 package/src/node/to-amd-compiler.js
-rw-r--r--  0 501    20       2003 Aug 24 22:57 package/src/node/api.js
-rw-r--r--  0 501    20        994 Aug 24 22:57 package/src/node/to-commonjs-compiler.js
-rw-r--r--  0 501    20        977 Sep  5 16:28 package/src/node/System.js
-rw-r--r--  0 501    20       1026 Sep  3 11:41 package/src/node/traceur.js
-rw-r--r--  0 501    20       4000 Aug 24 22:57 package/src/node/getopt.js
-rwxr-xr-x  0 501    20         55 Aug 24 22:57 package/traceur
```
