### PR TITLE
Support circular annotations

### DIFF
--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -38,7 +38,7 @@ import {
   createNewExpression,
   createStringLiteralToken
 } from './ParseTreeFactory';
-import {parseExpression} from './PlaceholderParser';
+import {parseExpression, parseStatement} from './PlaceholderParser';
 
 class AnnotationsScope {
   constructor() {
@@ -292,21 +292,24 @@ class AnnotationsScope {
     if (annotations !== null) {
       annotations = this.transformAnnotations_(annotations);
       if (annotations.length > 0) {
-        metadataStatements.push(createAssignmentStatement(
-            createMemberExpression(target, 'annotations'),
-            createArrayLiteralExpression(annotations)));
+        metadataStatements.push(this.createDefinePropertyStatement_(target,
+            'annotations', createArrayLiteralExpression(annotations)));
       }
     }
 
     if (parameters !== null) {
       parameters = this.transformParameters_(parameters);
       if (parameters.length > 0) {
-        metadataStatements.push(createAssignmentStatement(
-            createMemberExpression(target, 'parameters'),
-            createArrayLiteralExpression(parameters)));
+        metadataStatements.push(this.createDefinePropertyStatement_(target,
+            'parameters', createArrayLiteralExpression(parameters)));
       }
     }
     return metadataStatements;
+  }
+
+  createDefinePropertyStatement_(target, property, value) {
+    return parseStatement `Object.defineProperty(${target}, ${property},
+        {get: function() {return ${value}}});`
   }
 
   createLiteralStringExpression_(tree) {

--- a/test/instantiate/circular_annotation1.js
+++ b/test/instantiate/circular_annotation1.js
@@ -1,0 +1,7 @@
+// Options: --annotations --types
+import {FooAnnotation} from './circular_annotation2';
+
+@FooAnnotation
+export class BarAnnotation {
+  constructor(@FooAnnotation foo1, foo2: FooAnnotation) {}
+}

--- a/test/instantiate/circular_annotation2.js
+++ b/test/instantiate/circular_annotation2.js
@@ -1,0 +1,9 @@
+// Options: --annotations --types
+import {BarAnnotation} from './circular_annotation1';
+
+@BarAnnotation
+export class FooAnnotation {
+  constructor(@BarAnnotation bar1, bar2: BarAnnotation) {
+
+  }
+}

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -5,6 +5,15 @@ global.System = traceurSystem;
 
 System.baseURL = __dirname + '/instantiate/';
 
+
+// Parse Traceur options from prolog (comment at the top of a source file).
+var parseProlog = require('./test-utils').parseProlog;
+System.translate = function(load) {
+  load.metadata.traceurOptions = parseProlog(load.source).traceurOptions;
+  return load.source;
+};
+
+
 suite('instantiate', function() {
   test('Inheritance', function(done) {
     System.import('inheritance').then(function(m) {
@@ -26,6 +35,36 @@ suite('instantiate', function() {
       System.import('circular2').then(function(m2) {
         assert.equal(m2.output, 'test circular 1');
         assert.equal(m1.output, 'test circular 2');
+        done();
+      }).catch(done);
+    }).catch(done);
+  });
+
+  test('Circular annotations', function(done) {
+    System.import('circular_annotation1').then(function(m1) {
+      System.import('circular_annotation2').then(function(m2) {
+        assert.instanceOf(m1.BarAnnotation.annotations[0], m2.FooAnnotation);
+        assert.instanceOf(m2.FooAnnotation.annotations[0], m1.BarAnnotation);
+        done();
+      }).catch(done);
+    }).catch(done);
+  });
+
+  test('Circular parameter annotations', function(done) {
+    System.import('circular_annotation1').then(function(m1) {
+      System.import('circular_annotation2').then(function(m2) {
+        assert.instanceOf(m1.BarAnnotation.parameters[0][0], m2.FooAnnotation);
+        assert.instanceOf(m2.FooAnnotation.parameters[0][0], m1.BarAnnotation);
+        done();
+      }).catch(done);
+    }).catch(done);
+  });
+
+  test('Circular type annotations', function(done) {
+    System.import('circular_annotation1').then(function(m1) {
+      System.import('circular_annotation2').then(function(m2) {
+        assert.equal(m1.BarAnnotation.parameters[1][0], m2.FooAnnotation);
+        assert.equal(m2.FooAnnotation.parameters[1][0], m1.BarAnnotation);
         done();
       }).catch(done);
     }).catch(done);

--- a/third_party/es6-module-loader/system.js
+++ b/third_party/es6-module-loader/system.js
@@ -285,7 +285,9 @@
         try {
           load.kind = 'declarative';
 
-          var options = { modules: 'instantiate' };
+          var options = load.metadata.traceurOptions || {};
+          options.modules = 'instantiate';
+
           var compiler = new traceur.Compiler(options);
           var tree = compiler.parse(load.source, load.address);
           depsList = getImports(tree);


### PR DESCRIPTION
With es6-module-loader, it is possible to use circular imports.
Classes from circular imports are not available during the module
evaluation and thus this code fails (`Inject` is undefined):

``` js
Foo.annotations = [new Inject];
```

This commit changes the annotation output to use a getter:

``` js
Object.defineProperty(Foo, 'annotations', {
  get: function() {
    return [new Inject];
  }
});
```

NOTE:
If the code tries to read `.annotations` or `.parameters` property
during the module evaluation (root context), it won’t work.
