### PR TITLE
Fix issue with finally in async functions

### DIFF
--- a/src/codegeneration/generator/AsyncTransformer.js
+++ b/src/codegeneration/generator/AsyncTransformer.js
@@ -109,15 +109,11 @@ export class AsyncTransformer extends CPSTransformer {
       expression = this.transformAny(inExpression);
     }
 
-
     var createTaskState = this.allocateState();
-    var callbackState = this.allocateState();
     var fallThroughState = this.allocateState();
-    if (!left)
-      callbackState = fallThroughState;
+    var callbackState = left ? this.allocateState() : fallThroughState;
 
     var states = [];
-    var expression = this.transformAny(expression);
     //  case createTaskState:
     states.push(new AwaitState(createTaskState, callbackState, expression));
 
@@ -133,9 +129,8 @@ export class AsyncTransformer extends CPSTransformer {
               left,
               operator,
               parseExpression `$ctx.value`));
-      var assignment = [statement];
       states.push(new FallThroughState(callbackState, fallThroughState,
-                                       assignment));
+                                       [statement]));
     }
 
     var awaitMachine =

--- a/src/codegeneration/generator/GeneratorTransformer.js
+++ b/src/codegeneration/generator/GeneratorTransformer.js
@@ -104,10 +104,7 @@ export class GeneratorTransformer extends CPSTransformer {
     var startState = this.allocateState();
     var fallThroughState = this.allocateState();
     var yieldMachine = this.stateToStateMachine_(
-        new YieldState(
-            startState,
-            fallThroughState,
-            this.transformAny(expression)),
+        new YieldState(startState, fallThroughState, expression),
         fallThroughState);
 
     if (machine)

--- a/test/feature/AsyncFunctions/Finally2.js
+++ b/test/feature/AsyncFunctions/Finally2.js
@@ -1,0 +1,21 @@
+// Options: --async-functions
+// Async.
+
+var finallyVisited = false;
+var resolve;
+
+async function test() {
+  try {
+    await new Promise((r) => {
+      resolve = r;
+    });
+  } finally {
+    finallyVisited = true;
+  }
+  assert.isTrue(finallyVisited);
+  done();
+}
+
+test();
+assert.isFalse(finallyVisited);
+resolve();


### PR DESCRIPTION
We were not correctly going to the finally state after an await
when there were no more statement (including generated) after the
await in the try block.

This sets the finallyFallThrough state and updates the callback id
to go the finally state.

Fixes #1316
