### PR TITLE
Generic type assertions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ RUNTIME_SRC = \
   src/runtime/classes.js \
   src/runtime/generators.js \
   src/runtime/url.js \
+  src/runtime/type-assertions.js \
   src/runtime/ModuleStore.js
 POLYFILL_SRC = \
   src/runtime/polyfills/Map.js \

--- a/src/codegeneration/TypeToExpressionTransformer.js
+++ b/src/codegeneration/TypeToExpressionTransformer.js
@@ -14,12 +14,13 @@
 
 import {ParseTreeTransformer} from './ParseTreeTransformer';
 import {
+  ArgumentList,
   IdentifierExpression,
   MemberExpression
 } from '../syntax/trees/ParseTrees';
 import {
-  createMemberExpression
-} from './ParseTreeFactory';
+  parseExpression
+} from './PlaceholderParser';
 
 export class TypeToExpressionTransformer extends ParseTreeTransformer {
 
@@ -32,7 +33,18 @@ export class TypeToExpressionTransformer extends ParseTreeTransformer {
   }
 
   transformPredefinedType(tree) {
-    return createMemberExpression('$traceurRuntime', 'type', tree.typeToken);
+    return parseExpression `$traceurRuntime.type.${tree.typeToken})`;
+  }
+
+  transformTypeReference(tree) {
+    var typeName = this.transformAny(tree.typeName);
+    var args = this.transformAny(tree.args);
+    var argumentList = new ArgumentList(tree.location, [typeName, ...args]);
+    return parseExpression `$traceurRuntime.genericType(${argumentList})`;
+  }
+
+  transformTypeArguments(tree) {
+    return this.transformList(tree.args);
   }
 
 }

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -47,16 +47,6 @@
     };
   }
 
-  // ### Primitive value types
-  var types = {
-    any: {name: 'any'},
-    boolean: {name: 'boolean'},
-    number: {name: 'number'},
-    string: {name: 'string'},
-    symbol: {name: 'symbol'},
-    void: {name: 'void'},
-  };
-
   var method = nonEnum;
 
   // ### Symbols
@@ -408,7 +398,6 @@
     require: relativeRequire,
     toObject: toObject,
     toProperty: toProperty,
-    type: types,
     typeof: typeOf,
   };
 

--- a/src/runtime/type-assertions.js
+++ b/src/runtime/type-assertions.js
@@ -1,0 +1,42 @@
+// Copyright 2014 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function() {
+  'use strict';
+
+  // ### Primitive value types
+  var types = {
+    any: {name: 'any'},
+    boolean: {name: 'boolean'},
+    number: {name: 'number'},
+    string: {name: 'string'},
+    symbol: {name: 'symbol'},
+    void: {name: 'void'},
+  };
+
+  class GenericType {
+    constructor(type, argumentTypes) {
+      this.type = type;
+      this.argumentTypes = argumentTypes;
+    }
+  }
+
+  function genericType(type, ...argumentTypes) {
+    return new GenericType(type, argumentTypes);
+  }
+
+  $traceurRuntime.GenericType = GenericType;
+  $traceurRuntime.genericType = genericType;
+  $traceurRuntime.type = types;
+})();

--- a/test/feature/TypeAssertions/GenericArray.js
+++ b/test/feature/TypeAssertions/GenericArray.js
@@ -1,0 +1,14 @@
+// Options: --types --type-assertions --type-assertion-module=./resources/assert
+
+var a: Array = [];
+var b: Array<number> = [];
+var c: Array<number> = [0];
+var d: Array<number> = [1, 2];
+
+assert.throw(() => {
+  var a: Array<number> = ['s'];
+});
+
+// TODO(arv): Issue #1467
+// var e: Array<Array<number> > = [[]];
+// var f: Array<Array<number> > = [[3, 4], [5]];

--- a/test/feature/TypeAssertions/resources/assert.js
+++ b/test/feature/TypeAssertions/resources/assert.js
@@ -14,15 +14,23 @@ assert.type = function (actual, type) {
     // chai.assert treats Number as number :'(
     // Use runtime to handle symbol
     assert.equal($traceurRuntime.typeof(actual), type.name);
+  } else if (type instanceof $traceurRuntime.GenericType) {
+    assert.type(actual, type.type);
+    if (type.type === Array) {
+      for (var i = 0; i < actual.length; i++) {
+        assert.type(actual[i], type.argumentTypes[0]);
+      }
+    } else {
+      throw new Error(`Unsupported generic type${type}`);
+    }
   } else {
     assert.instanceOf(actual, type);
   }
 
-  // TODO(arv): Handle generics, structural types and more.
+  // TODO(arv): Handle more generics, structural types and more.
 
   return actual;
 };
-
 
 assert.argumentTypes = function(...params) {
   for (var i = 0; i < params.length; i += 2) {


### PR DESCRIPTION
This adds basic support for generics for the type assertions pass.
Right now the responsibility for validating the type is part of
the test. All Traceur does is to transform

`T<x, y>`

into

`$traceurRuntime.genericType(T, x, y)`

which now constructs a new $traceurRuntime.GenericType which the
testing asserts can inspect to determine how to validate the value.
