### PR TITLE
Fix issue with symbols and for of

### DIFF
--- a/src/codegeneration/ForOfTransformer.js
+++ b/src/codegeneration/ForOfTransformer.js
@@ -47,7 +47,8 @@ export class ForOfTransformer extends TempVarTransformer {
 
     return parseStatement `
         for (var ${iter} =
-                 ${tree.collection}[Symbol.iterator](),
+                 ${tree.collection}[
+                     $traceurRuntime.toProperty(Symbol.iterator)](),
                  ${result};
              !(${result} = ${iter}.next()).done; ) {
           ${assignment};

--- a/test/feature/Collections/SetWithSymbols.js
+++ b/test/feature/Collections/SetWithSymbols.js
@@ -1,0 +1,4 @@
+// Options: --symbols
+
+var s = new Set(['Banana', 'Orange', 'Apple', 'Mango', 'Apple', 'Apple']);
+assert.equal(s.size, 4);


### PR DESCRIPTION
With the experimental symbols option we need to expande for-of to
use $traceurRuntime.toProperty.

Fixes #1228
