### PR TITLE
Only turn member variables into getters/setters if type assertions on

### DIFF
--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -105,11 +105,12 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (transformOptions.annotations)
       append(AnnotationsTransformer);
 
-    if (options.memberVariables)
-      append(MemberVariableTransformer);
-
-    if (options.typeAssertions)
+    if (options.typeAssertions) {
+      // Transforming member variabless to getters/setters only make
+      // sense when the type assertions are enabled.
+      if (options.memberVariables) append(MemberVariableTransformer);
       append(TypeAssertionTransformer);
+    }
 
     // PropertyNameShorthandTransformer needs to come before
     // module transformers. See #1120 or

--- a/src/codegeneration/PureES6Transformer.js
+++ b/src/codegeneration/PureES6Transformer.js
@@ -51,8 +51,12 @@ export class PureES6Transformer extends MultiTransformer {
       });
     }
 
-    if (options.memberVariables) append(MemberVariableTransformer);
-    if (options.typeAssertions) append(TypeAssertionTransformer);
+    if (options.typeAssertions) {
+      // Transforming member variabless to getters/setters only make
+      // sense when the type assertions are enabled.
+      if (options.memberVariables) append(MemberVariableTransformer);
+      append(TypeAssertionTransformer);
+    }
     append(AnnotationsTransformer);
     append(TypeTransformer);
   }


### PR DESCRIPTION
fixes #1530

Generating getters and setters is a way to add assertions on the return
type and argument.
However getters and setters are generally slower (V8 expected) then they
are only generated when required (type assertions on).
