### PR TITLE
Update super to match latest spec.

### DIFF
--- a/src/codegeneration/AmdTransformer.js
+++ b/src/codegeneration/AmdTransformer.js
@@ -31,7 +31,7 @@ export class AmdTransformer extends ModuleTransformer {
   }
 
   getExportProperties() {
-    var properties = super();
+    var properties = super.getExportProperties();
 
     if (this.exportVisitor_.hasExports())
       properties.push(parsePropertyDefinition `__esModule: true`);
@@ -46,7 +46,7 @@ export class AmdTransformer extends ModuleTransformer {
           `if (!${local} || !${local}.__esModule)
             ${local} = {default: ${local}}`;
     });
-    return super().concat(locals);
+    return super.moduleProlog().concat(locals);
   }
 
   wrapModule(statements) {

--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -86,7 +86,7 @@ class AnnotationsScope {
  *
  *    var B = function(x) {
  *      "use strict";
- *      $traceurRuntime.superCall(this, $B.prototype, "constructor", []);
+ *      $traceurRuntime.superConstructor($B).call(this);
  *    };
  *    var $B = ($traceurRuntime.createClass)(B, {method: function(x) {
  *        "use strict";
@@ -131,7 +131,7 @@ class AnnotationsScope {
 
     // we need to recurse to collect the constructor metadata before
     // we process the class metadata
-    tree = super(tree);
+    tree = super.transformClassDeclaration(tree);
     scope.metadata.unshift(...this.transformMetadata_(
         createIdentifierExpression(tree.name),
         scope.annotations,
@@ -154,7 +154,7 @@ class AnnotationsScope {
         scope.annotations,
         tree.parameterList.parameters));
 
-    tree = super(tree);
+    tree = super.transformFunctionDeclaration(tree);
     if (tree.annotations.length > 0) {
       tree = new FunctionDeclaration(tree.location, tree.name, tree.functionKind,
           tree.parameterList, tree.typeAnnotation, [], tree.body);
@@ -167,12 +167,12 @@ class AnnotationsScope {
       tree = new FormalParameter(tree.location, tree.parameter,
           tree.typeAnnotation, []);
     }
-    return super(tree);
+    return super.transformFormalParameter(tree);
   }
 
   transformGetAccessor(tree) {
     if (!this.scope.inClassScope)
-      return super(tree);
+      return super.transformGetAccessor(tree);
 
     this.scope.metadata.push(...this.transformMetadata_(
         this.transformAccessor_(tree, this.scope.className, 'get'),
@@ -183,12 +183,12 @@ class AnnotationsScope {
       tree = new GetAccessor(tree.location, tree.isStatic, tree.name,
           tree.typeAnnotation, [], tree.body);
     }
-    return super(tree);
+    return super.transformGetAccessor(tree);
   }
 
   transformSetAccessor(tree) {
     if (!this.scope.inClassScope)
-      return super(tree);
+      return super.transformSetAccessor(tree);
 
     this.scope.metadata.push(...this.transformMetadata_(
         this.transformAccessor_(tree, this.scope.className, 'set'),
@@ -200,12 +200,12 @@ class AnnotationsScope {
       tree = new SetAccessor(tree.location, tree.isStatic, tree.name,
           parameterList, [], tree.body);
     }
-    return super(tree);
+    return super.transformSetAccessor(tree);
   }
 
   transformPropertyMethodAssignment(tree) {
     if (!this.scope.inClassScope)
-      return super(tree);
+      return super.transformPropertyMethodAssignment(tree);
 
     if (!tree.isStatic && propName(tree) === CONSTRUCTOR) {
       this.scope.annotations.push(...tree.annotations);
@@ -224,7 +224,7 @@ class AnnotationsScope {
           tree.functionKind, tree.name, parameterList,
           tree.typeAnnotation, [], tree.body);
     }
-    return super(tree);
+    return super.transformPropertyMethodAssignment(tree);
   }
 
   appendMetadata_(tree) {

--- a/src/codegeneration/BlockBindingTransformer.js
+++ b/src/codegeneration/BlockBindingTransformer.js
@@ -249,7 +249,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   // this is a start and end point of this transformer
   transformFunctionBody(tree) {
     if (tree === this.rootTree_ || !this.rootTree_) {
-      tree = super(tree);
+      tree = super.transformFunctionBody(tree);
       if (this.prependStatement_.length || this.blockRenames_.length) {
         var statements = prependStatements(tree.statements,
             ...this.prependStatement_);
@@ -272,7 +272,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   // this is a start and end point of this transformer
   transformScript(tree) {
     if (tree === this.rootTree_ || !this.rootTree_) {
-      tree = super(tree);
+      tree = super.transformScript(tree);
       if (this.prependStatement_.length || this.blockRenames_.length) {
         var scriptItemList = prependStatements(tree.scriptItemList,
             ...this.prependStatement_);
@@ -295,7 +295,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   // this is a start and end point of this transformer
   transformModule(tree) {
     if (tree === this.rootTree_ || !this.rootTree_) {
-      tree = super(tree);
+      tree = super.transformModule(tree);
       if (this.prependStatement_.length || this.blockRenames_.length) {
         var scriptItemList = prependStatements(tree.scriptItemList,
             ...this.prependStatement_);
@@ -331,7 +331,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
 
   transformVariableDeclarationList(tree) {
     if (tree.declarationType === VAR) {
-      return super(tree);
+      return super.transformVariableDeclarationList(tree);
     }
 
     // If we are at a var scope we do not need to rename.
@@ -366,7 +366,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
                                 this.reporter_);
       return bindingIdentifier;
     }
-    return super(tree);
+    return super.transformBindingIdentifier(tree);
   }
 
   transformBindingElement(tree) {
@@ -399,7 +399,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   transformObjectPattern(tree) {
     var inObjectPattern = this.inObjectPattern_;
     this.inObjectPattern_ = true;
-    var transformed = super(tree);
+    var transformed = super.transformObjectPattern(tree);
     this.inObjectPattern_ = inObjectPattern;
     return transformed;
   }
@@ -417,7 +417,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
 
   transformBlock(tree) {
     var scope = this.pushScope(tree);
-    tree = super(tree);
+    tree = super.transformBlock(tree);
     if (this.prependBlockStatement_.length) {
       tree = new Block(tree.location, prependStatements(tree.statements,
           ...this.prependBlockStatement_));
@@ -452,15 +452,18 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   }
 
   transformGetAccessor(tree) {
-    return this.transformFunctionForScope_(() => super(tree), tree);
+    return this.transformFunctionForScope_(
+        () => super.transformGetAccessor(tree), tree);
   }
 
   transformSetAccessor(tree) {
-    return this.transformFunctionForScope_(() => super(tree), tree);
+    return this.transformFunctionForScope_(
+        () => super.transformSetAccessor(tree), tree);
   }
 
   transformFunctionExpression(tree) {
-    return this.transformFunctionForScope_(() => super(tree), tree);
+    return this.transformFunctionForScope_(
+        () => super.transformFunctionExpression(tree), tree);
   }
 
   transformFunctionDeclaration(tree) {
@@ -489,7 +492,8 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
       return new AnonBlock(null, []);
     }
 
-    return this.transformFunctionForScope_(() => super(tree), tree);
+    return this.transformFunctionForScope_(
+        () => super.transformFunctionDeclaration(tree), tree);
   }
 
   /**
@@ -600,14 +604,14 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   }
 
   transformForInStatement(tree) {
-    return this.transformLoop_((t) => super(t), tree,
+    return this.transformLoop_((t) => super.transformForInStatement(t), tree,
         (initializer, renames, body) => new ForInStatement(tree.location,
             initializer, renameAll(renames, tree.collection), body)
     );
   }
 
   transformForStatement(tree) {
-    return this.transformLoop_((t) => super(t), tree,
+    return this.transformLoop_((t) => super.transformForStatement(t), tree,
         (initializer, renames, body) => new ForStatement(tree.location,
             initializer, renameAll(renames, tree.condition),
             renameAll(renames, tree.increment), body)
@@ -615,14 +619,14 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
   }
 
   transformWhileStatement(tree) {
-    return this.transformLoop_((t) => super(t), tree,
+    return this.transformLoop_((t) => super.transformWhileStatement(t), tree,
         (initializer, renames, body) => new WhileStatement(tree.location,
             renameAll(renames, tree.condition), body)
     );
   }
 
   transformDoWhileStatement(tree) {
-    return this.transformLoop_((t) => super(t), tree,
+    return this.transformLoop_((t) => super.transformDoWhileStatement(t), tree,
         (initializer, renames, body) => new DoWhileStatement(tree.location,
             body, renameAll(renames, tree.condition))
     );
@@ -643,7 +647,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
       }
       return new LabelledStatement(tree.location, tree.name, statement);
     }
-    return super(tree);
+    return super.transformLabelledStatement(tree);
   }
 }
 
@@ -691,10 +695,18 @@ class FindBlockBindingInLoop extends FindVisitor {
     super(tree, false);
   }
 
-  visitForInStatement(tree) {this.visitLoop_(tree, () => super(tree));}
-  visitForStatement(tree) {this.visitLoop_(tree, () => super(tree));}
-  visitWhileStatement(tree) {this.visitLoop_(tree, () => super(tree));}
-  visitDoWhileStatement(tree) {this.visitLoop_(tree, () => super(tree));}
+  visitForInStatement(tree) {
+    this.visitLoop_(tree, () => super.visitForInStatement(tree));
+  }
+  visitForStatement(tree) {
+    this.visitLoop_(tree, () => super.visitForStatement(tree));
+  }
+  visitWhileStatement(tree) {
+    this.visitLoop_(tree, () => super.visitWhileStatement(tree));
+  }
+  visitDoWhileStatement(tree) {
+    this.visitLoop_(tree, () => super.visitDoWhileStatement(tree));
+  }
   visitLoop_(tree, func) {
     if (this.acceptLoop_) {
       this.acceptLoop_ = false;

--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -49,7 +49,7 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
   }
 
   moduleProlog() {
-    var statements = super();
+    var statements = super.moduleProlog();
 
     // declare temp vars in prolog
     if (this.moduleVars_.length) {
@@ -123,14 +123,14 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
 
     // require the module, if it is not marked as an ES6 module, treat it as { default: module }
     // this allows for an unlinked CommonJS / ES6 interop
-    // note that future implementations should also check for native Module with 
+    // note that future implementations should also check for native Module with
     //   Reflect.isModule or similar
-    return parseExpression `(${tvId} = require(${moduleName}), 
+    return parseExpression `(${tvId} = require(${moduleName}),
         ${tvId} && ${tvId}.__esModule && ${tvId} || {default: ${tvId}})`;
   }
 
   getExportProperties() {
-    var properties = super();
+    var properties = super.getExportProperties();
 
     if (this.exportVisitor_.hasExports())
       properties.push(parsePropertyDefinition `__esModule: true`);

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -176,7 +176,7 @@ export class DestructuringTransformer extends TempVarTransformer {
     if (tree.operator.type == EQUAL && tree.left.isPattern()) {
       rv = this.transformAny(this.desugarAssignment_(tree.left, tree.right));
     } else {
-      rv = super(tree);
+      rv = super.transformBinaryExpression(tree);
     }
 
     this.popTempScope();
@@ -356,7 +356,7 @@ export class DestructuringTransformer extends TempVarTransformer {
 
   transformFunctionBody(tree) {
     if (this.parameterDeclarations === null)
-      return super(tree);
+      return super.transformFunctionBody(tree);
 
     var list = createVariableDeclarationList(VAR, this.parameterDeclarations);
     var statement = createVariableStatement(list);
@@ -365,7 +365,7 @@ export class DestructuringTransformer extends TempVarTransformer {
 
     this.parameterDeclarations = null;
 
-    var result = super(newBody);
+    var result = super.transformFunctionBody(newBody);
     this.popTempScope();
     return result;
   }

--- a/src/codegeneration/ExponentiationTransformer.js
+++ b/src/codegeneration/ExponentiationTransformer.js
@@ -34,6 +34,6 @@ export class ExponentiationTransformer extends TempVarTransformer {
         return this.transformAny(exploded);
     }
 
-    return super(tree);
+    return super.transformBinaryExpression(tree);
   }
 }

--- a/src/codegeneration/FnExtractAbruptCompletions.js
+++ b/src/codegeneration/FnExtractAbruptCompletions.js
@@ -159,7 +159,7 @@ export class FnExtractAbruptCompletions extends ParseTreeTransformer {
     if (tree) {
       if (tree.isBreakableStatement()) this.inBreakble_++;
       if (tree.isIterationStatement()) this.inLoop_++;
-      tree = super(tree);
+      tree = super.transformAny(tree);
       if (tree.isBreakableStatement()) this.inBreakble_--;
       if (tree.isIterationStatement()) this.inLoop_--;
     }
@@ -183,13 +183,13 @@ export class FnExtractAbruptCompletions extends ParseTreeTransformer {
   transformBreakStatement(tree) {
     if (!tree.name) {
       if (this.inBreakble_) {
-        return super(tree);
+        return super.transformBreakStatement(tree);
       } else {
         tree = new BreakStatement(tree.location,
             this.requestParentLabel_());
       }
     } else if (this.labelledStatements_[tree.name]) {
-      return super(tree);
+      return super.transformBreakStatement(tree);
     }
     return this.transformAbruptCompletion_(tree);
   }
@@ -197,13 +197,13 @@ export class FnExtractAbruptCompletions extends ParseTreeTransformer {
   transformContinueStatement(tree) {
     if (!tree.name) {
       if (this.inLoop_) {
-        return super(tree);
+        return super.transformContinueStatement(tree);
       } else {
         tree = new ContinueStatement(tree.location,
             this.requestParentLabel_());
       }
     } else if (this.labelledStatements_[tree.name]) {
-      return super(tree);
+      return super.transformContinueStatement(tree);
     }
     return this.transformAbruptCompletion_(tree);
   }
@@ -211,7 +211,7 @@ export class FnExtractAbruptCompletions extends ParseTreeTransformer {
   // keep track of labels in the tree
   transformLabelledStatement(tree) {
     this.labelledStatements_[tree.name] = true;
-    return super(tree);
+    return super.transformLabelledStatement(tree);
   }
 
   transformVariableStatement(tree) {
@@ -231,7 +231,7 @@ export class FnExtractAbruptCompletions extends ParseTreeTransformer {
       return new AnonBlock(null, assignments);
     }
 
-    return super(tree);
+    return super.transformVariableStatement(tree);
   }
 
 

--- a/src/codegeneration/GeneratorTransformPass.js
+++ b/src/codegeneration/GeneratorTransformPass.js
@@ -66,7 +66,7 @@ export class GeneratorTransformPass extends TempVarTransformer {
    */
   transformFunctionDeclaration(tree) {
     if (!needsTransform(tree))
-      return super(tree);
+      return super.transformFunctionDeclaration(tree);
 
     if (tree.isGenerator())
       return this.transformGeneratorDeclaration_(tree);
@@ -102,7 +102,7 @@ export class GeneratorTransformPass extends TempVarTransformer {
    */
   transformFunctionExpression(tree) {
     if (!needsTransform(tree))
-      return super(tree);
+      return super.transformFunctionExpression(tree);
 
     if (tree.isGenerator())
       return this.transformGeneratorExpression_(tree);
@@ -159,7 +159,7 @@ export class GeneratorTransformPass extends TempVarTransformer {
 
   transformArrowFunctionExpression(tree) {
     if (!tree.isAsyncFunction())
-      return super(tree);
+      return super.transformArrowFunctionExpression(tree);
 
     return this.transformAny(ArrowFunctionTransformer.transform(this, tree));
   }
@@ -167,7 +167,7 @@ export class GeneratorTransformPass extends TempVarTransformer {
   transformBlock(tree) {
     var inBlock = this.inBlock_;
     this.inBlock_ = true;
-    var rv = super(tree);
+    var rv = super.transformBlock(tree);
     this.inBlock_ = inBlock;
     return rv;
   }

--- a/src/codegeneration/HoistVariablesTransformer.js
+++ b/src/codegeneration/HoistVariablesTransformer.js
@@ -166,7 +166,7 @@ class HoistVariablesTransformer extends ParseTreeTransformer {
     // https://github.com/google/traceur-compiler/issues/969
     var keepBindingIdentifiers = this.keepBindingIdentifiers_;
     this.keepBindingIdentifiers_ = true;
-    var transformed = super(tree);
+    var transformed = super.transformObjectPattern(tree);
     this.keepBindingIdentifiers_ = keepBindingIdentifiers;
     return transformed;
   }
@@ -176,7 +176,7 @@ class HoistVariablesTransformer extends ParseTreeTransformer {
     // https://github.com/google/traceur-compiler/issues/969
     var keepBindingIdentifiers = this.keepBindingIdentifiers_;
     this.keepBindingIdentifiers_ = true;
-    var transformed = super(tree);
+    var transformed = super.transformArrayPattern(tree);
     this.keepBindingIdentifiers_ = keepBindingIdentifiers;
     return transformed;
   }
@@ -269,7 +269,7 @@ class HoistVariablesTransformer extends ParseTreeTransformer {
   transformBlock(tree) {
     var inBlockOrFor = this.inBlockOrFor_;
     this.inBlockOrFor_ = true;
-    tree = super(tree);
+    tree = super.transformBlock(tree);
     this.inBlockOrFor_ = inBlockOrFor;
     return tree;
   }

--- a/src/codegeneration/ParameterTransformer.js
+++ b/src/codegeneration/ParameterTransformer.js
@@ -26,41 +26,41 @@ export class ParameterTransformer extends TempVarTransformer {
   transformArrowFunctionExpression(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);
-    return super(tree);
+    return super.transformArrowFunctionExpression(tree);
   }
 
   transformFunctionDeclaration(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);
-    return super(tree);
+    return super.transformFunctionDeclaration(tree);
   }
 
   transformFunctionExpression(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);
-    return super(tree);
+    return super.transformFunctionExpression(tree);
   }
 
   transformGetAccessor(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);
-    return super(tree);
+    return super.transformGetAccessor(tree);
   }
 
   transformSetAccessor(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);
-    return super(tree);
+    return super.transformSetAccessor(tree);
   }
 
   transformPropertyMethodAssignment(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);
-    return super(tree);
+    return super.transformPropertyMethodAssignment(tree);
   }
 
   transformFunctionBody(tree) {
-    var transformedTree = super(tree);
+    var transformedTree = super.transformFunctionBody(tree);
 
     // The stack is pushed onto further up in the call chain
     // (transformFunctionDeclaration, transformFunctionExpression,

--- a/src/codegeneration/PlaceholderParser.js
+++ b/src/codegeneration/PlaceholderParser.js
@@ -249,7 +249,7 @@ export class PlaceholderTransformer extends ParseTreeTransformer {
         return transformedExpression;
       return createExpressionStatement(transformedExpression);
     }
-    return super(tree);
+    return super.transformExpressionStatement(tree);
   }
 
   transformBlock(tree) {
@@ -262,7 +262,7 @@ export class PlaceholderTransformer extends ParseTreeTransformer {
       if (transformedStatement.type === BLOCK)
         return transformedStatement;
     }
-    return super(tree);
+    return super.transformBlock(tree);
   }
 
   transformFunctionBody(tree) {
@@ -275,13 +275,13 @@ export class PlaceholderTransformer extends ParseTreeTransformer {
       if (transformedStatement.type === BLOCK)
         return createFunctionBody(transformedStatement.statements);
     }
-    return super(tree);
+    return super.transformFunctionBody(tree);
   }
 
   transformMemberExpression(tree) {
     var value = this.getValue_(tree.memberName.value);
     if (value === NOT_FOUND)
-      return super(tree);
+      return super.transformMemberExpression(tree);
     var operand = this.transformAny(tree.operand);
     return createMemberExpression(operand, value);
   }
@@ -294,7 +294,7 @@ export class PlaceholderTransformer extends ParseTreeTransformer {
             convertValueToIdentifierToken(value));
       }
     }
-    return super(tree);
+    return super.transformLiteralPropertyName(tree);
   }
 
   transformArgumentList(tree) {
@@ -306,6 +306,6 @@ export class PlaceholderTransformer extends ParseTreeTransformer {
       if (arg0.type === ARGUMENT_LIST)
         return arg0;
     }
-    return super(tree);
+    return super.transformArgumentList(tree);
   }
 }

--- a/src/codegeneration/RestParameterTransformer.js
+++ b/src/codegeneration/RestParameterTransformer.js
@@ -36,7 +36,7 @@ function getRestParameterLiteralToken(parameterList) {
 export class RestParameterTransformer extends ParameterTransformer {
 
   transformFormalParameterList(tree) {
-    var transformed = super(tree);
+    var transformed = super.transformFormalParameterList(tree);
     if (hasRestParameter(transformed)) {
       var parametersWithoutRestParam = new FormalParameterList(
           transformed.location,

--- a/src/codegeneration/TypeAssertionTransformer.js
+++ b/src/codegeneration/TypeAssertionTransformer.js
@@ -70,7 +70,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    * @return {ParseTree}
    */
   transformScript(tree) {
-    return this.prependAssertionImport_(super(tree), Script);
+    return this.prependAssertionImport_(super.transformScript(tree), Script);
   }
 
   /**
@@ -78,7 +78,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    * @return {ParseTree}
    */
   transformModule(tree) {
-    return this.prependAssertionImport_(super(tree), Module);
+    return this.prependAssertionImport_(super.transformModule(tree), Module);
   }
 
   /**
@@ -92,7 +92,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
 
       this.assertionAdded_ = true;
     }
-    return super(tree);
+    return super.transformVariableDeclaration(tree);
   }
 
   transformFormalParameterList(tree) {
@@ -103,7 +103,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
       arguments: []
     });
 
-    var transformed = super(tree);
+    var transformed = super.transformFormalParameterList(tree);
     var params = this.parametersStack_.pop();
 
     if (params.atLeastOneParameterTyped) {
@@ -122,7 +122,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    * @return {ParseTree}
    */
   transformFormalParameter(tree) {
-    var transformed = super(tree);
+    var transformed = super.transformFormalParameter(tree);
 
     switch (transformed.parameter.type) {
       case BINDING_ELEMENT:
@@ -144,7 +144,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    */
   transformGetAccessor(tree) {
     this.pushReturnType_(tree.typeAnnotation);
-    tree = super(tree);
+    tree = super.transformGetAccessor(tree);
     this.popReturnType_();
     return tree;
   }
@@ -155,7 +155,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    */
   transformPropertyMethodAssignment(tree) {
     this.pushReturnType_(tree.typeAnnotation);
-    tree = super(tree);
+    tree = super.transformPropertyMethodAssignment(tree);
     this.popReturnType_();
     return tree;
   }
@@ -166,7 +166,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    */
   transformFunctionDeclaration(tree) {
     this.pushReturnType_(tree.typeAnnotation);
-    tree = super(tree);
+    tree = super.transformFunctionDeclaration(tree);
     this.popReturnType_();
     return tree;
   }
@@ -177,7 +177,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    */
   transformFunctionExpression(tree) {
     this.pushReturnType_(tree.typeAnnotation);
-    tree = super(tree);
+    tree = super.transformFunctionExpression(tree);
     this.popReturnType_();
     return tree;
   }
@@ -187,7 +187,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    * @return {ParseTree}
    */
   transformReturnStatement(tree) {
-    tree = super(tree);
+    tree = super.transformReturnStatement(tree);
 
     if (this.returnType_ && tree.expression) {
       this.assertionAdded_ = true;

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -313,7 +313,7 @@ export class CPSTransformer extends TempVarTransformer {
           this.expressionToStateMachine(tree.condition));
       body = this.transformAny(tree.body);
     } else {
-      var result = super(tree);
+      var result = super.transformDoWhileStatement(tree);
       ({condition, body} = result);
       if (body.type != STATE_MACHINE)
         return result;
@@ -571,7 +571,7 @@ export class CPSTransformer extends TempVarTransformer {
       ifClause = this.transformAny(tree.ifClause);
       elseClause = this.transformAny(tree.elseClause);
     } else {
-      var result = super(tree);
+      var result = super.transformIfStatement(tree);
       ({condition, ifClause, elseClause} = result);
       if (ifClause.type !== STATE_MACHINE &&
           (elseClause === null || elseClause.type !== STATE_MACHINE)) {

--- a/src/codegeneration/module/ModuleSpecifierVisitor.js
+++ b/src/codegeneration/module/ModuleSpecifierVisitor.js
@@ -40,32 +40,32 @@ export class ModuleSpecifierVisitor extends ParseTreeVisitor {
 
   visitVariableDeclaration(tree) {
     this.addTypeAssertionDependency_(tree.typeAnnotation);
-    return super(tree);
+    return super.visitVariableDeclaration(tree);
   }
 
   visitFormalParameter(tree) {
     this.addTypeAssertionDependency_(tree.typeAnnotation);
-    return super(tree);
+    return super.visitFormalParameter(tree);
   }
 
   visitGetAccessor(tree) {
     this.addTypeAssertionDependency_(tree.typeAnnotation);
-    return super(tree);
+    return super.visitGetAccessor(tree);
   }
 
   visitPropertyMethodAssignment(tree) {
     this.addTypeAssertionDependency_(tree.typeAnnotation);
-    return super(tree);
+    return super.visitPropertyMethodAssignment(tree);
   }
 
   visitFunctionDeclaration(tree) {
     this.addTypeAssertionDependency_(tree.typeAnnotation);
-    return super(tree);
+    return super.visitFunctionDeclaration(tree);
   }
 
   visitFunctionExpression(tree) {
     this.addTypeAssertionDependency_(tree.typeAnnotation);
-    return super(tree);
+    return super.visitFunctionExpression(tree);
   }
 
   addTypeAssertionDependency_(typeAnnotation) {

--- a/src/outputgeneration/ParseTreeMapWriter.js
+++ b/src/outputgeneration/ParseTreeMapWriter.js
@@ -53,7 +53,7 @@ export class ParseTreeMapWriter extends ParseTreeWriter {
     if (tree.location)
       this.enterBranch(tree.location);
 
-    super(tree);
+    super.visitAny(tree);
 
     if (tree.location)
       this.exitBranch(tree.location);

--- a/src/runtime/classes.js
+++ b/src/runtime/classes.js
@@ -41,6 +41,13 @@
     return undefined;
   }
 
+  function superConstructor(ctor) {
+    // __proto__ gets set for IE10 by createClass.
+    return ctor.__proto__;
+  }
+
+  // TODO(arv): Remove once we have pushed new version to npm.
+  // https://github.com/google/traceur-compiler/issues/1425
   function superCall(self, homeObject, name, args) {
     return superGet(self, homeObject, name).apply(self, args);
   }
@@ -117,6 +124,8 @@
             typeof superClass}.`);
   }
 
+  // TODO(arv): Remove once we have pushed new version to npm.
+  // https://github.com/google/traceur-compiler/issues/1425
   function defaultSuperCall(self, homeObject, args) {
     if ($getPrototypeOf(homeObject) !== null)
       superCall(self, homeObject, 'constructor', args);
@@ -125,6 +134,7 @@
   $traceurRuntime.createClass = createClass;
   $traceurRuntime.defaultSuperCall = defaultSuperCall;
   $traceurRuntime.superCall = superCall;
+  $traceurRuntime.superConstructor = superConstructor;
   $traceurRuntime.superGet = superGet;
   $traceurRuntime.superSet = superSet;
 })();

--- a/src/semantics/ConstChecker.js
+++ b/src/semantics/ConstChecker.js
@@ -43,14 +43,14 @@ export class ConstChecker extends ScopeVisitor {
          tree.operator.type === MINUS_MINUS)) {
       this.validateMutation_(tree.operand);
     }
-    super(tree);
+    super.visitUnaryExpression(tree);
   }
 
   visitPostfixExpression(tree) {
     if (tree.operand.type === IDENTIFIER_EXPRESSION) {
       this.validateMutation_(tree.operand);
     }
-    super(tree);
+    super.visitPostfixExpression(tree);
   }
 
   visitBinaryExpression(tree) {
@@ -58,7 +58,7 @@ export class ConstChecker extends ScopeVisitor {
         tree.operator.isAssignmentOperator()) {
       this.validateMutation_(tree.left);
     }
-    super(tree);
+    super.visitBinaryExpression(tree);
   }
 
   validateMutation_(identifierExpression) {

--- a/src/semantics/FreeVariableChecker.js
+++ b/src/semantics/FreeVariableChecker.js
@@ -78,7 +78,7 @@ class FreeVariableChecker extends ScopeVisitor {
         scope.addVar(tree.operand, this.reporter_);
       }
     } else {
-      super(tree);
+      super.visitUnaryExpression(tree);
     }
   }
 

--- a/src/semantics/ScopeChainBuilder.js
+++ b/src/semantics/ScopeChainBuilder.js
@@ -43,12 +43,12 @@ export class ScopeChainBuilder extends ScopeVisitor {
 
   visitImportedBinding(tree) {
     this.declarationType_ = CONST;
-    super(tree);
+    super.visitImportedBinding(tree);
   }
 
   visitVariableDeclarationList(tree) {
     this.declarationType_ = tree.declarationType;
-    super(tree);
+    super.visitVariableDeclarationList(tree);
   }
 
   visitBindingIdentifier(tree) {
@@ -68,7 +68,7 @@ export class ScopeChainBuilder extends ScopeVisitor {
 
   visitFormalParameter(tree) {
     this.declarationType_ = VAR;
-    super(tree);
+    super.visitFormalParameter(tree);
   }
 
   visitFunctionDeclaration(tree) {
@@ -122,7 +122,7 @@ export class ScopeChainBuilder extends ScopeVisitor {
 
   visitComprehensionFor(tree) {
     this.declarationType_ = LET;
-    super(tree);
+    super.visitComprehensionFor(tree);
   }
 
   declareVariable(tree) {

--- a/src/semantics/ScopeVisitor.js
+++ b/src/semantics/ScopeVisitor.js
@@ -57,19 +57,19 @@ export class ScopeVisitor extends ParseTreeVisitor {
 
   visitScript(tree) {
     var scope = this.pushScope(tree);
-    super(tree);
+    super.visitScript(tree);
     this.popScope(scope);
   }
 
   visitModule(tree) {
     var scope = this.pushScope(tree);
-    super(tree);
+    super.visitModule(tree);
     this.popScope(scope);
   }
 
   visitBlock(tree) {
     var scope = this.pushScope(tree);
-    super(tree);
+    super.visitBlock(tree);
     this.popScope(scope);
   }
 
@@ -158,18 +158,18 @@ export class ScopeVisitor extends ParseTreeVisitor {
   }
 
   visitForInStatement(tree) {
-    this.visitLoop_(tree, () => super(tree));
+    this.visitLoop_(tree, () => super.visitForInStatement(tree));
   }
 
   visitForOfStatement(tree) {
-    this.visitLoop_(tree, () => super(tree));
+    this.visitLoop_(tree, () => super.visitForOfStatement(tree));
   }
 
   visitForStatement(tree) {
     if (!tree.initializer) {
-      super(tree);
+      super.visitForStatement(tree);
     } else {
-      this.visitLoop_(tree, () => super(tree));
+      this.visitLoop_(tree, () => super.visitForStatement(tree));
     }
   }
 

--- a/test/feature/Classes/ExtendStrange.js
+++ b/test/feature/Classes/ExtendStrange.js
@@ -16,9 +16,9 @@ class D extends null {
   }
 }
 
-assert.throw(function() {
-  new D();
-}, TypeError);
+// super() does not depend on the [HomeObject]. It just calls the [Prototype]
+// of the function.
+new D();
 
 class E extends function() { return null }() {
   constructor(...args) {
@@ -26,10 +26,9 @@ class E extends function() { return null }() {
   }
 }
 
-assert.throw(function() {
-  new E();
-}, TypeError);
-
+// super() does not depend on the [HomeObject]. It just calls the [Prototype]
+// of the function.
+new E();
 
 function f() {};
 f.prototype = null;

--- a/test/feature/Classes/InheritanceFromMemberExpression.js
+++ b/test/feature/Classes/InheritanceFromMemberExpression.js
@@ -1,6 +1,8 @@
 var baseContainer = {
-  base: function() {}
-}
+  base: function() {
+    this.yyy = 'base constructor';
+  }
+};
 
 baseContainer.base.prototype = {
   x: 'proto x',
@@ -23,7 +25,7 @@ var a = new MemberExprBase('w value');
 var pa = Object.getPrototypeOf(a);
 var ppa = Object.getPrototypeOf(pa);
 
-assertHasOwnProperty(a, 'y', 'w', 'z');
+assertHasOwnProperty(a, 'yyy', 'w', 'z');
 assertLacksOwnProperty(a, 'x');
 assertHasOwnProperty(pa, 'constructor');
-assertHasOwnProperty(ppa, 'x', 'constructor')
+assertHasOwnProperty(ppa, 'x', 'constructor');

--- a/test/feature/Classes/SuperChangeProto.js
+++ b/test/feature/Classes/SuperChangeProto.js
@@ -10,9 +10,9 @@ class OtherBase {
 class Derived extends Base {
   p() {
     log += '[Derived]';
-    super();
+    super.p();
     Derived.prototype.__proto__ = OtherBase.prototype;
-    super();
+    super.p();
   }
 }
 

--- a/test/unit/node/resources/class.js
+++ b/test/unit/node/resources/class.js
@@ -9,7 +9,7 @@ class B {
 
 class C extends B {
   method() {
-    return super() + this.x;
+    return super.method() + this.x;
   }
 }
 


### PR DESCRIPTION
`super()` now means call the proto of the current function.

Therefore we now need to be explicit with `super.method()`.
