### PR TITLE
Fix export default class declaration

### DIFF
--- a/test/instantiate/export-default-class.js
+++ b/test/instantiate/export-default-class.js
@@ -1,0 +1,5 @@
+export default class F {
+  foo() {
+    return 'foo';
+  }
+}

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -106,4 +106,12 @@ suite('instantiate', function() {
     }).catch(done);
   });
 
+  test('Export default class', function(done) {
+    System.import('export-default-class').then(function(m) {
+      var f = new m.default();
+      assert.equal(f.foo(), 'foo');
+      done();
+    }).catch(done);
+  });
+
 });


### PR DESCRIPTION
This fixes the incorrect output for `export default class`, as discussed in https://github.com/google/traceur-compiler/issues/1208#issuecomment-56306090.
