### PR TITLE
Add support for goog.module (Closure) based imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ UNIT_TESTS = \
 TESTS = \
 	test/node-commonjs-test.js \
 	test/node-amd-test.js \
+	test/node-closure-test.js \
 	test/node-instantiate-test.js \
 	test/node-feature-test.js \
 	test/node-api-test.js \
@@ -112,6 +113,9 @@ test/commonjs: test/commonjs-compiled
 
 test/amd: test/amd-compiled
 	node_modules/.bin/mocha $(MOCHA_OPTIONS) test/node-amd-test.js
+
+test/closure:
+	node_modules/.bin/mocha $(MOCHA_OPTIONS) test/node-closure-test.js
 
 test/features: bin/traceur.js bin/traceur-runtime.js test/test-list.js
 	node_modules/.bin/mocha $(MOCHA_OPTIONS) $(MOCHAX) test/node-feature-test.js

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -106,6 +106,20 @@ export class Compiler {
     return merge(amdOptions, options);
   }
   /**
+   * Options to create 'goog'/Closure module format.
+   *
+   * @param  {Object=} options Traceur options to override defaults.
+   * @return {Object}
+   */
+  static closureOptions(options = {}) {
+    var closureOptions = {
+      modules: 'closure',
+      sourceMaps: false,
+      moduleName: true
+    };
+    return merge(closureOptions, options);
+  }
+  /**
    * Options to create 'commonjs' module format.
    *
    * @param  {Object=} options Traceur options to override defaults.
@@ -175,12 +189,23 @@ export class Compiler {
   /**
    * Apply transformations selected by options to tree.
    * @param {ParseTree} tree
-   * @param {string} moduleName Value for __moduleName or true
-   *     to use input filename.
+   * @param {string} moduleName value for __moduleName if any
+   * @param {string} sourceName used as the moduleName if defined and requested
+   *     by the module system configuration.
    * @return {ParseTree}
    */
-  transform(tree, moduleName = undefined) {
+  transform(tree, moduleName = undefined, sourceName = undefined) {
     var transformer;
+
+    if (!moduleName && this.options_.moduleName) {
+      // this.options_.moduleName is true or non-empty string.
+      if (typeof this.options_.moduleName === 'string') {
+        moduleName = this.options_.moduleName;
+      } else {
+        // use filename as moduleName
+        moduleName = sourceName;
+      }
+    }
 
     if (moduleName) {
       var transformer = new AttachModuleNameTransformer(moduleName);

--- a/src/Options.js
+++ b/src/Options.js
@@ -85,7 +85,7 @@ export var transformOptions = Object.create(null);
 
 var defaultValues = Object.create(null);
 var experimentalOptions = Object.create(null);
-var moduleOptions = ['amd', 'commonjs', 'instantiate', 'inline', 'register'];
+var moduleOptions = ['amd', 'commonjs', 'closure', 'instantiate', 'inline', 'register'];
 
 export class Options {
 

--- a/src/codegeneration/ClosureModuleTransformer.js
+++ b/src/codegeneration/ClosureModuleTransformer.js
@@ -1,0 +1,92 @@
+// Copyright 2014 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ModuleTransformer} from './ModuleTransformer.js';
+
+import {
+  createIdentifierExpression,
+  createMemberExpression,
+  createPropertyNameAssignment
+} from './ParseTreeFactory.js';
+
+import {
+  EXPORT_DEFAULT,
+  EXPORT_SPECIFIER
+} from '../syntax/trees/ParseTreeType.js';
+
+import {
+  parseExpression,
+  parseStatement,
+  parseStatements
+} from './PlaceholderParser.js';
+
+import {prependStatements} from './PrependStatements.js';
+
+export class ClosureModuleTransformer extends ModuleTransformer {
+
+  moduleProlog() {
+    // 'use strict'; and module name are implied by the goog.module call.
+    if (!this.moduleName) {
+      throw new Error('Closure modules (goog.module) require a moduleName');
+    }
+    return parseStatements `goog.module(${this.moduleName});`
+  }
+
+  wrapModule(statements) {
+    // Ensure that the module contains no "export *" statements.
+    if (this.hasStarExports()) {
+      throw new Error('Closure modules (goog.module) do not support "export *"');
+    }
+    // goog.module requires no wrapping, scoping semantics are handled by the
+    // module loader at runtime (through evaluation in a function scope).
+    return statements;
+  }
+
+  appendExportStatement(statements) {
+    if (!this.hasExports()) return statements;
+    var exportObject = this.getExportObject();
+    statements.push(parseStatement `exports = ${exportObject}`);
+    return statements;
+  }
+
+  getGetterExport({name, tree, moduleSpecifier}) {
+    // goog.module does not support getters in exports, so all exports are
+    // simple assignments into the exports object.
+    var expression;
+    switch (tree.type) {
+      case EXPORT_DEFAULT:
+        expression = createIdentifierExpression('$__default');
+        break;
+
+      case EXPORT_SPECIFIER:
+        if (moduleSpecifier) {
+          var idName = this.getTempVarNameForModuleSpecifier(moduleSpecifier);
+          expression = createMemberExpression(idName, tree.lhs);
+        } else {
+          expression = createPropertyNameAssignment(name, tree.lhs)
+        }
+        break;
+
+      default:
+        expression = createIdentifierExpression(name);
+        break;
+    }
+    return createPropertyNameAssignment(name, expression);
+  }
+
+  transformModuleSpecifier(tree) {
+    var moduleName = tree.token.processedValue;
+    return parseExpression `goog.require(${moduleName})`;
+  }
+}

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -19,6 +19,7 @@ import {ArrowFunctionTransformer} from './ArrowFunctionTransformer.js';
 import {BlockBindingTransformer} from './BlockBindingTransformer.js';
 import {ClassTransformer} from './ClassTransformer.js';
 import {CommonJsModuleTransformer} from './CommonJsModuleTransformer.js';
+import {ClosureModuleTransformer} from './ClosureModuleTransformer.js';
 import {ExponentiationTransformer} from './ExponentiationTransformer.js';
 import {validate as validateConst} from '../semantics/ConstChecker.js';
 import {DefaultParametersTransformer} from './DefaultParametersTransformer.js';
@@ -126,6 +127,9 @@ export class FromOptionsTransformer extends MultiTransformer {
           break;
         case 'amd':
           append(AmdTransformer);
+          break;
+        case 'closure':
+          append(ClosureModuleTransformer);
           break;
         case 'inline':
           append(InlineModuleTransformer);

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -204,6 +204,13 @@ export class ModuleTransformer extends TempVarTransformer {
     return this.exportVisitor_.hasExports();
   }
 
+  /**
+   * @return {boolean}
+   */
+  hasStarExports() {
+    return this.exportVisitor_.starExports.length > 0;
+  }
+
   transformExportDeclaration(tree) {
     this.exportVisitor_.visitAny(tree);
     return this.transformAny(tree.declaration);

--- a/src/node/NodeCompiler.js
+++ b/src/node/NodeCompiler.js
@@ -30,7 +30,6 @@ var Compiler = traceur.Compiler;
 function NodeCompiler(options, sourceRoot) {
   sourceRoot = sourceRoot || process.cwd();
   Compiler.call(this, options, sourceRoot);
-  this.moduleName = options.moduleName;
 }
 
 NodeCompiler.prototype = {
@@ -58,14 +57,9 @@ NodeCompiler.prototype = {
         return;
       }
 
-      var moduleName = null;
-      if (typeof this.moduleName === 'string') {
-        moduleName = this.moduleName;
-      } else if (this.moduleName) {
-        moduleName = inputFilePath;
-      }
       var parsed = this.parse(contents.toString(), inputFilePath);
-      this.writeTreeToFile(this.transform(parsed, moduleName), outputFilePath);
+      this.writeTreeToFile(this.transform(parsed, undefined, inputFilePath),
+                           outputFilePath);
     }.bind(this));
   },
 

--- a/src/node/api.js
+++ b/src/node/api.js
@@ -54,5 +54,6 @@ module.exports = {
   compile: compile,
   commonJSOptions: Compiler.commonJSOptions,
   amdOptions: Compiler.amdOptions,
+  closureOptions: Compiler.closureOptions,
   RUNTIME_PATH: RUNTIME_PATH
 };

--- a/src/node/to-closure-compiler.js
+++ b/src/node/to-closure-compiler.js
@@ -1,0 +1,28 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var traceurAPI = require('./api.js');
+
+if (process.argv.length < 4) {
+  console.log('Not enough arguments!\n' +
+              '  Usage node src/node/to-closure-compiler.js <inputDirectory> <outputDirectory>');
+  process.exit(1);
+}
+
+var inputDir = process.argv[2];
+var outputDir = process.argv[3];
+
+traceurAPI.compileAllJsFilesInDir(inputDir, outputDir, traceurAPI.closureOptions());

--- a/test/closure/BasicImport-expected.txt
+++ b/test/closure/BasicImport-expected.txt
@@ -1,0 +1,4 @@
+goog.module("test/closure/BasicImport.js");
+var Foo = goog.require("./deps/foo").Foo;
+console.log(Foo);
+//# sourceURL=test/closure/BasicImport.js

--- a/test/closure/BasicImport.js
+++ b/test/closure/BasicImport.js
@@ -1,0 +1,3 @@
+import {Foo} from './deps/foo';
+
+console.log(Foo);

--- a/test/closure/ImportMulti-expected.txt
+++ b/test/closure/ImportMulti-expected.txt
@@ -1,0 +1,6 @@
+goog.module("test/closure/ImportMulti.js");
+var $__0 = goog.require("./deps/foo"),
+    Foo = $__0.Foo,
+    Bar = $__0.Bar;
+console.log(Foo);
+//# sourceURL=test/closure/ImportMulti.js

--- a/test/closure/ImportMulti.js
+++ b/test/closure/ImportMulti.js
@@ -1,0 +1,3 @@
+import {Foo, Bar} from './deps/foo';
+
+console.log(Foo);

--- a/test/closure/ImportStar-expected.txt
+++ b/test/closure/ImportStar-expected.txt
@@ -1,0 +1,4 @@
+goog.module("test/closure/ImportStar.js");
+var foo = goog.require("./deps/foo.js");
+console.log(foo.Foo);
+//# sourceURL=test/closure/ImportStar.js

--- a/test/closure/ImportStar.js
+++ b/test/closure/ImportStar.js
@@ -1,0 +1,3 @@
+import * as foo from './deps/foo.js';
+
+console.log(foo.Foo);

--- a/test/closure/deps/export-default-expected.txt
+++ b/test/closure/deps/export-default-expected.txt
@@ -1,0 +1,4 @@
+goog.module("test/closure/deps/export-default.js");
+var $__default = 'default from foo.js';
+exports = {default: $__default};
+//# sourceURL=test/closure/deps/export-default.js

--- a/test/closure/deps/export-default.js
+++ b/test/closure/deps/export-default.js
@@ -1,0 +1,1 @@
+export default 'default from foo.js';

--- a/test/closure/deps/export-named-expected.txt
+++ b/test/closure/deps/export-named-expected.txt
@@ -1,0 +1,4 @@
+goog.module("test/closure/deps/export-named.js");
+var $__test_47_closure_47_deps_47_foo_46_js__ = goog.require("./foo.js");
+exports = {Foo: $__test_47_closure_47_deps_47_foo_46_js__.Foo};
+//# sourceURL=test/closure/deps/export-named.js

--- a/test/closure/deps/export-named.js
+++ b/test/closure/deps/export-named.js
@@ -1,0 +1,1 @@
+export {Foo} from './foo.js';

--- a/test/closure/deps/foo-expected.txt
+++ b/test/closure/deps/foo-expected.txt
@@ -1,0 +1,4 @@
+goog.module("test/closure/deps/foo.js");
+var Foo = 'Foo from foo.js';
+exports = {Foo: Foo};
+//# sourceURL=test/closure/deps/foo.js

--- a/test/closure/deps/foo.js
+++ b/test/closure/deps/foo.js
@@ -1,0 +1,1 @@
+export var Foo = 'Foo from foo.js';

--- a/test/node-closure-test.js
+++ b/test/node-closure-test.js
@@ -1,0 +1,58 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+var fs = require('fs');
+var traceurAPI = require('../src/node/api.js');
+
+// This compares golden files in test/closure with the output after compilation
+// in the respective -expected.txt files.
+
+suite('closure', function() {
+  function collectFiles(path, result) {
+    if (!fs.statSync(path).isDirectory()) {
+      result.push(path);
+    } else {
+      fs.readdirSync(path).forEach(function(p) {
+        collectFiles(path + '/' + p, result);
+      });
+    }
+  }
+
+  var files = [];
+  collectFiles('test/closure', files);
+  var goldenFiles = files.filter(function(p) {
+    return p.endsWith('-expected.txt');
+  });
+
+  goldenFiles.forEach(function(goldenFile) {
+    var goldenText = fs.readFileSync(goldenFile, 'utf8');
+    var inputFile = goldenFile.replace(/\-expected\.txt$/, '.js');
+    var inputText = fs.readFileSync(inputFile, 'utf8');
+    var actualText =
+        traceurAPI.compile(inputText, traceurAPI.closureOptions(), inputFile);
+
+    test(goldenFile, function() {
+      assert.equal(actualText, goldenText);
+    });
+  });
+
+  test('fails for export *', function() {
+    assert.throws(
+        function() {
+          traceurAPI.compile('export * from "./foo.js";',
+                             traceurAPI.closureOptions());
+        },
+        /Closure modules.*do not support "export \*/);
+  });
+});


### PR DESCRIPTION
- option to enable Closure modules
- golden file based tests
- based on moduleName for the current file
- fails for export *

Based on @vojtajina's initial work.
