### PR TITLE
Split System.register into .register() and .registerModule().

### DIFF
--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -127,7 +127,7 @@ export class ModuleTransformer extends TempVarTransformer {
               ${functionExpression});`;
     }
     return parseStatements
-        `System.register(${this.moduleName}, [], ${functionExpression});`;
+        `System.registerModule(${this.moduleName}, [], ${functionExpression});`;
   }
 
   /**

--- a/src/runtime/ModuleStore.js
+++ b/src/runtime/ModuleStore.js
@@ -184,7 +184,7 @@
 
     // -- Non standard extensions to ModuleStore.
 
-    registerModule(name, func) {
+    registerModule(name, deps, func) {
       var normalizedName = ModuleStore.normalize(name);
       if (moduleInstantiators[normalizedName])
         throw new Error('duplicate module named ' + normalizedName);
@@ -197,7 +197,7 @@
     register(name, deps, func) {
       if (!deps || !deps.length && !func.length) {
         // Traceur System.register
-        this.registerModule(name, func);
+        this.registerModule(name, deps, func);
       } else {
         // System.register instantiate form
         this.bundleStore[name] = {
@@ -259,6 +259,7 @@
 
   global.System = {
     register: ModuleStore.register.bind(ModuleStore),
+    registerModule: ModuleStore.registerModule.bind(ModuleStore),
     get: ModuleStore.get,
     set: ModuleStore.set,
     normalize: ModuleStore.normalize,

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -276,12 +276,25 @@ export class TraceurLoader extends Loader {
   }
 
   /**
+   * Used for 'instantiate' module format.
    * @param {string} normalized name of module
    * @param {Array<string>} unnormalized dependency names.
    * @param {Function<Array<string>>} factory takes array of normalized names.
    */
   register(normalizedName, deps, factoryFunction) {
-    $traceurRuntime.ModuleStore.register(normalizedName, deps, factoryFunction);
+    $traceurRuntime.ModuleStore.register(normalizedName, deps,
+      factoryFunction);
+  }
+
+  /**
+   * Used for 'regsiter' module format.
+   * @param {string} normalized name of module
+   * @param {Array<string>} unnormalized dependency names.
+   * @param {Function<Array<string>>} factory takes array of normalized names.
+   */
+  registerModule(normalizedName, deps, factoryFunction) {
+    $traceurRuntime.ModuleStore.registerModule(normalizedName, deps,
+      factoryFunction);
   }
 
 }

--- a/test/unit/node/api.js
+++ b/test/unit/node/api.js
@@ -46,8 +46,8 @@ suite('api.js', function() {
     var api = require('../../../src/node/api');
     var options = {modules: 'register', experimental: true, moduleName: true};
     var result = api.compile('var a = 1;', options, 'a.js');
-    assert.equal(result.indexOf('System.register("a.js", [], function() {'), 0,
-        'The module has register format and name "a.js"');
+    assert.equal(result.indexOf('System.registerModule("a.js", [], function() {'), 0,
+        'The module has register format and name "a"');
   });
 
   test('api compile inline', function() {


### PR DESCRIPTION
'instantiate' -> .register()
'register' -> .registerModule()
This allows the two formats to evolve independently.

Add `require` argument in prep for sending relativeRequire via function arguments.
