### PR TITLE
Allow >> in type generics syntax

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -3760,7 +3760,12 @@ export class Parser {
       this.eat_(COMMA);
       args.push(this.parseType_());
     }
-    this.eat_(CLOSE_ANGLE);
+
+    var token = this.nextCloseAngle_();
+    if (token.type !== CLOSE_ANGLE) {
+      return this.parseUnexpectedToken_(token.type);
+    }
+
     return new TypeArguments(this.getTreeLocation_(start), args);
   }
 
@@ -4102,6 +4107,10 @@ export class Parser {
 
   nextTemplateLiteralToken_() {
     return this.scanner_.nextTemplateLiteralToken();
+  }
+
+  nextCloseAngle_() {
+    return this.scanner_.nextCloseAngle();
   }
 
   isAtEnd() {

--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -256,6 +256,25 @@ export class Scanner {
     return t;
   }
 
+  /**
+   * Called for the close angle for type generics. This allows type expressions
+   * like `Array<Array<number>>` to be parsed as `Array<Array<number> >`.
+   */
+  nextCloseAngle() {
+    switch (token.type) {
+      case GREATER_EQUAL:
+      case RIGHT_SHIFT:
+      case RIGHT_SHIFT_EQUAL:
+      case UNSIGNED_RIGHT_SHIFT:
+      case UNSIGNED_RIGHT_SHIFT_EQUAL:
+        this.index -= token.type.length - 1;
+        lastToken = createToken(CLOSE_ANGLE, index);
+        token = scanToken();
+        return lastToken;
+    }
+    return nextToken();
+  }
+
   /** @return {Token} */
   nextToken() {
     return nextToken();

--- a/test/feature/TypeAssertions/GenericArray.js
+++ b/test/feature/TypeAssertions/GenericArray.js
@@ -9,6 +9,8 @@ assert.throw(() => {
   var a: Array<number> = ['s'];
 });
 
-// TODO(arv): Issue #1467
-// var e: Array<Array<number> > = [[]];
-// var f: Array<Array<number> > = [[3, 4], [5]];
+var e: Array<Array<number> > = [[]];
+var e: Array<Array<number>> = [[]];
+var f: Array<Array<number>>= [[3, 4], [5]];
+var g: Array<Array<Array<number>>> = [[[]]];
+var h: Array<Array<Array<number>>>= [[[]]];


### PR DESCRIPTION
We support this in a similar way to the way parsing regexps work.
When we look for the `>` we let the scanner treat `>>` as `>` and
decrease the position of the scanner so that next token it sees
starts after the first `>`.

Fixes #1467
