### PR TITLE
instantiate generators fix

### DIFF
--- a/src/codegeneration/HoistVariablesTransformer.js
+++ b/src/codegeneration/HoistVariablesTransformer.js
@@ -108,7 +108,7 @@ class HoistVariablesTransformer extends ParseTreeTransformer {
 
   getVariableStatement() {
     if (!this.hasVariables())
-      return null;
+      return new AnonBlock(null, []);
 
     var declarations = this.getVariableNames().map((name) => {
       return createVariableDeclaration(name, null);

--- a/test/instantiate/generator.js
+++ b/test/instantiate/generator.js
@@ -1,0 +1,3 @@
+export function* generator() {
+  yield 1;
+}

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -92,4 +92,10 @@ suite('instantiate', function() {
       });
     }).catch(done);
   });
+
+  test('Generator exports', function(done) {
+    System.import('generator').then(function(m) {
+      done();
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
There was a null block being incorrectly returned, which was only being picked up when exporting a generator function.

This fixes that issue and includes a test for generator exports.
