### PR TITLE
Type asserts: Fix issues with TypeName and asserts

### DIFF
--- a/src/codegeneration/TypeToExpressionTransformer.js
+++ b/src/codegeneration/TypeToExpressionTransformer.js
@@ -14,15 +14,21 @@
 
 import {ParseTreeTransformer} from './ParseTreeTransformer';
 import {
-  createIdentifierExpression,
+  IdentifierExpression,
+  MemberExpression
+} from '../syntax/trees/ParseTrees';
+import {
   createMemberExpression
 } from './ParseTreeFactory';
-
 
 export class TypeToExpressionTransformer extends ParseTreeTransformer {
 
   transformTypeName(tree) {
-    return createIdentifierExpression(tree.name);
+    if (tree.moduleName) {
+      var operand = this.transformAny(tree.moduleName);
+      return new MemberExpression(tree.location, operand, tree.name);
+    }
+    return new IdentifierExpression(tree.location, tree.name);
   }
 
   transformPredefinedType(tree) {

--- a/test/feature/TypeAssertions/ClassParams.js
+++ b/test/feature/TypeAssertions/ClassParams.js
@@ -1,11 +1,11 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
 class Test {
-  single(a:Number) { return true; }
-  multiple(a:Number, b:Boolean) { return true; }
-  initialized(a:Number = 1) { return a; }
+  single(a: number) { return true; }
+  multiple(a: number, b: boolean) { return true; }
+  initialized(a: number = 1) { return a; }
   untyped(a) { return true; }
 
-  set name(val: String) {
+  set name(val: string) {
     this._name = val;
   }
 }

--- a/test/feature/TypeAssertions/ClassReturnTypes.js
+++ b/test/feature/TypeAssertions/ClassReturnTypes.js
@@ -1,19 +1,19 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
 class Test {
-  simple():Number { return 1; }
+  simple(): number { return 1; }
 
-  throwsAssertion():Boolean {
+  throwsAssertion(): boolean {
     return {test: '123'};
   }
 
-  get getter():Number { return 1; }
+  get getter(): number { return 1; }
 
-  static staticSimple():Number { return 1; }
-  static staticThrowsAssertion():Boolean {
+  static staticSimple(): number { return 1; }
+  static staticThrowsAssertion(): boolean {
     return {test: '123'};
   }
 
-  static get staticGetter():Number { return 1; }
+  static get staticGetter(): number { return 1; }
 }
 
 var test = new Test();

--- a/test/feature/TypeAssertions/DefaultParam.js
+++ b/test/feature/TypeAssertions/DefaultParam.js
@@ -1,5 +1,5 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
-function initialized(a:Number = 1) { return a; }
+function initialized(a: number = 1) { return a; }
 
 assert.equal(1, initialized());
 assert.equal(2, initialized(2));

--- a/test/feature/TypeAssertions/FunctionParams.js
+++ b/test/feature/TypeAssertions/FunctionParams.js
@@ -1,8 +1,8 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
-function single(a:Number) {}
-function multiple(a:Number, b:Boolean) {}
+function single(a: number) {}
+function multiple(a: number, b: boolean) {}
 function untyped(a) {}
-function onlySome(a, b:Number) {}
+function onlySome(a, b: number) {}
 
 single(1);
 multiple(1, true);

--- a/test/feature/TypeAssertions/FunctionReturnType.js
+++ b/test/feature/TypeAssertions/FunctionReturnType.js
@@ -1,13 +1,13 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
-function returnType():Number { return 1; }
+function returnType(): number { return 1; }
 
-function multipleReturnPaths(value):Number {
+function multipleReturnPaths(value): number {
   if (value)
     return 1;
   return 2;
 }
 
-function returnWithinForLoop(value):Boolean {
+function returnWithinForLoop(value): boolean {
   if (!value)
     return false;
 
@@ -19,7 +19,7 @@ function returnWithinForLoop(value):Boolean {
   return false;
 }
 
-function returnWithinWhileLoop(value):Boolean {
+function returnWithinWhileLoop(value): boolean {
   var i = 0;
   while(++i < 10) {
     if (i === value) {
@@ -29,7 +29,7 @@ function returnWithinWhileLoop(value):Boolean {
   return false;
 }
 
-function returnWithinDoWhileLoop(value):Boolean {
+function returnWithinDoWhileLoop(value): boolean {
   var i = 0;
   do {
     if (i === value) {
@@ -39,16 +39,16 @@ function returnWithinDoWhileLoop(value):Boolean {
   return false;
 }
 
-function returnExpression(value):Number {
+function returnExpression(value): number {
   return value === 0 ? 0 : value / 2;
 }
 
-function throwsAssertion():Boolean {
+function throwsAssertion(): boolean {
   return {test: '123'};
 }
 
-function nested(value):Boolean {
-  var square = function (value):Number {
+function nested(value): boolean {
+  var square = function (value): number {
     return value * value;
   };
 

--- a/test/feature/TypeAssertions/NestedFunctionDefaultParam.js
+++ b/test/feature/TypeAssertions/NestedFunctionDefaultParam.js
@@ -1,7 +1,7 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
-function f(value:String, a:Function = function():Function {
+function f(value: string, a: Function = function(): Function {
   // body of default param expression
-  return function (x:String):Number {
+  return function (x: string): number {
     if (x === 'invalid')
       return x;
     return x.length;

--- a/test/feature/TypeAssertions/TypeName.js
+++ b/test/feature/TypeAssertions/TypeName.js
@@ -1,0 +1,11 @@
+// Options: --types --type-assertions --type-assertion-module=./resources/assert
+
+var a = {
+  B: class {}
+};
+
+var b : a.B = new a.B();
+
+assert.throw(() => {
+  var c : a.B = 42;
+});

--- a/test/feature/TypeAssertions/Variables.js
+++ b/test/feature/TypeAssertions/Variables.js
@@ -1,16 +1,16 @@
 // Options: --types --type-assertions --type-assertion-module=./resources/assert
-var globalVar:Number = 1;
-var globalUninitializedVar:Number;
+var globalVar: number = 1;
+var globalUninitializedVar: number;
 
 function variableTypes() {
-  var x:Number = 1;
-  var y:Number;
-  var a:Number, b:Number;
-  var c:Number = 1, d:Number = 2, e:String = 'test';
+  var x: number = 1;
+  var y: number;
+  var a: number, b: number;
+  var c: number = 1, d: number = 2, e: string = 'test';
 }
 
 function throwsAssertion(value) {
-  var x:Number = value;
+  var x: number = value;
 }
 
 assert.throw(() => { throwsAssertion('test'); }, chai.AssertionError);

--- a/test/feature/TypeAssertions/WrappersVsPrimitives.js
+++ b/test/feature/TypeAssertions/WrappersVsPrimitives.js
@@ -1,0 +1,30 @@
+// Options: --types --type-assertions --type-assertion-module=./resources/assert
+
+
+var num : Number = new Number(1);
+var str : String = new String('str');
+var bool : Boolean = new Boolean(true);
+
+var n : number = 1;
+var s : string = 'str';
+var b : boolean = true;
+
+assert.throw(() => {
+  var num : Number = 1;
+});
+assert.throw(() => {
+  var str : String = 'str';
+});
+assert.throw(() => {
+  var bool : Boolean = true;
+});
+
+assert.throw(() => {
+  var num : number = new Number(1);
+});
+assert.throw(() => {
+  var str : string = new String('str');
+});
+assert.throw(() => {
+  var bool : boolean = new Boolean(true);
+});

--- a/test/feature/TypeAssertions/resources/assert.js
+++ b/test/feature/TypeAssertions/resources/assert.js
@@ -10,8 +10,15 @@ assert.type = function (actual, type) {
     return actual;
   }
 
-  var typeName = type.name || type.toString().match(/^\s*function\s*([^\s(]+)/)[1];
-  assert.typeOf(actual, typeName);
+  if ($traceurRuntime.type[type.name] === type) {
+    // chai.assert treats Number as number :'(
+    assert.equal(typeof actual, type.name);
+  } else {
+    assert.instanceOf(actual, type);
+  }
+
+  // TODO(arv): Handle generics, structural types and more.
+
   return actual;
 };
 

--- a/test/feature/TypeAssertions/resources/exported-function.js
+++ b/test/feature/TypeAssertions/resources/exported-function.js
@@ -1,4 +1,4 @@
 import {assert} from './assert'
-export function exportedParamAndReturn(a:Number):Number {
+export function exportedParamAndReturn(a: number): number {
   return a === 0 ? 'invalid' : a;
 }


### PR DESCRIPTION
The assert functions we used for testing was wrong. It did not
handle number vs Number.

We also dropped the `moduleName` of the TypeName on the floor.
