### PR TITLE
Rename argument to avoid bug in Safari 5.1.

### DIFF
--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -83,11 +83,11 @@ class CodeUnit {
     return this.state_;
   }
 
-  set state(state) {
-    if (state < this.state_) {
+  set state(value) {
+    if (value < this.state_) {
       throw new Error('Invalid state change');
     }
-    this.state_ = state;
+    this.state_ = value;
   }
 
   /**


### PR DESCRIPTION
Argument 'state' in 'set state' cause Safari 5.1 to throw erroneous error

Fixes #1535
