### PR TITLE
Support glob patterns in file names while compiling with --out

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,3 +44,4 @@ Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
 Victor Berchet <victor@suumit.com>
 Paul Selden <pselden4@gmail.com>
 Steven Vachon <contact@svachon.com>
+Maga D. Zandaqo <denelxan@gmail.com>

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -360,5 +360,52 @@ suite('context test', function() {
       assert.equal(depContents + '', "\"use strict\";\nObject.defineProperties(exports, {\n  q: {get: function() {\n      return q;\n    }},\n  __esModule: {value: true}\n});\nvar q = 'q';\n");
       done();
     });
-  })
+  });
+
+  test('use a pattern that does not match any source', function(done) {
+    tempFileName = resolve(uuid.v4() + '.js');
+    var executable = 'node ' + resolve('src/node/command.js');
+    var inputFileName = './unit/node/resources/*someNonExistentPattern';
+
+    exec(executable + ' --out ' + tempFileName + ' ' + inputFileName,
+      function(error, stdout, stderr) {
+        assert.isNull(error);
+        done();
+      });
+  });
+
+  test('use a pattern to match sources for compilation', function(done) {
+    tempFileName = resolve(uuid.v4() + '.js');
+    var executable = 'node ' + resolve('src/node/command.js');
+    var inputFileName = './unit/node/resources/glob-pattern-?.js';
+
+    exec(executable + ' --out ' + tempFileName + ' ' + inputFileName,
+      function(error, stdout, stderr) {
+        assert.isNull(error);
+        executeFileWithRuntime(tempFileName).then(function() {
+          assert.equal(global.someResult, 42);
+          assert.equal(global.anotherResult, 17);
+          done();
+        }).catch(done);
+      });
+  });
+
+  test('use a pattern and a normal file name to match sources', function(done) {
+    tempFileName = resolve(uuid.v4() + '.js');
+    var executable = 'node ' + resolve('src/node/command.js');
+    var inputFileName = './unit/node/resources/glob-pattern-?.js';
+    var inputAnotherFile = './unit/node/resources/glob-normal.js';
+
+    exec(executable + ' --out ' + tempFileName + ' --modules=inline ' + inputFileName + ' --script ' + inputAnotherFile,
+      function(error, stdout, stderr) {
+        assert.isNull(error);
+        executeFileWithRuntime(tempFileName).then(function() {
+          assert.equal(global.someResult, 42);
+          assert.equal(global.anotherResult, 17);
+          assert.equal(global.normalResult, true);
+          done();
+        }).catch(done);
+      });
+  });
+
 });

--- a/test/unit/node/resources/glob-normal.js
+++ b/test/unit/node/resources/glob-normal.js
@@ -1,0 +1,1 @@
+this.normalResult = true;

--- a/test/unit/node/resources/glob-pattern-a.js
+++ b/test/unit/node/resources/glob-pattern-a.js
@@ -1,0 +1,1 @@
+this.anotherResult = 17;

--- a/test/unit/node/resources/glob-pattern-b.js
+++ b/test/unit/node/resources/glob-pattern-b.js
@@ -1,0 +1,1 @@
+this.someResult = 42;


### PR DESCRIPTION
Hi guys,

I would like for the compiler to support shell patterns in sources' file names when compiling with --out option. Currently we can either use module names or file names/full paths while listing sources for compilation. That is, for example, we are currently doing this:

`traceur --out compiled.js module1.es6.js module2.es6.js module3.es6.js`

with patterns we can do it like this:

`traceur --out compiled.js *.es6.js`

or use any other pattern that glob library supports.

This patch doesn't add much in terms of complexity and since the glob library is already used in the project, we also don't need any new dependencies. It shouldn't cause problems with backwards compatibility because it only affects file names that use glob's special symbols (*, ?, [, ], etc) which are not normally used in file/module names.
