### PR TITLE
Add parsing support for more type syntax

### DIFF
--- a/demo/repl.html
+++ b/demo/repl.html
@@ -65,7 +65,7 @@ html, body {
   height: auto;
   width: -webkit-calc(50% - 15px);
   width: calc(50% - 15px);
-  font-family:  'Droid Sans Mono', sans-serif;
+  font-family:  'Droid Sans Mono', monospace;
   font-size: 12px;
   margin: 5px;
   line-height: 1.2;

--- a/src/codegeneration/DefaultParametersTransformer.js
+++ b/src/codegeneration/DefaultParametersTransformer.js
@@ -100,4 +100,13 @@ export class DefaultParametersTransformer extends ParameterTransformer {
 
     return new FormalParameterList(tree.location, parameters);
   }
+
+  transformConstructorType(tree) {
+    return tree;
+  }
+
+  transformFunctionType(tree) {
+    return tree;
+  }
+
 }

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -96,7 +96,7 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (transformOptions.templateLiterals)
       append(TemplateLiteralTransformer);
 
-    if (options.types)
+    if (transformOptions.types)
       append(TypeToExpressionTransformer);
 
     if (transformOptions.unicodeEscapeSequences)

--- a/src/codegeneration/ParseTreeFactory.js
+++ b/src/codegeneration/ParseTreeFactory.js
@@ -680,7 +680,7 @@ function createLiteralPropertyName(name) {
  * @return {RestParameter}
  */
 function createRestParameter(identifier) {
-  return new RestParameter(null, createBindingIdentifier(identifier));
+  return new RestParameter(null, createBindingIdentifier(identifier), null);
 }
 
 /**

--- a/src/codegeneration/RestParameterTransformer.js
+++ b/src/codegeneration/RestParameterTransformer.js
@@ -64,4 +64,12 @@ export class RestParameterTransformer extends ParameterTransformer {
 
     return transformed;
   }
+
+  transformConstructorType(tree) {
+    return tree;
+  }
+
+  transformFunctionType(tree) {
+    return tree;
+  }
 }

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -216,6 +216,15 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   /**
+   * @param {ArrayType} tree
+   */
+  visitArrayType(tree) {
+    this.visitAny(tree.elementType);
+    this.write_(OPEN_SQUARE);
+    this.write_(CLOSE_SQUARE);
+  }
+
+  /**
    * @param {ArrowFunctionExpression} tree
    */
   visitArrowFunctionExpression(tree) {
@@ -333,6 +342,19 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   /**
+   * @param {CallSignature} tree
+   */
+  visitCallSignature(tree) {
+    if (tree.typeParameters) {
+      this.visitAny(tree.typeParameters);
+    }
+    this.write_(OPEN_PAREN);
+    this.visitAny(tree.parameterList);
+    this.write_(CLOSE_PAREN);
+    this.writeTypeAnnotation_(tree.returnType);
+  }
+
+  /**
    * @param {CaseClause} tree
    */
   visitCaseClause(tree) {
@@ -422,6 +444,24 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     this.write_(OPEN_SQUARE);
     this.visitAny(tree.expression);
     this.write_(CLOSE_SQUARE);
+  }
+
+  /**
+   * @param {ConstructSignature} tree
+   */
+  visitConstructSignature(tree) {
+    this.write_(NEW);
+    this.writeSpace_();
+    this.visitCallSignature(tree);
+  }
+
+  /**
+   * @param {ConstructorType} tree
+   */
+  visitConstructorType(tree) {
+    this.write_(NEW);
+    this.writeSpace_();
+    this.visitFunctionType(tree);
   }
 
   /**
@@ -707,6 +747,19 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     this.visitAny(tree.body);
   }
 
+  visitFunctionType(tree) {
+    if (tree.typeParameters !== null) {
+      this.visitAny(tree.typeParameters);
+    }
+    this.write_(OPEN_PAREN);
+    this.visitAny(tree.parameterList);
+    this.write_(CLOSE_PAREN);
+    this.writeSpace_();
+    this.write_(ARROW);
+    this.writeSpace_();
+    this.visitAny(tree.returnType);
+  }
+
   visitGeneratorComprehension(tree) {
     this.write_(OPEN_PAREN);
     this.visitList(tree.comprehensionList);
@@ -761,6 +814,20 @@ export class ParseTreeWriter extends ParseTreeVisitor {
         this.visitAnyBlockOrIndent_(tree.elseClause);
       }
     }
+  }
+
+  /**
+   * @param {IndexSignature} tree
+   */
+  visitIndexSignature(tree) {
+    this.write_(OPEN_SQUARE);
+    this.write_(tree.name);
+    this.write_(COLON);
+    this.writeSpace_();
+    this.visitAny(tree.indexType);
+    this.write_(CLOSE_SQUARE);
+    this.writeTypeAnnotation_(tree.typeAnnotation);
+    this.write_(SEMI_COLON);
   }
 
   /**
@@ -877,6 +944,18 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   /**
+   * @param {MethodSignature} tree
+   */
+  visitMethodSignature(tree) {
+    this.visitAny(tree.name);
+    if (tree.optional) {
+      this.write_(QUESTION);
+    }
+    this.visitAny(tree.callSignature);
+    this.write_(SEMI_COLON);
+  }
+
+  /**
    * @param {SyntaxErrorTree} tree
    */
   visitSyntaxErrorTree(tree) {
@@ -955,6 +1034,15 @@ export class ParseTreeWriter extends ParseTreeVisitor {
       this.writeSpace_();
       this.visitAny(tree.element);
     }
+  }
+
+  /**
+   * @param {ObjectType} tree
+   */
+  visitObjectType(tree) {
+    this.write_(OPEN_CURLY);
+    this.writelnList_(tree.typeMembers);
+    this.write_(CLOSE_CURLY);
   }
 
   /**
@@ -1050,6 +1138,18 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   /**
+   * @param {PropertySignature} tree
+   */
+  visitPropertySignature(tree) {
+    this.visitAny(tree.name);
+    if (tree.optional) {
+      this.write_(QUESTION);
+    }
+    this.writeTypeAnnotation_(tree.typeAnnotation);
+    this.write_(SEMI_COLON);
+  }
+
+  /**
    * @param {TemplateLiteralExpression} tree
    */
   visitTemplateLiteralExpression(tree) {
@@ -1096,7 +1196,7 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   visitRestParameter(tree) {
     this.write_(DOT_DOT_DOT);
     this.write_(tree.identifier.identifierToken);
-    this.writeTypeAnnotation_(this.currentParameterTypeAnnotation_);
+    this.writeTypeAnnotation_(tree.typeAnnotation);
   }
 
   /**
@@ -1224,6 +1324,28 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   // visitTypeReference needs no override.
+
+  /**
+   * @param {TypeParameter} tree
+   */
+  visitTypeParameter(tree) {
+    this.write_(tree.identifierToken);
+    if (tree.extendsType) {
+      this.writeSpace_();
+      this.write_(EXTENDS);
+      this.writeSpace_();
+      this.visitAny(tree.extendsType);
+    }
+  }
+
+  /**
+   * @param {TypeParameters} tree
+   */
+  visitTypeParameters(tree) {
+    this.write_(OPEN_ANGLE);
+    this.writeList_(tree.parameters, COMMA, false);
+    this.write_(CLOSE_ANGLE);
+  }
 
   /**
    * @param {UnaryExpression} tree

--- a/src/semantics/ScopeVisitor.js
+++ b/src/semantics/ScopeVisitor.js
@@ -200,4 +200,9 @@ export class ScopeVisitor extends ParseTreeVisitor {
   visitGeneratorComprehension(tree) {
     this.visitComprehension_(tree);
   }
+
+  // Do not recurse into type annotations
+  visitPredefinedType(tree) {}
+  visitTypeArguments(tree) {}
+  visitFunctionType(tree) {}
 }

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -96,6 +96,7 @@ import {
   TEMPLATE_SUBSTITUTION,
   TYPE_ARGUMENTS,
   TYPE_NAME,
+  TYPE_PARAMETER,
   VARIABLE_DECLARATION_LIST,
   VARIABLE_STATEMENT
 } from './trees/ParseTreeType.js';
@@ -1014,6 +1015,29 @@ export class ParseTreeValidator extends ParseTreeVisitor {
   visitTypeReference(tree) {
     this.checkType_(TYPE_NAME, tree.typeName, 'typeName must be a TypeName');
     this.checkType_(TYPE_ARGUMENTS, tree.args, 'args must be a TypeArguments');
+  }
+
+  /**
+   * @param {TypeParameters} tree
+   */
+  visitTypeParameters(tree) {
+    var {parameters} = tree;
+    for (var i = 0; i < parameters.length; i++) {
+      this.checkType_(TYPE_PARAMETER, parameters[i],
+                      'Type parameters must all be type parameters');
+    }
+  }
+
+  /**
+   * @param {TypeParameter} tree
+   */
+  visitTypeParameter(tree) {
+    this.check_(tree.identifierToken.type === IDENTIFIER, tree,
+                'Type parameter must be an identifier token');
+    if (tree.extendsType) {
+      this.checkVisit_(tree.extendsType.isType(), tree.extendsType,
+                       'extends type must be a type expression');
+    }
   }
 
   /**

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -53,6 +53,14 @@
       "Array<ParseTree>"
     ]
   },
+  "ArrayType": {
+    "location": [
+      "SourceRange"
+    ],
+    "elementType": [
+      "ParseTree"
+    ]
+  },
   "ArrowFunctionExpression": {
     "location": [
       "SourceRange"
@@ -146,6 +154,20 @@
     ],
     "args": [
       "ArgumentList"
+    ]
+  },
+  "CallSignature": {
+    "location": [
+      "SourceRange"
+    ],
+    "typeParameters": [
+      "TypeParameters"
+    ],
+    "parameterList": [
+      "FormalParameterList"
+    ],
+    "returnType": [
+      "ParseTree"
     ]
   },
   "CaseClause": {
@@ -250,6 +272,34 @@
       "ParseTree"
     ],
     "right": [
+      "ParseTree"
+    ]
+  },
+  "ConstructSignature": {
+    "location": [
+      "SourceRange"
+    ],
+    "typeParameters": [
+      "TypeParameters"
+    ],
+    "parameterList": [
+      "FormalParameterList"
+    ],
+    "returnType": [
+      "ParseTree"
+    ]
+  },
+  "ConstructorType": {
+    "location": [
+      "SourceRange"
+    ],
+    "typeParameters": [
+      "TypeParameters"
+    ],
+    "parameterList": [
+      "FormalParameterList"
+    ],
+    "returnType": [
       "ParseTree"
     ]
   },
@@ -498,6 +548,20 @@
       "FunctionBody"
     ]
   },
+  "FunctionType": {
+    "location": [
+      "SourceRange"
+    ],
+    "typeParameters": [
+      "TypeParameters"
+    ],
+    "parameterList": [
+      "FormalParameterList"
+    ],
+    "returnType": [
+      "ParseTree"
+    ]
+  },
   "GeneratorComprehension": {
     "location": [
       "SourceRange"
@@ -591,6 +655,20 @@
       "Array<ImportSpecifier>"
     ]
   },
+  "IndexSignature": {
+    "location": [
+      "SourceRange"
+    ],
+    "name": [
+      "IdentifierToken"
+    ],
+    "indexType": [
+      "ParseTree"
+    ],
+    "typeAnnotation": [
+      "ParseTree"
+    ]
+  },
   "LabelledStatement": {
     "location": [
       "SourceRange"
@@ -638,6 +716,20 @@
     ],
     "memberExpression": [
       "ParseTree"
+    ]
+  },
+  "MethodSignature": {
+    "location": [
+      "SourceRange"
+    ],
+    "name": [
+      "ParseTree"
+    ],
+    "optional": [
+      "boolean"
+    ],
+    "callSignature": [
+      "CallSignature"
     ]
   },
   "Module": {
@@ -717,6 +809,14 @@
     ],
     "element": [
       "ParseTree"
+    ]
+  },
+  "ObjectType": {
+    "location": [
+      "SourceRange"
+    ],
+    "typeMembers": [
+      "Array<ParseTree>"
     ]
   },
   "ParenExpression": {
@@ -819,12 +919,29 @@
       "Array<ParseTree>"
     ]
   },
+  "PropertySignature": {
+    "location": [
+      "SourceRange"
+    ],
+    "name": [
+      "ParseTree"
+    ],
+    "optional": [
+      "boolean"
+    ],
+    "typeAnnotation": [
+      "ParseTree"
+    ]
+  },
   "RestParameter": {
     "location": [
       "SourceRange"
     ],
     "identifier": [
       "BindingIdentifier"
+    ],
+    "typeAnnotation": [
+      "ParseTree"
     ]
   },
   "ReturnStatement": {
@@ -969,6 +1086,25 @@
     ],
     "name": [
       "IdentifierToken"
+    ]
+  },
+  "TypeParameter": {
+    "location": [
+      "SourceRange"
+    ],
+    "identifierToken": [
+      "IdentifierToken"
+    ],
+    "extendsType": [
+      "ParseTree"
+    ]
+  },
+  "TypeParameters": {
+    "location": [
+      "SourceRange"
+    ],
+    "parameters": [
+      "Array<TypeParameter>"
     ]
   },
   "TypeReference": {

--- a/test/feature/Types/Error_FunctionType.js
+++ b/test/feature/Types/Error_FunctionType.js
@@ -1,0 +1,7 @@
+// Options: --types
+// Error: :6:3: unresolved is not defined
+
+(function() {
+  var f: (unresolved: number) => string
+  unresolved;
+});

--- a/test/feature/Types/TypeSyntax.js
+++ b/test/feature/Types/TypeSyntax.js
@@ -1,22 +1,37 @@
 // Options: --types
 
-var a : any;
-var b : boolean;
-var s : string;
-var v : void;
-var n : number;
+var a: any;
+var b: boolean;
+var s: string;
+var v: void;
+var n: number;
 
-var named : namespace.type;
+var named: namespace.type;
 
 class Test {}
 
-function abc(x : Test) : Test {
-  var a : Test = new Test();
+function abc(x: Test): Test {
+  var a: Test = new Test();
 }
 
-function xyz({x, y} : Test) {}
+function xyz({x, y}: Test) {}
 
-var x = function (a : Test) : Test {}
+var x = function (a: Test): Test {}
 
-var arr : Array<number>;
-var map : Map<number, boolean>;
+var arr: Array<number>;
+var map: Map<number, boolean>;
+
+var f: <T, V extends T>(x: T, y: string = 'str', ...rest: Array<V>) => void;
+var C: new <T, V extends T>(x: T, y: string = 'str', ...rest: Array<V>) => void;
+
+var arr2 : number[]
+[0, 1];
+
+var o : {};
+var o2 : {x; y?; z: number; w?: string};
+var o3 : {x(); y?(); z(): number; w?(): string; m<T>(x: T): T};
+var o4 : {new ();};
+var o5 : {new <T>(x: T) : T;};
+
+var i1 : {[x: number] : T; y};
+var i2 : {[x: string] : V; y()};


### PR DESCRIPTION
This adds support for
- ArrayType
- CallSignature
- CosntructSignature
- ConstructorType
- FunctionType
- IndexSignature
- MethodSignature
- ObjectType
- PropertySignature
- TypeParameter

The only remaining type syntax left from TS 1.0 is the TypeQuery type
expression. (Interfaces and declare as well).

This does not yet add runtime asserts for any of these.
