### PR TITLE
Add parsing support for type generics

### DIFF
--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -29,7 +29,6 @@ import {
   FROM,
   GET,
   OF,
-  MODULE,
   SET
 } from '../syntax/PredefinedName';
 import {
@@ -45,6 +44,7 @@ import {
   CASE,
   CATCH,
   CLASS,
+  CLOSE_ANGLE,
   CLOSE_CURLY,
   CLOSE_PAREN,
   CLOSE_SQUARE,
@@ -69,6 +69,7 @@ import {
   MINUS_MINUS,
   NEW,
   NUMBER,
+  OPEN_ANGLE,
   OPEN_CURLY,
   OPEN_PAREN,
   OPEN_SQUARE,
@@ -1183,6 +1184,21 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   /**
+   * @param {TypeArguments} tree
+   */
+  visitTypeArguments(tree) {
+    this.write_(OPEN_ANGLE);
+    var {args} = tree;
+    this.visitAny(args[0]);
+    for (var i = 1; i < args.length; i++) {
+      this.write_(COMMA);
+      this.writeSpace_();
+      this.visitAny(args[i]);
+    }
+    this.write_(CLOSE_ANGLE);
+  }
+
+  /**
    * @param {TypeName} tree
    */
   visitTypeName(tree) {
@@ -1192,6 +1208,8 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     }
     this.write_(tree.name);
   }
+
+  // visitTypeReference needs no override.
 
   /**
    * @param {UnaryExpression} tree

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -93,6 +93,8 @@ import {
   SET_ACCESSOR,
   TEMPLATE_LITERAL_PORTION,
   TEMPLATE_SUBSTITUTION,
+  TYPE_ARGUMENTS,
+  TYPE_NAME,
   VARIABLE_DECLARATION_LIST,
   VARIABLE_STATEMENT
 } from './trees/ParseTreeType';
@@ -982,10 +984,34 @@ export class ParseTreeValidator extends ParseTreeVisitor {
   }
 
   /**
+   * @param {TypeArguments} tree
+   */
+  visitTypeArguments(tree) {
+    var {args} = tree;
+    for (var i = 0; i < args.length; i++) {
+      this.checkVisit_(args[i].isType(), args[i],
+                       'Type arguments must be type expressions');
+    }
+  }
+
+  /**
    * @param {TypeName} tree
    */
   visitTypeName(tree) {
-    // TODO(peterhal): Implement.
+    this.checkVisit_(tree.moduleName === null ||
+                     tree.moduleName.type === TYPE_NAME,
+                     tree.moduleName,
+                     'moduleName must be null or a TypeName');
+    this.check_(tree.name.type === IDENTIFIER, tree,
+                'name must be an identifier');
+  }
+
+  /**
+   * @param {TypeReference} tree
+   */
+  visitTypeReference(tree) {
+    this.checkType_(TYPE_NAME, tree.typeName, 'typeName must be a TypeName');
+    this.checkType_(TYPE_ARGUMENTS, tree.args, 'args must be a TypeArguments');
   }
 
   /**

--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -44,17 +44,17 @@ import {
   EMPTY_STATEMENT,
   EXPORT_DECLARATION,
   EXPRESSION_STATEMENT,
+  FORMAL_PARAMETER,
   FOR_IN_STATEMENT,
   FOR_OF_STATEMENT,
   FOR_STATEMENT,
-  FORMAL_PARAMETER,
   FUNCTION_DECLARATION,
   FUNCTION_EXPRESSION,
   GENERATOR_COMPREHENSION,
   IDENTIFIER_EXPRESSION,
   IF_STATEMENT,
-  IMPORT_DECLARATION,
   IMPORTED_BINDING,
+  IMPORT_DECLARATION,
   LABELLED_STATEMENT,
   LITERAL_EXPRESSION,
   MEMBER_EXPRESSION,
@@ -65,6 +65,7 @@ import {
   OBJECT_PATTERN,
   PAREN_EXPRESSION,
   POSTFIX_EXPRESSION,
+  PREDEFINED_TYPE,
   PROPERTY_NAME_SHORTHAND,
   REST_PARAMETER,
   RETURN_STATEMENT,
@@ -76,6 +77,7 @@ import {
   THIS_EXPRESSION,
   THROW_STATEMENT,
   TRY_STATEMENT,
+  TYPE_REFERENCE,
   UNARY_EXPRESSION,
   VARIABLE_DECLARATION,
   VARIABLE_STATEMENT,
@@ -336,6 +338,20 @@ export class ParseTree {
     return this.functionKind !== null &&
         this.functionKind.type === IDENTIFIER &&
         this.functionKind.value === ASYNC;
+  }
+
+  isType() {
+    switch (this.type) {
+      case PREDEFINED_TYPE:
+      case TYPE_REFERENCE:
+      // TODO(arv): Implement the rest.
+      // case TYPE_QUERY:
+      // case OBJECT_TYPE:
+      // case FUNCTION_TYPE:
+      // case CONSTRUCTOR_TYPE:
+        return true;
+    }
+    return false;
   }
 
   getDirectivePrologueStringToken_() {

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -935,6 +935,14 @@
       "Finally"
     ]
   },
+  "TypeArguments": {
+    "location": [
+      "SourceRange"
+    ],
+    "args": [
+      "Arrray<ParseTree>"
+    ]
+  },
   "TypeName": {
     "location": [
       "SourceRange"
@@ -944,6 +952,17 @@
     ],
     "name": [
       "IdentifierToken"
+    ]
+  },
+  "TypeReference": {
+    "location": [
+      "SourceRange"
+    ],
+    "typeName": [
+      "TypeName"
+    ],
+    "args": [
+      "TypeArguments"
     ]
   },
   "UnaryExpression": {

--- a/test/feature/Types/Error_TypeArguments.js
+++ b/test/feature/Types/Error_TypeArguments.js
@@ -1,0 +1,4 @@
+// Options: --types
+// Error: :4:17: Unexpected token )
+
+function f(x: X<) {}

--- a/test/feature/Types/Error_TypeArguments2.js
+++ b/test/feature/Types/Error_TypeArguments2.js
@@ -1,0 +1,4 @@
+// Options: --types
+// Error: :5:1: Unexpected token End of File
+
+var x: X<

--- a/test/feature/Types/Error_TypeArguments3.js
+++ b/test/feature/Types/Error_TypeArguments3.js
@@ -1,0 +1,4 @@
+// Options: --types
+// Error: :4:10: Unexpected token >
+
+var x: X<>;

--- a/test/feature/Types/TypeAnnotations.js
+++ b/test/feature/Types/TypeAnnotations.js
@@ -1,4 +1,4 @@
-// Options: --types=true --annotations=true
+// Options: --types --annotations
 
 class Test {}
 

--- a/test/feature/Types/TypeSyntax.js
+++ b/test/feature/Types/TypeSyntax.js
@@ -1,7 +1,7 @@
-// Options: --types=true
+// Options: --types
 
 var a : any;
-var b : bool;
+var b : boolean;
 var s : string;
 var v : void;
 var n : number;
@@ -17,3 +17,6 @@ function abc(x : Test) : Test {
 function xyz({x, y} : Test) {}
 
 var x = function (a : Test) : Test {}
+
+var arr : Array<number>;
+var map : Map<number, boolean>;


### PR DESCRIPTION
Aka TypeArguments. The syntax is taken from the TypeScript spec
and here are some examples:

`Array<number>`
`Map<number, boolean>`
`a.b<c, d.e, f.g.h>`
