### PR TITLE
Fix issue with block binding in unbraced for

### DIFF
--- a/build/build-parse-tree-transformer.js
+++ b/build/build-parse-tree-transformer.js
@@ -81,8 +81,14 @@ function printTransformBody(name, tree, trees) {
       if (fieldName == 'location') {
         return;
       }
-      var fieldType = tree[fieldName][0];
-      if (util.isParseTreeType(fieldType, trees)) {
+      var fieldTypes = tree[fieldName];
+      var fieldType = fieldTypes[0];
+      if (util.isBlockOrStatementType(fieldTypes, trees)) {
+        util.print('    var ' + fieldName +
+                   ' = this.transformToBlockOrStatement(tree.' + fieldName +
+                   ');');
+        addTest(fieldName);
+      } else if (util.isParseTreeType(fieldType, trees)) {
         util.print('    var ' + fieldName + ' = this.transformAny(tree.' +
             fieldName + ');');
         addTest(fieldName);

--- a/build/parse-tree-transformer.header
+++ b/build/parse-tree-transformer.header
@@ -22,3 +22,10 @@ export class ParseTreeTransformer {
   transformStateMachine(tree) {
     throw Error('State machines should not live outside of the GeneratorTransformer.');
   }
+  transformToBlockOrStatement(tree) {
+    var transformed = this.transformAny(tree);
+    if (transformed instanceof AnonBlock) {
+      return new Block(transformed.location, transformed.statements);
+    }
+    return transformed;
+  }

--- a/build/util.js
+++ b/build/util.js
@@ -19,8 +19,12 @@ var path = require('path');
 var print = console.log.bind(console);
 
 function isParseTreeType(type, trees) {
-    return type in trees || type === 'ParseTree';
-  };
+  return type in trees || type === 'ParseTree';
+}
+
+function isBlockOrStatementType(types, trees) {
+  return types[0] === 'Block' && isParseTreeType(types[1], trees);
+}
 
 module.exports = {
   print: print,
@@ -51,10 +55,12 @@ module.exports = {
   },
 
   isParseTreeType: isParseTreeType,
+  isBlockOrStatementType: isBlockOrStatementType,
 
   isParseTreeListType: function(type, trees) {
-    return (type.lastIndexOf('Array.<', 0) === 0) &&
-      isParseTreeType(type.substring('Array.<'.length, type.length - 1), trees);
+    return type.lastIndexOf('Array<', 0) === 0 &&
+        isParseTreeType(type.substring('Array<'.length, type.length - 1),
+                        trees);
   },
 
   // Filters out keys that are used as comments.

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -15,7 +15,7 @@
       "SourceRange"
     ],
     "statements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ArgumentList": {
@@ -23,7 +23,7 @@
       "SourceRange"
     ],
     "args": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ArrayComprehension": {
@@ -31,7 +31,7 @@
       "SourceRange"
     ],
     "comprehensionList": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "expression": [
       "ParseTree"
@@ -42,7 +42,7 @@
       "SourceRange"
     ],
     "elements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ArrayPattern": {
@@ -50,7 +50,7 @@
       "SourceRange"
     ],
     "elements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ArrowFunctionExpression": {
@@ -126,7 +126,7 @@
       "SourceRange"
     ],
     "statements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "BreakStatement": {
@@ -156,7 +156,7 @@
       "ParseTree"
     ],
     "statements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "Catch": {
@@ -181,10 +181,10 @@
       "ParseTree"
     ],
     "elements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ClassExpression": {
@@ -198,10 +198,10 @@
       "ParseTree"
     ],
     "elements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "CommaExpression": {
@@ -209,7 +209,7 @@
       "SourceRange"
     ],
     "expressions": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ComprehensionFor": {
@@ -266,7 +266,7 @@
       "SourceRange"
     ],
     "expressions": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "CoverInitializedName": {
@@ -293,7 +293,7 @@
       "SourceRange"
     ],
     "statements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "DoWhileStatement": {
@@ -301,6 +301,7 @@
       "SourceRange"
     ],
     "body": [
+      "Block",
       "ParseTree"
     ],
     "condition": [
@@ -320,7 +321,7 @@
       "ParseTree"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ExportDefault": {
@@ -347,7 +348,7 @@
       "SourceRange"
     ],
     "specifiers": [
-      "Array.<ExportSpecifier>"
+      "Array<ExportSpecifier>"
     ]
   },
   "ExportStar": {
@@ -382,6 +383,7 @@
       "ParseTree"
     ],
     "body": [
+      "Block",
       "ParseTree"
     ]
   },
@@ -396,6 +398,7 @@
       "ParseTree"
     ],
     "body": [
+      "Block",
       "ParseTree"
     ]
   },
@@ -413,6 +416,7 @@
       "ParseTree"
     ],
     "body": [
+      "Block",
       "ParseTree"
     ]
   },
@@ -428,7 +432,7 @@
       "ParseTree"
     ],
     "annotations": [
-      "Array.<Annotation>"
+      "Array<Annotation>"
     ]
   },
   "FormalParameterList": {
@@ -436,7 +440,7 @@
       "SourceRange"
     ],
     "parameters": [
-      "Array.<FormalParameter>"
+      "Array<FormalParameter>"
     ]
   },
   "FunctionBody": {
@@ -444,7 +448,7 @@
       "SourceRange"
     ],
     "statements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "//": "FunctionDeclaration and FunctionExpression needs to have the exact same shape",
@@ -465,7 +469,7 @@
       "ParseTree"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "body": [
       "FunctionBody"
@@ -488,7 +492,7 @@
       "ParseTree"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "body": [
       "FunctionBody"
@@ -499,7 +503,7 @@
       "SourceRange"
     ],
     "comprehensionList": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "expression": [
       "ParseTree"
@@ -519,7 +523,7 @@
       "ParseTree"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "body": [
       "FunctionBody"
@@ -541,9 +545,11 @@
       "ParseTree"
     ],
     "ifClause": [
+      "Block",
       "ParseTree"
     ],
     "elseClause": [
+      "Block",
       "ParseTree"
     ]
   },
@@ -582,7 +588,7 @@
       "SourceRange"
     ],
     "specifiers": [
-      "Array.<ImportSpecifier>"
+      "Array<ImportSpecifier>"
     ]
   },
   "LabelledStatement": {
@@ -639,7 +645,7 @@
       "SourceRange"
     ],
     "scriptItemList": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "moduleName": [
       "string"
@@ -691,7 +697,7 @@
       "SourceRange"
     ],
     "propertyNameAndValues": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ObjectPattern": {
@@ -699,7 +705,7 @@
       "SourceRange"
     ],
     "fields": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "ObjectPatternField": {
@@ -745,7 +751,7 @@
       "SourceRange"
     ],
     "scriptItemList": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "moduleName": [
       "string"
@@ -771,7 +777,7 @@
       "ParseTree"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "body": [
       "FunctionBody"
@@ -826,7 +832,7 @@
       "FormalParameterList"
     ],
     "annotations": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ],
     "body": [
       "FunctionBody"
@@ -861,7 +867,7 @@
       "ParseTree"
     ],
     "caseClauses": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "SyntaxErrorTree": {
@@ -883,7 +889,7 @@
       "ParseTree"
     ],
     "elements": [
-      "Array.<ParseTree>"
+      "Array<ParseTree>"
     ]
   },
   "TemplateLiteralPortion": {
@@ -973,7 +979,7 @@
       "TokenType"
     ],
     "declarations": [
-      "Array.<VariableDeclaration>"
+      "Array<VariableDeclaration>"
     ]
   },
   "VariableStatement": {
@@ -992,6 +998,7 @@
       "ParseTree"
     ],
     "body": [
+      "Block",
       "ParseTree"
     ]
   },
@@ -1003,6 +1010,7 @@
       "ParseTree"
     ],
     "body": [
+      "Block",
       "ParseTree"
     ]
   },

--- a/test/feature/Scope/Regress1381.js
+++ b/test/feature/Scope/Regress1381.js
@@ -1,0 +1,8 @@
+function test() {
+  let ret = true;
+  while (false)
+    for (let i = 0; i < 1; i++)
+      ret = () => i;
+  return ret
+}
+assert.isTrue(test());


### PR DESCRIPTION
When transforming the body for if, for, while, do and with, where
either a Block or a single statement is allowed we need to convert
AnonBlocks to normal blocks.

The code for this is generated by the code gen. We use the type
`Block | ParseTree` as the type to trigger this code path.

Fixes #1381
