### PR TITLE
Add support for type parameters for classes

### DIFF
--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -139,7 +139,7 @@ class AnnotationsScope {
 
     if (tree.annotations.length > 0) {
       tree = new ClassDeclaration(tree.location, tree.name,
-          tree.superClass, tree.elements, []);
+          tree.superClass, tree.elements, [], null);
     }
     return this.appendMetadata_(tree);
   }

--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -74,7 +74,8 @@ class DeclarationExtractionTransformer extends HoistVariablesTransformer {
     this.addVariable(tree.name.identifierToken.value);
 
     // Convert a class declaration into a class expression.
-    tree = new ClassExpression(tree.location, tree.name, tree.superClass, tree.elements, tree.annotations);
+    tree = new ClassExpression(tree.location, tree.name, tree.superClass,
+        tree.elements, tree.annotations, tree.typeParameters);
 
     return parseStatement `${tree.name.identifierToken} = ${tree}`;
   }
@@ -333,12 +334,12 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
               $__export(p, m[p]);
           });
         `);
-        
+
         var exportNames = {};
         this.localExportBindings.concat(this.externalExportBindings).forEach(function(binding) {
           exportNames[binding.exportName] = true;
         });
-        
+
         declarationStatements.push(parseStatement `
           var $__exportNames = ${createObjectLiteral(exportNames)};
         `);
@@ -484,10 +485,12 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
     var superClass = this.transformAny(tree.superClass);
     var elements = this.transformList(tree.elements);
     var annotations = this.transformList(tree.annotations);
+    var typeParameters = this.transformAny(tree.typeParameters);
 
     var varName = name.identifierToken.value;
     // convert into class expression
-    var classExpression = new ClassExpression(tree.location, name, superClass, elements, annotations);
+    var classExpression = new ClassExpression(tree.location, name, superClass,
+        elements, annotations, typeParameters);
     this.addLocalExportBinding(varName);
     return parseStatement `var ${varName} = $__export(${varName}, ${classExpression});`;
   }
@@ -588,8 +591,9 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
 
     // convert class into a class expression
     if (expression.type === CLASS_DECLARATION) {
-      expression = new ClassExpression(expression.location, expression.name, 
-          expression.superClass, expression.elements, expression.annotations);
+      expression = new ClassExpression(expression.location, expression.name,
+          expression.superClass, expression.elements, expression.annotations,
+          expression.typeParameters);
     }
 
     if (expression.type === FUNCTION_DECLARATION) {

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -387,6 +387,9 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     this.write_(CLASS);
     this.writeSpace_();
     this.visitAny(tree.name);
+    if (tree.typeParameters !== null) {
+      this.visitAny(tree.typeParameters);
+    }
     if (tree.superClass !== null) {
       this.writeSpace_();
       this.write_(EXTENDS);

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -97,6 +97,7 @@ import {
   TYPE_ARGUMENTS,
   TYPE_NAME,
   TYPE_PARAMETER,
+  TYPE_PARAMETERS,
   VARIABLE_DECLARATION_LIST,
   VARIABLE_STATEMENT
 } from './trees/ParseTreeType.js';
@@ -375,6 +376,23 @@ export class ParseTreeValidator extends ParseTreeVisitor {
    * @param {ClassDeclaration} tree
    */
   visitClassDeclaration(tree) {
+    this.visitClassShared_(tree);
+  }
+
+  /**
+   * @param {ClassExpression} tree
+   */
+  visitClassExpression(tree) {
+    this.visitClassShared_(tree);
+  }
+
+  visitClassShared_(tree) {
+    if (tree.typeParameters) {
+      this.checkVisit_(
+          tree.typeParameters.type == TYPE_PARAMETERS,
+          tree.typeParameters,
+          'type parameters expected');
+    }
     for (var i = 0; i < tree.elements.length; i++) {
       var element = tree.elements[i];
       switch (element.type) {
@@ -389,6 +407,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
       this.visitAny(element);
     }
   }
+
 
   /**
    * @param {CommaExpression} tree

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -754,11 +754,15 @@ export class Parser {
     this.strictMode_ = true;
     this.eat_(CLASS);
     var name = null;
+    var typeParameters = null;
     var annotations = [];
     // Name is optional for ClassExpression
     if (constr == ClassDeclaration ||
         !this.peek_(EXTENDS) && !this.peek_(OPEN_CURLY)) {
       name = this.parseBindingIdentifier_();
+      if (this.options_.types) {
+        typeParameters = this.parseTypeParametersOpt_();
+      }
       annotations = this.popAnnotations_();
     }
     var superClass = null;
@@ -770,7 +774,7 @@ export class Parser {
     this.eat_(CLOSE_CURLY);
     this.strictMode_ = strictMode;
     return new constr(this.getTreeLocation_(start), name, superClass,
-                      elements, annotations);
+                      elements, annotations, typeParameters);
   }
 
   /**
@@ -4095,7 +4099,7 @@ export class Parser {
     var start = this.getTreeStartLocation_();
     this.eat_(INTERFACE);
     var name = this.eatId_();
-    var typeParameters = this.parseTypeParametersOpt_()
+    var typeParameters = this.parseTypeParametersOpt_();
     var extendsClause;
     if (this.eatIf_(EXTENDS)) {
       extendsClause = this.parseInterfaceExtendsClause_();

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -207,6 +207,9 @@
     ],
     "annotations": [
       "Array<ParseTree>"
+    ],
+    "typeParameters": [
+      "TypeParameters"
     ]
   },
   "ClassExpression": {
@@ -224,6 +227,9 @@
     ],
     "annotations": [
       "Array<ParseTree>"
+    ],
+    "typeParameters": [
+      "TypeParameters"
     ]
   },
   "CommaExpression": {

--- a/test/feature/Classes/Types.js
+++ b/test/feature/Classes/Types.js
@@ -1,6 +1,6 @@
 // Options: --types
 
-class Typed {
+class Typed<T> {
   constructor(x : number) {
     this.x_ = x;
   }
@@ -18,6 +18,9 @@ class Typed {
     this.x_ = x;
   }
 }
+
+// Generics, ClassExpression
+var C = class ClassExpression<T> {};
 
 assert.equal(1, new Typed(1).x);
 assert.equal(2, new Typed(1).addTo(1));


### PR DESCRIPTION
Allow type parameters for class, ie `class Foo<Bar, Baz>`

/cc @vojtajina 
