### PR TITLE
Array destructuring should use iterators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ RUNTIME_SRC = \
   src/runtime/runtime.js \
   src/runtime/relativeRequire.js \
   src/runtime/spread.js \
+  src/runtime/destructuring.js \
   src/runtime/classes.js \
   src/runtime/generators.js \
   src/runtime/url.js \

--- a/src/runtime/destructuring.js
+++ b/src/runtime/destructuring.js
@@ -1,0 +1,29 @@
+// Copyright 2014 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function() {
+  'use strict';
+
+  function iteratorToArray(iter) {
+    var rv = [];
+    var i = 0;
+    var tmp;
+    while (!(tmp = iter.next()).done) {
+      rv[i++] = tmp.value;
+    }
+    return rv;
+  }
+
+  $traceurRuntime.iteratorToArray = iteratorToArray;
+})();

--- a/test/feature/Destructuring/Empty.js
+++ b/test/feature/Destructuring/Empty.js
@@ -3,10 +3,14 @@ var calls = 0;
 var {} = Object(calls++);
 assert.equal(calls, 1);
 
-var [] = Object(calls++);
+assert.throw(function() {
+  var [] = Object(calls++);
+}, TypeError);
 assert.equal(calls, 2);
 
-var {} = Object(calls++), [] = Object(calls++);
+assert.throw(function() {
+  var {} = Object(calls++), [] = Object(calls++);
+});
 assert.equal(calls, 4);
 
 
@@ -17,8 +21,12 @@ calls = 0;
 ({} = Object(calls++));
 assert.equal(calls, 1);
 
-[] = Object(calls++);
+assert.throw(function() {
+  [] = Object(calls++);
+}, TypeError);
 assert.equal(calls, 2);
 
-({} = Object(calls++), [] = Object(calls++));
+assert.throw(function() {
+  ({} = Object(calls++), [] = Object(calls++));
+}, TypeError);
 assert.equal(calls, 4);

--- a/test/feature/Destructuring/Rest.js
+++ b/test/feature/Destructuring/Rest.js
@@ -1,17 +1,19 @@
 function destructRest() {
-  var a, b, c, d, e;
+  var a, b, c, d;
   [...a] = [1, 2, 3];
   [b, ...c] = [1, 2, 3];
   [,,, ...d] = [1, 2, 3];
-  [...e] = {x: 'boom'};
-  return {a: a, b: b, c: c, d: d, e: e};
+  return {a: a, b: b, c: c, d: d};
 }
-
-// ----------------------------------------------------------------------------
 
 var result = destructRest();
 assertArrayEquals([1, 2, 3], result.a);
 assert.equal(1, result.b);
 assertArrayEquals([2, 3], result.c);
 assertArrayEquals([], result.d);
-assertArrayEquals([], result.e);
+
+assert.throw(function() {
+  var e;
+  // No iterator.
+  [...e] = {x: 'boom'};
+}, TypeError);

--- a/test/feature/Destructuring/RestIterator.js
+++ b/test/feature/Destructuring/RestIterator.js
@@ -1,0 +1,45 @@
+(function() {
+  var i;
+
+  function* f() {
+    for (i = 0; i < 8; i++) {
+      yield i;
+    }
+  }
+  var x, x2, xs;
+  [, x, , x2, , ...xs] = f();
+  assert.equal(1, x);
+  assert.equal(3, x2);
+  assertArrayEquals([5, 6, 7], xs);
+
+  [] = f();
+  assert.equal(8, i);  // Since we never call next().
+
+  x = -1;
+  [x] = f();
+  assert.equal(0, x);
+  assert.equal(0, i);  // Since we called next once.
+})();
+
+// Same but with VariableDeclarations instead of AssignmenExpressions.
+(function() {
+  var i;
+
+  function* f() {
+    for (i = 0; i < 8; i++) {
+      yield i;
+    }
+  }
+
+  var [, x, , x2, , ...xs] = f();
+  assert.equal(1, x);
+  assert.equal(3, x2);
+  assertArrayEquals([5, 6, 7], xs);
+
+  var [] = f();
+  assert.equal(8, i);  // Since we never call next().
+
+  var [y] = f();
+  assert.equal(0, y);
+  assert.equal(0, i);  // Since we called next once.
+})();


### PR DESCRIPTION
The assignment

  [x] = obj;

should desugar to something like:

  $tmp = obj,
  $iter = $tmp[Symbol.iterator](),
  $iterResultObject = $iter.next(),
  x = $iterResultObject.done ? undefined : $iterResultObject.value;
  obj

When you add holes, spread and default initializers it gets even
hairier.

Fixes #840
