### PR TITLE
Promise.all(iterable)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Liubomyr Mykhalchenko <liubko.qwert@gmail.com>
 Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
 Victor Berchet <victor@suumit.com>
 Paul Selden <pselden4@gmail.com>
+Oliver Joseph Ash <oliverjash@gmail.com>

--- a/test/feature/PromiseAll.js
+++ b/test/feature/PromiseAll.js
@@ -1,0 +1,13 @@
+// Async.
+
+function* gen() {
+  yield 1;
+  yield 2;
+}
+
+var p2 = Promise.all(gen());
+
+p2.then((v) => {
+  assert.deepEqual(v, [1,2]);
+  done();
+});


### PR DESCRIPTION
`Promise.all` (and possibly other static methods) should allow you to pass an iterable, apparently: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all

``` js
const iterable = {
  *[Symbol.iterator]() {
    yield 1;
    yield 2;
    yield 3;
  }
};

Promise.all(iterable)
    .then(x => {
        console.log(x);
    });
```

Is this something that could be added to the polyfill? I might have a go, if so.
