### PR TITLE
Fix FindVisitor to not start the visiting in the constructor

### DIFF
--- a/src/codegeneration/BlockBindingTransformer.js
+++ b/src/codegeneration/BlockBindingTransformer.js
@@ -518,6 +518,7 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
     // We only create an "iife" if the loop has block bindings and functions
     // that use those block binded variables
     var finder = new FindBlockBindingInLoop(tree, this.scopeBuilder_);
+    finder.visitAny(tree);
     if (!finder.found) {
       // just switch it to var
       if (initializerIsBlockBinding) {
@@ -682,6 +683,7 @@ function renameAll(renames, tree) {
 class FindBlockBindingInLoop extends FindVisitor {
 
   constructor(tree, scopeBuilder) {
+    super();
     this.scopeBuilder_ = scopeBuilder;
     // Not all Loop Statements have a scope, but all their block bodies should.
     // Example: a For Loop with no initializer, or one that uses 'var' doesn't
@@ -692,7 +694,6 @@ class FindBlockBindingInLoop extends FindVisitor {
         scopeBuilder.getScopeForTree(tree.body);
     this.outOfScope_ = null;
     this.acceptLoop_ = tree.isIterationStatement();
-    super(tree, false);
   }
 
   visitForInStatement(tree) {

--- a/src/codegeneration/FindVisitor.js
+++ b/src/codegeneration/FindVisitor.js
@@ -22,15 +22,13 @@ import {ParseTreeVisitor} from '../syntax/ParseTreeVisitor.js';
  */
 export class FindVisitor extends ParseTreeVisitor {
   /**
-   * @param {ParseTree} tree
    * @param {boolean=} keepOnGoing Whether to stop searching after the first
    *     found condition.
    */
-  constructor(tree, keepOnGoing = undefined) {
+  constructor(keepOnGoing = undefined) {
     this.found_ = false;
     this.shouldContinue_ = true;
     this.keepOnGoing_ = keepOnGoing;
-    this.visitAny(tree);
   }
 
   /**

--- a/src/codegeneration/GeneratorTransformPass.js
+++ b/src/codegeneration/GeneratorTransformPass.js
@@ -134,7 +134,8 @@ export class GeneratorTransformPass extends TempVarTransformer {
 
     // We need to transform for-in loops because the object key iteration
     // cannot be interrupted.
-    var finder = new ForInFinder(body);
+    var finder = new ForInFinder();
+    finder.visitAny(body);
     if (finder.found) {
       body = new ForInTransformPass(this.identifierGenerator).
           transformAny(body);

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -45,12 +45,9 @@ import {transformOptions} from '../Options.js';
  * computed property name, an at name or a __proto__ property.
  */
 class FindAdvancedProperty extends FindVisitor {
-  /**
-   * @param {ObjectLiteralTree} tree
-   */
-  constructor(tree) {
+  constructor() {
+    super(true);
     this.protoExpression = null;
-    super(tree, true);
   }
 
   visitPropertyNameAssignment(tree) {
@@ -185,7 +182,8 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
     var oldSeenAccessors = this.seenAccessors;
 
     try {
-      var finder = new FindAdvancedProperty(tree);
+      var finder = new FindAdvancedProperty();
+      finder.visitAny(tree);
       if (!finder.found) {
         this.needsAdvancedTransform = false;
         return super.transformObjectLiteralExpression(tree);

--- a/src/codegeneration/alphaRenameThisAndArguments.js
+++ b/src/codegeneration/alphaRenameThisAndArguments.js
@@ -24,10 +24,10 @@ import {FindInFunctionScope} from './FindInFunctionScope.js';
  * 'arguments'.
  */
 class FindThisOrArguments extends FindInFunctionScope {
-  constructor(tree) {
+  constructor() {
+    super();
     this.foundThis = false;
     this.foundArguments = false;
-    super(tree);
   }
   visitThisExpression(tree) {
     this.foundThis = true;
@@ -42,7 +42,8 @@ class FindThisOrArguments extends FindInFunctionScope {
 }
 
 export default function alphaRenameThisAndArguments(tempVarTransformer, tree) {
-  var finder = new FindThisOrArguments(tree);
+  var finder = new FindThisOrArguments();
+  finder.visitAny(tree);
   if (finder.foundArguments) {
     var argumentsTempName = tempVarTransformer.addTempVarForArguments();
     tree = AlphaRenamer.rename(tree, ARGUMENTS, argumentsTempName);

--- a/src/codegeneration/generator/AsyncTransformer.js
+++ b/src/codegeneration/generator/AsyncTransformer.js
@@ -52,7 +52,9 @@ class AwaitFinder extends FindInFunctionScope {
 }
 
 function scopeContainsAwait(tree) {
-  return new AwaitFinder(tree).found;
+  var visitor = new AwaitFinder();
+  visitor.visitAny(tree);
+  return visitor.found;
 }
 
 /**

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -90,7 +90,8 @@ class NeedsStateMachine extends FindInFunctionScope {
 }
 
 function needsStateMachine(tree) {
-  var visitor = new NeedsStateMachine(tree);
+  var visitor = new NeedsStateMachine();
+  visitor.visitAny(tree);
   return visitor.found;
 }
 

--- a/src/codegeneration/generator/GeneratorTransformer.js
+++ b/src/codegeneration/generator/GeneratorTransformer.js
@@ -53,7 +53,9 @@ class YieldFinder extends FindInFunctionScope {
 }
 
 function scopeContainsYield(tree) {
-  return new YieldFinder(tree).found;
+  var finder = new YieldFinder();
+  finder.visitAny(tree);
+  return finder.found;
 }
 
 /**

--- a/src/codegeneration/scopeContainsThis.js
+++ b/src/codegeneration/scopeContainsThis.js
@@ -21,7 +21,8 @@ class FindThis extends FindInFunctionScope {
 }
 
 function scopeContainsThis(tree) {
-  var visitor = new FindThis(tree);
+  var visitor = new FindThis();
+  visitor.visitAny(tree);
   return visitor.found;
 }
 

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -290,9 +290,9 @@ var Initializer = {
  * the tree is not going to be used as a pattern.
  */
 class ValidateObjectLiteral extends FindVisitor {
-  constructor(tree) {
+  constructor() {
+    super();
     this.errorToken = null;
-    super(tree);
   }
 
   visitCoverInitializedName(tree) {
@@ -3180,7 +3180,8 @@ export class Parser {
     if (coverInitializedNameCount === this.coverInitializedNameCount_)
       return;
 
-    var finder = new ValidateObjectLiteral(tree);
+    var finder = new ValidateObjectLiteral();
+    finder.visitAny(tree);
     if (finder.found) {
       var token = finder.errorToken;
       this.reportError_(token.location, `Unexpected token ${token}`);

--- a/test/verify-compat.js
+++ b/test/verify-compat.js
@@ -15,7 +15,6 @@
 // Run's test from https://github.com/kangax/compat-table
 
 import {Compiler} from '../src/Compiler.js';
-import {FindVisitor} from '../src/codegeneration/FindVisitor.js';
 import {IDENTIFIER_EXPRESSION} from '../src/syntax/trees/ParseTreeType.js';
 
 Reflect.global.exports = {};


### PR DESCRIPTION
We used to call visitAny in the constructor, which lead to bad
API where we had to set things on this before calling super.
