### PR TITLE
Block Binding: use orignal name where possible

### DIFF
--- a/src/semantics/Scope.js
+++ b/src/semantics/Scope.js
@@ -75,6 +75,25 @@ export class Scope {
     this.lexicalDeclarations[name] = {type, tree};
   }
 
+  // we deduce the oldType
+  renameBinding(oldName, newTree, newType, reporter) {
+    var name = newTree.getStringValue();
+    if (newType == VAR) {
+      if (this.lexicalDeclarations[oldName]) {
+        delete this.lexicalDeclarations[oldName];
+        this.addVar(newTree, reporter);
+      }
+    } else {
+      if (this.variableDeclarations[oldName]) {
+        delete this.variableDeclarations[oldName];
+        this.addDeclaration(newTree, newType, reporter);
+        if (!this.isVarScope && this.parent) {
+          this.parent.renameBinding(oldName, newTree, newType);
+        }
+      }
+    }
+  }
+
   get isVarScope() {
     switch (this.tree.type) {
       case BLOCK:

--- a/test/unit/codegeneration/BlockBindingTransformer.js
+++ b/test/unit/codegeneration/BlockBindingTransformer.js
@@ -13,6 +13,8 @@ suite('BlockBindingTransformer.js', function() {
     getForTesting('src/syntax/ParseTreeValidator').ParseTreeValidator;
   var options = $traceurRuntime.ModuleStore.
     getForTesting('src/Options').options;
+  var ErrorReporter = $traceurRuntime.ModuleStore.
+      getForTesting('src/util/CollectingErrorReporter').CollectingErrorReporter;
 
   var currentOption;
 
@@ -43,73 +45,88 @@ suite('BlockBindingTransformer.js', function() {
   function makeTest(name, code, expected) {
     test(name, function() {
       var tree = parseFunction(code);
-      var transformer = new BlockBindingTransformer(new UniqueIdentifierGenerator(), null, tree);
+      var reporter = new ErrorReporter();
+      var transformer = new BlockBindingTransformer(
+          new UniqueIdentifierGenerator(), reporter, tree);
       var transformed = transformer.transformAny(tree);
       new ParseTreeValidator().visitAny(transformed);
       assert.equal(normalize(expected), write(transformed.body));
+      assert.lengthOf(reporter.errors, 0);
     });
   }
 
   makeTest('Let to Var', 'let x;', 'var x;');
   makeTest('Let to Var In Block', '1; { 2; let x; }',
-    'var x$__0; 1; { 2; }');
+    'var x; 1; { 2; }');
   makeTest('Let to Var In Block', '1; if (true) { 2; let x = 5; }',
-    'var x$__0; 1; if(true) { 2; x$__0 = 5; }');
+    'var x; 1; if(true) { 2; x = 5; }');
 
 
   makeTest('Let to Var In ForLoop', 'for(let i = 0; i < 5; i++);',
-    'for(var i$__0 = 0; i$__0 < 5; i$__0++);');
+    'for(var i = 0; i < 5; i++);');
   makeTest('Let to Var In ForLoop', 'for(let i = 0; i < 5; i++){ log(i); function t(){} }',
-    'var t$__1;' +
-    'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-    '  t$__1 = function() {};' +
-    '  log(i$__0);' +
+    'var t;' +
+    'for (var i = 0; i < 5; i++) {' +
+    '  t = function() {};' +
+    '  log(i);' +
     '}');
 
 
   makeTest('Let to Var In ForLoop with Fn using local var', 'for(let i = 0; i < 5; i++){ function t(){alert(i); let i = 5;} }',
-    'var t$__1;' +
-    'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-    '  t$__1 = function() {alert(i); var i = 5;};' +
+    'var t;' +
+    'for (var i = 0; i < 5; i++) {' +
+    '  t = function() {alert(i); var i = 5;};' +
+    '}');
+
+
+  makeTest('Let to Var with name collisions', 'if(true){let x = 5;} if(true){let x = 5;}',
+    'var x;' +
+    'var x$__0;' +
+    'if (true) {' +
+    '  x = 5;' +
+    '}' +
+    'if (true) {' +
+    '  x$__0 = 5;' +
     '}');
 
   suite('Loops with Fns using block variables', function() {
     makeTest('Let to Var in',
       'for(let i = 0; i < 5; i++){ function t(){log(i)} }',
       // ======
-      'var $__1 = function(i) {' +
+      'var $__0 = function(i) {' +
       '  function t() {' +
       '    log(i);' +
       '  }' +
       '};' +
-      'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '$__1(i$__0);' +
+      'for (var i = 0; i < 5; i++) {' +
+        '$__0(i);' +
       '}');
 
     makeTest('Return in Fn', 'for(let i = 0; i < 5; i++) { return function t(){return i;} }',
-        'var $__1 = function(i) {' +
+        'var $__0 = function(i) {' +
         '  return {v: function t() {' +
         '    return i;' +
         '  }};' +
-        '}, $__2;' +
-        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '  $__2 = $__1(i$__0);' +
-        '  if (typeof $__2 === "object") ' +
-        '    return $__2.v;' +
+        '}, $__1;' +
+        'for (var i = 0; i < 5; i++) {' +
+        '  $__1 = $__0(i);' +
+        '  if (typeof $__1 === "object") ' +
+        '    return $__1.v;' +
         '}');
 
     makeTest('Return nothing in Fn', 'for(let i = 0; i < 5; i++) { return; function t(){return i;} } }',
-        'var $__1 = function(i) {' +
+        'var $__0 = function(i) {' +
         '  return {v: (void 0)};' +
         '  function t(){return i;}' +
-        '}, $__2;' +
-        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '  $__2 = $__1(i$__0);' +
-        '  if (typeof $__2 === "object") ' +
-        '    return $__2.v;' +
+        '}, $__1;' +
+        'for (var i = 0; i < 5; i++) {' +
+        '  $__1 = $__0(i);' +
+        '  if (typeof $__1 === "object") ' +
+        '    return $__1.v;' +
         '}');
 
     makeTest('Break and Continue in Fn',
+        '"use strict";' +
         'outer: while(true) {' +
         ' for(let i = 0; i < 5; i++){ ' +
         '   inner: while(true) {' +
@@ -123,11 +140,12 @@ suite('BlockBindingTransformer.js', function() {
         '   }' +
         ' }',
         // ======
+        '"use strict";' +
         'outer: while (true) {' +
-        '  var $__1 = function (i) {' +
-        '    var t$__3;' +
+        '  var $__0 = function (i) {' +
+        '    var t;' +
         '    inner: while (true) {' +
-        '      t$__3 = function () {' +
+        '      t = function () {' +
         '        return i;' +
         '      };' +
         '      break;' +
@@ -137,10 +155,10 @@ suite('BlockBindingTransformer.js', function() {
         '      return 1;' +
         '      continue inner;' +
         '    }' +
-        '  }, $__2;' +
-        '  for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '    $__2 = $__1(i$__0);' +
-        '    switch ($__2) {' +
+        '  }, $__1;' +
+        '  for (var i = 0; i < 5; i++) {' +
+        '    $__1 = $__0(i);' +
+        '    switch ($__1) {' +
         '      case 0:' +
         '        break outer;' +
         '      case 1:' +
@@ -149,40 +167,41 @@ suite('BlockBindingTransformer.js', function() {
         '  }' +
         '}');
 
+
     makeTest('This and Arguments',
         'for(let i = 0; i < 5; i++){ console.log(this, arguments); function t(){log(i)} }',
         // ======
-        'var $__1 = arguments,' +
-        '    $__2 = this,' +
-        '    $__3 = function(i) { console.log($__2, $__1); function t() {log(i)} };' +
-        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '$__3(i$__0);' +
+        'var $__0 = arguments,' +
+        '    $__1 = this,' +
+        '    $__2 = function(i) { console.log($__1, $__0); function t() {log(i)} };' +
+        'for (var i = 0; i < 5; i++) {' +
+        '$__2(i);' +
         '}');
 
     makeTest('Hoist Var Declaration',
         'for(let i = 0; i < 5; i++){ var k = 1; function t(){log(i)} }',
         // ======
-        'var k, $__1 = function(i) {' +
+        'var k, $__0 = function(i) {' +
         '  k = 1;' +
         '  function t() {' +
         '    log(i);' +
         '  }' +
         '};' +
-        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '$__1(i$__0);' +
+        'for (var i = 0; i < 5; i++) {' +
+        '$__0(i);' +
         '}');
 
     makeTest('Function as Block Binding',
         'for(let i = 0; i < 5; i++){ function k() {} function t(){log(k)} }',
         // ======
-        'var $__1 = function(i) {' +
+        'var $__0 = function(i) {' +
         '  function k() {}' +
         '  function t() {' +
         '    log(k);' +
         '  }' +
         '};' +
-        'for (var i$__0 = 0; i$__0 < 5; i$__0++) {' +
-        '$__1(i$__0);' +
+        'for (var i = 0; i < 5; i++) {' +
+        '$__0(i);' +
         '}');
 
     makeTest('Loop with Var initializer remains untouched',


### PR DESCRIPTION
To accomplish that, the `BlockBindingTransformer` keeps track of a `usedVars_` object, indicating which variables are used in the function so far. The object is initialized with all the bindings in the scope.

I also introduced a `Scope.renameBinding` function, that renames a binding to a new tree and a newType when needed. I use it to keep scope's data correct, mainly for `FindBlockBindingInLoop`, and also to avoid a duplicateVarDeclaration error

Closes #1274
