### PR TITLE
fix InstantiateTransformer export default parsing

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -565,6 +565,7 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
     // =>
     // $__export('default', ...)
     //
+    this.inExport_ = false;
     var expression = this.transformAny(tree.expression);
     this.addLocalExportBinding('default');
     if (expression.type === FUNCTION_DECLARATION) {

--- a/test/instantiate/export-default-fn.js
+++ b/test/instantiate/export-default-fn.js
@@ -1,0 +1,15 @@
+export default {
+  fn: function bar() {
+
+    function test() {
+    }
+
+    function foo() {
+      test();
+    }
+
+    return {
+      foo: foo
+    }
+  }
+};

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -98,4 +98,12 @@ suite('instantiate', function() {
       done();
     }).catch(done);
   });
+
+  test('Export default function parsing', function(done) {
+    System.import('export-default-fn').then(function(m) {
+      assert.equal(m.test, undefined);
+      done();
+    }).catch(done);
+  });
+
 });


### PR DESCRIPTION
In order to detect function export declarations in https://github.com/google/traceur-compiler/blob/master/src/codegeneration/InstantiateModuleTransformer.js#L487, we use the `this.inExport_` value to tell if it is a normal function declaration or an export declaration.

This guard wasn't being disabled with `export default`, meaning the following:

``` javascript
export default {
  p: function q() {
  }
}
```

Would think there is an export named `q`. This adds a fix for that behaviour.
