### PR TITLE
Make sure native symbols work

### DIFF
--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -157,7 +157,6 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
    * @return {ParseTree}
    */
   getPropertyName_(nameTree) {
-    // TODO(arv): Computed property names
     var token = nameTree.literalToken;
     switch (token.type) {
       case IDENTIFIER:

--- a/src/codegeneration/generator/ForInTransformPass.js
+++ b/src/codegeneration/generator/ForInTransformPass.js
@@ -70,12 +70,10 @@ export class ForInTransformPass extends TempVarTransformer {
   //   statement
   // }
   /**
-   * @param {ForInStatement} original
+   * @param {ForInStatement} tree
    * @return {ParseTree}
    */
-  transformForInStatement(original) {
-    var tree = original;
-
+  transformForInStatement(tree) {
     // Transform body first
     var bodyStatements = [];
     var body = this.transformAny(tree.body);

--- a/src/runtime/classes.js
+++ b/src/runtime/classes.js
@@ -24,6 +24,11 @@
   var $getOwnPropertyNames = $traceurRuntime.getOwnPropertyNames;
   var $getPrototypeOf = Object.getPrototypeOf;
 
+  var {
+    getOwnPropertyNames,
+    getOwnPropertySymbols
+  } = Object;
+
   function superDescriptor(homeObject, name) {
     var proto = $getPrototypeOf(homeObject);
     do {
@@ -56,14 +61,21 @@
       descriptor.set.call(self, value);
       return value;
     }
-    throw $TypeError("super has no setter '" + name + "'.");
+    throw $TypeError(`super has no setter '${name}'.`);
   }
 
   function getDescriptors(object) {
-    var descriptors = {}, name, names = $getOwnPropertyNames(object);
+    var descriptors = {};
+    var names = getOwnPropertyNames(object);
     for (var i = 0; i < names.length; i++) {
       var name = names[i];
       descriptors[name] = $getOwnPropertyDescriptor(object, name);
+    }
+    var symbols = getOwnPropertySymbols(object);
+    for (var i = 0; i < symbols.length; i++) {
+      var symbol = symbols[i];
+      descriptors[$traceurRuntime.toProperty(symbol)] =
+          $getOwnPropertyDescriptor(object, $traceurRuntime.toProperty(symbol));
     }
     return descriptors;
   }

--- a/src/runtime/polyfills/Object.js
+++ b/src/runtime/polyfills/Object.js
@@ -21,8 +21,8 @@ var {
   defineProperty,
   getOwnPropertyDescriptor,
   getOwnPropertyNames,
-  keys,
-  privateNames,
+  isPrivateName,
+  keys
 } = $traceurRuntime;
 
 // Object.is
@@ -42,8 +42,7 @@ export function assign(target) {
     var p, length = props.length;
     for (p = 0; p < length; p++) {
       var name = props[p];
-      if (privateNames[name])
-        continue;
+      if (isPrivateName(name)) continue;
       target[name] = source[name];
     }
   }
@@ -56,8 +55,7 @@ export function mixin(target, source) {
   var p, descriptor, length = props.length;
   for (p = 0; p < length; p++) {
     var name = props[p];
-    if (privateNames[name])
-      continue;
+    if (isPrivateName(name)) continue;
     descriptor = getOwnPropertyDescriptor(source, props[p]);
     defineProperty(target, props[p], descriptor);
   }

--- a/src/runtime/polyfills/StringIterator.js
+++ b/src/runtime/polyfills/StringIterator.js
@@ -3,7 +3,8 @@ import {
   isObject
 } from './utils';
 
-var {hasOwnProperty, toProperty} = $traceurRuntime;
+var {toProperty} = $traceurRuntime;
+var {hasOwnProperty} = Object.prototype;
 
 // 21.1.5.3 Properties of String Iterator Instances
 
@@ -20,7 +21,7 @@ class StringIterator {
   next() {
     var o = this;
 
-    if (!isObject(o) || !hasOwnProperty(o, iteratedString)) {
+    if (!isObject(o) || !hasOwnProperty.call(o, iteratedString)) {
       throw new TypeError('this must be a StringIterator object');
     }
 

--- a/test/feature/Symbol/Inherited.js
+++ b/test/feature/Symbol/Inherited.js
@@ -1,4 +1,5 @@
 // Options: --symbols
+'use strict';
 
 var s = Symbol();
 var p = {};

--- a/test/feature/Symbol/Object.js
+++ b/test/feature/Symbol/Object.js
@@ -4,7 +4,8 @@ var s = Symbol();
 var object = {};
 object[s] = 42;
 assert.equal(42, object[s]);
-assert.isUndefined(object[n + '']);
+// Native Symbol throws for ToString.
+// assert.isUndefined(object[s + '']);
 assertArrayEquals([], Object.getOwnPropertyNames(object));
 assert.isTrue(object.hasOwnProperty(s));
 
@@ -16,8 +17,15 @@ var n = Symbol();
 assert.equal(object[n] = 1, 1);
 assert.equal(object[n] += 2, 3);
 
-assert.isFalse(Object.getOwnPropertyDescriptor(object, n).enumerable);
+assert.isTrue(Object.getOwnPropertyDescriptor(object, n).enumerable);
 
 assert.isTrue(n in object);
 assert.isTrue(delete object[n]);
 assert.isFalse(n in object);
+
+var keys = [];
+for (var k in object) {
+  keys.push(k);
+}
+assert.equal(0, keys.length, keys + '');
+assert.equal(0, Object.keys(object).length);


### PR DESCRIPTION
Do not overwrite the native Symbol if present.

Instead of enforcing that our shim symbols are non enumerable we
now generate code to filter out symbols for for-in loops. This allows
us to remove $traceurRuntime.setProperty since it is now OK to use
the standard browser [[Set]].

For the class runtime we need to iterate over the symbols too.

Fixes #1330
