### PR TITLE
[Polyfill] Don't skip holes in Array#find and Array#findIndex

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ David Håsäther <hasather@gmail.com>
 Amjad Masad <amjad.masad@gmail.com>
 Peter Flannery <flannery.peter@ntlworld.com>
 Liubomyr Mykhalchenko <liubko.qwert@gmail.com>
+Dmitry Soshnikov <dmitry.soshnikov@gmail.com>

--- a/src/runtime/polyfills/Array.js
+++ b/src/runtime/polyfills/Array.js
@@ -134,11 +134,9 @@ function findHelper(self, predicate, thisArg = undefined, returnIndex = false) {
 
   // run through until predicate returns true
   for (var i = 0; i < len; i++) {
-    if (i in object) {
-      var value = object[i];
-      if (predicate.call(thisArg, value, i, object)) {
-        return returnIndex ? i : value;
-      }
+    var value = object[i];
+    if (predicate.call(thisArg, value, i, object)) {
+      return returnIndex ? i : value;
     }
   }
 

--- a/test/feature/ArrayExtras/Find.js
+++ b/test/feature/ArrayExtras/Find.js
@@ -85,4 +85,4 @@ assert.equal(Array.prototype.find.call(object, (v) => {
 }), 'a');
 assert.equal(lengthCalls, 1);
 assert.equal(itemCalls, 1);
-assert.equal(callbackCalls, 1);
+assert.equal(callbackCalls, 3);

--- a/test/feature/ArrayExtras/FindIndex.js
+++ b/test/feature/ArrayExtras/FindIndex.js
@@ -44,4 +44,4 @@ assert.equal(Array.prototype.findIndex.call(object, (v) => {
 }), 2);
 assert.equal(lengthCalls, 1);
 assert.equal(itemCalls, 1);
-assert.equal(callbackCalls, 1);
+assert.equal(callbackCalls, 3);


### PR DESCRIPTION
Per Rev27 of ES6 draft, `Array.prototype.find` and `Array.prototype.findIndex` do not skip holes anymore.

[1] http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.find
