### PR TITLE
PlaceholderParser: Allow null in type context

### DIFF
--- a/src/codegeneration/PlaceholderParser.js
+++ b/src/codegeneration/PlaceholderParser.js
@@ -197,9 +197,9 @@ function convertValueToIdentifierToken(value) {
 }
 
 function convertValueToType(value) {
-  if (value instanceof ParseTree) {
-    return value;
-  }
+  // We allow null here since it is common to have `var x : ${value}`.
+  if (value === null) return null;
+  if (value instanceof ParseTree) return value;
   if (typeof value === 'string') {
     return new TypeName(null, null, convertValueToIdentifierToken(value));
   }

--- a/test/unit/es6/codegeneration/PlaceholderParser.js
+++ b/test/unit/es6/codegeneration/PlaceholderParser.js
@@ -178,6 +178,11 @@ suite('PlaceholderParser.traceur.js', function() {
     assert.equal('var x: a.b;', write(tree));
   });
 
+  test('Type null', function() {
+    var tree = parseStatement `var x: ${null} = 1;`;
+    assert.equal('var x = 1;', write(tree));
+  });
+
   test('TypeName 2', function() {
     var a = 'a';
     var tree = parseStatement `var x: ${a}.b;`;


### PR DESCRIPTION
This is so that you can do:

  parseStatement `var x: ${null};`

result in

  var x;
