### PR TITLE
Pass metadata to REPL onFailure.

### DIFF
--- a/demo/repl-module.js
+++ b/demo/repl-module.js
@@ -175,7 +175,9 @@ function resetAndCompileContents(contents, newOptions) {
   compileContents(contents);
 }
 
-function onFailure(error) {
+function onFailure(error, metadata) {
+  if (metadata.transcoded)
+    output.setValue(metadata.transcoded);
   hasError = true;
   errorElement.hidden = false;
   errorElement.textContent = error.stack || error;

--- a/demo/transcode.js
+++ b/demo/transcode.js
@@ -42,7 +42,8 @@ export function transcode(contents, onSuccess, onFailure) {
   var loader = new TraceurLoader(webLoader, url);
   var load = traceurOptions.script ? loader.script : loader.module;
   load.call(loader, contents, loadOptions).
-      then((module) => onSuccess(loadOptions.metadata), onFailure);
+      then(() => onSuccess(loadOptions.metadata),
+          (error) => onFailure(error, loadOptions.metadata));
 }
 
 export function renderSourceMap(source, sourceMap) {


### PR DESCRIPTION
Show transcoding if the error is an evaluation error.

Fixes #1373
