### PR TITLE
Enforces end-of-line to be LF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*	eol=lf
+* eol=lf


### PR DESCRIPTION
fixes #1392 
relates to #235
