### PR TITLE
Recompute `entries_.length` on each iteration of MapIterator and Map.prototype.forEach

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Fabrício Matté <ultcombo@gmail.com>
 Jordan Harband <ljharb@gmail.com>
 Martín Ciparelli <mciparelli@gmail.com>
 David Håsäther <hasather@gmail.com>
+Amjad Masad <amjad.masad@gmail.com>

--- a/src/runtime/polyfills/Map.js
+++ b/src/runtime/polyfills/Map.js
@@ -138,7 +138,7 @@ export class Map {
   }
 
   forEach(callbackFn, thisArg = undefined) {
-    for (var i = 0, len = this.entries_.length; i < len; i += 2) {
+    for (var i = 0; i < this.entries_.length; i += 2) {
       var key = this.entries_[i];
       var value = this.entries_[i + 1];
 
@@ -150,7 +150,7 @@ export class Map {
   }
 
   *entries() {
-    for (var i = 0, len = this.entries_.length; i < len; i += 2) {
+    for (var i = 0; i < this.entries_.length; i += 2) {
       var key = this.entries_[i];
       var value = this.entries_[i + 1];
 
@@ -162,7 +162,7 @@ export class Map {
   }
 
   *keys() {
-    for (var i = 0, len = this.entries_.length; i < len; i += 2) {
+    for (var i = 0; i < this.entries_.length; i += 2) {
       var key = this.entries_[i];
       var value = this.entries_[i + 1];
 
@@ -174,7 +174,7 @@ export class Map {
   }
 
   *values() {
-    for (var i = 0, len = this.entries_.length; i < len; i += 2) {
+    for (var i = 0; i < this.entries_.length; i += 2) {
       var key = this.entries_[i];
       var value = this.entries_[i + 1];
 

--- a/test/feature/Collections/Map.js
+++ b/test/feature/Collections/Map.js
@@ -69,12 +69,16 @@ var arrKeys = [];
 var arr = [];
 var cnt = 0;
 t.forEach(function (value, key, map) {
+  if (cnt === 0) {
+    t.set('foo', 42);
+  }
   assert.equal(map, t);
   arrKeys.push(key);
   arr.push(value);
   cnt++;
 });
-assert.equal(cnt, 8);
+assert.equal(cnt, 9);
+t.delete('foo');
 
 assertArrayEquals(arrKeys, [
   undefinedKey,
@@ -84,7 +88,8 @@ assertArrayEquals(arrKeys, [
   booleanKey,
   objectKey,
   nanKey,
-  zeroKey
+  zeroKey,
+  'foo'
 ]);
 assertArrayEquals(arr, [
   'value8',
@@ -94,7 +99,8 @@ assertArrayEquals(arr, [
   'value7',
   'value1',
   'value10',
-  'value11'
+  'value11',
+  42
 ]);
 
 // iterator
@@ -103,16 +109,20 @@ arr = [];
 cnt = 0;
 
 for (var mapIterItem of t) {
+  if (cnt === 0) {
+    t.set('foo', 42);
+  }
   var [mapIterItemKey, mapIterItemVal] = mapIterItem;
   arrKeys.push(mapIterItemKey);
   arr.push(mapIterItemVal);
   cnt++;
 }
-assert.equal(cnt, 8);
+assert.equal(cnt, 9);
+t.delete('foo');
 
 assertArrayEquals(arrKeys, [ undefinedKey, nullKey, stringKey,
     numberKey, booleanKey, objectKey,
-    nanKey, zeroKey ]);
+    nanKey, zeroKey, 'foo' ]);
 assertArrayEquals(arr, [
   'value8',
   'value9',
@@ -121,7 +131,8 @@ assertArrayEquals(arr, [
   'value7',
   'value1',
   'value10',
-  'value11'
+  'value11',
+  42
 ]);
 
 


### PR DESCRIPTION
Most recent ES6 spec says that on every `next` call of MapIterator the number of elements in entries should be recomputed. See [23.1.5.2.1 10](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-%mapiteratorprototype%.next)
I'm less sure about `Map.prototype.forEach` but unlike Array.prototype.forEach the spec doesn't specify that `len` should be cached. See [23.1.3.5](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map.prototype.foreach)
