### PR TITLE
feat(runtime): add memoization to genericType()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ TFLAGS = --
 RUNTIME_TESTS = \
   test/unit/runtime/Loader.js \
   test/unit/runtime/Object.js \
-  test/unit/runtime/System.js
+  test/unit/runtime/System.js \
+  test/unit/runtime/type-assertions.js
 
 UNIT_TESTS = \
 	test/unit/util/ \

--- a/src/runtime/type-assertions.js
+++ b/src/runtime/type-assertions.js
@@ -32,8 +32,42 @@
     }
   }
 
+  var typeRegister = Object.create(null);
+
+  /**
+   * Returns an instance of {@code GenericType}.
+   *
+   * A same instance is returned across calls given the same
+   * {@code type} and {@code argumentTypes}.
+   *
+   * @param type
+   * @param argumentTypes
+   * @returns {GenericType}
+   */
   function genericType(type, ...argumentTypes) {
-    return new GenericType(type, argumentTypes);
+    var typeMap = typeRegister;
+
+    var key = $traceurRuntime.getOwnHashObject(type).hash;
+    if (!typeMap[key]) {
+      typeMap[key] = Object.create(null);
+    }
+    typeMap = typeMap[key];
+
+    for (var i = 0; i < argumentTypes.length - 1; i++) {
+      key = $traceurRuntime.getOwnHashObject(argumentTypes[i]).hash;
+      if (!typeMap[key]) {
+        typeMap[key] = Object.create(null);
+      }
+      typeMap = typeMap[key];
+    }
+
+    var tail = argumentTypes[argumentTypes.length - 1];
+    key = $traceurRuntime.getOwnHashObject(tail).hash;
+    if (!typeMap[key]) {
+      typeMap[key] = new GenericType(type, argumentTypes);
+    }
+
+    return typeMap[key];
   }
 
   $traceurRuntime.GenericType = GenericType;

--- a/test/runner.html
+++ b/test/runner.html
@@ -17,6 +17,7 @@ mocha.setup({ui: 'tdd'});
 <script src="unit/codegeneration/low_level_tests.js"></script>
 <script src="unit/codegeneration/writer.js"></script>
 <script src="unit/runtime/Loader.js"></script>
+<script src="unit/runtime/type-assertions.js"></script>
 <script src="unit/semantics/VariableBinder.js"></script>
 <script src="unit/syntax/LineNumbers.js"></script>
 <script src="unit/syntax/ParseTreeValidator.js"></script>

--- a/test/unit/runtime/type-assertions.js
+++ b/test/unit/runtime/type-assertions.js
@@ -1,0 +1,29 @@
+// Copyright 2014 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+suite('type-assertions.js', function() {
+  function Foo() {};
+  function Bar() {};
+  function Baz() {};
+
+  test('genericType returns unique instances if types match', function() {
+    assert.strictEqual($traceurRuntime.genericType(Foo, Bar, Baz),
+                       $traceurRuntime.genericType(Foo, Bar, Baz));
+  });
+
+  test('genericType returns different instances if types don\'t match', function() {
+    assert.notStrictEqual($traceurRuntime.genericType(Foo, Bar, Baz),
+                          $traceurRuntime.genericType(Foo, Baz, Bar));
+  });
+});


### PR DESCRIPTION
This is an initial implementation (lacking unit tests).

The rationale is that we need `genericType(Foo, Bar) === genericType(Foo, Bar)` for the Dependency injection in Angular.

Before this PR it was not possible to detect when two generic types match (as they are not ===).
