### PR TITLE
Add patterns support for file names when compiling with --out

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Liubomyr Mykhalchenko <liubko.qwert@gmail.com>
 Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
 Victor Berchet <victor@suumit.com>
 Paul Selden <pselden4@gmail.com>
+Maga D. Zandaqo <denelxan@gmail.com>


### PR DESCRIPTION
Hi guys,

I would like for the compiler to support shell patterns in sources' file names when compiling with --out option. Currently we can either use module names or file names/full paths while listing sources for compilation. That is, for example, we are currently doing this:

`traceur --out compiled.js module1.es6.js module2.es6.js module3.es6.js`

with patterns we can do it like this:

`traceur --out compiled.js *.es6.js`

or use any other pattern that glob library supports. 

This patch doesn't add much in terms of complexity and since the glob library is already used in the project, we also don't need any new dependencies. It shouldn't cause problems with backwards compatibility because it only affects file names that use glob's special symbols (*, ?, [, ], etc) which are not normally used in file/module names.
