### PR TITLE
Update to regexpu v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "commander": "2.x",
     "glob": "4.x",
-    "regexpu": "0.2.1",
+    "regexpu": "0.3.0",
     "rsvp": "^3.0.13",
     "semver": "2.x"
   },


### PR DESCRIPTION
This fixes a bug with the output for `/\s/u` and `/\S/u`. See https://github.com/mathiasbynens/regexpu/issues/7.
