### PR TITLE
Class methods: generate named functions (for debugging)

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -32,6 +32,7 @@ export var optionsV01 = enumerableOnlyObject({
   commentCallback: false,
   computedPropertyNames: true,
   debug: false,
+  debugNames: false,
   defaultParameters: true,
   destructuring: true,
   exponentiation: false,
@@ -499,6 +500,7 @@ addFeatureOption('memberVariables', EXPERIMENTAL);
 
 addBoolOption('commentCallback');
 addBoolOption('debug');
+addBoolOption('debugNames');
 addBoolOption('freeVariableChecker');
 addBoolOption('script');
 addBoolOption('typeAssertions');

--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -222,7 +222,7 @@ class AnnotationsScope {
         tree.annotations.length > 0) {
       tree = new PropertyMethodAssignment(tree.location, tree.isStatic,
           tree.functionKind, tree.name, parameterList,
-          tree.typeAnnotation, [], tree.body);
+          tree.typeAnnotation, [], tree.body, tree.debugName);
     }
     return super.transformPropertyMethodAssignment(tree);
   }

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -140,12 +140,15 @@ function classMethodDebugName(className, methodName, isStatic) {
 export class ClassTransformer extends TempVarTransformer{
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
+   * @param {ErrorReporter} reporter
+   * @param {boolean} showDebugNames options.debugNames
    */
-  constructor(identifierGenerator, reporter) {
+  constructor(identifierGenerator, reporter, debugNames) {
     super(identifierGenerator);
     this.strictCount_ = 0;
     this.state_ = null;
     this.reporter_ = reporter;
+    this.showDebugNames_ = debugNames;
   }
 
   // Override to handle AnonBlock
@@ -374,7 +377,9 @@ export class ClassTransformer extends TempVarTransformer{
     var body = this.transformSuperInFunctionBody_(
         tree.body, homeObject, internalName);
 
-    tree.debugName = classMethodDebugName(originalName, methodNameFromTree(tree.name), isStatic);
+    if (this.showDebugNames_) {
+      tree.debugName = classMethodDebugName(originalName, methodNameFromTree(tree.name), isStatic);
+    }
 
     if (!tree.isStatic &&
         parameterList === tree.parameterList &&

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -273,7 +273,7 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
   }
 
   transformPropertyMethodAssignment(tree) {
-    var func = new FunctionExpression(tree.location, null, tree.functionKind,
+    var func = new FunctionExpression(tree.location, tree.debugName, tree.functionKind,
         this.transformAny(tree.parameterList), tree.typeAnnotation, [],
         this.transformAny(tree.body));
     if (!this.needsAdvancedTransform) {

--- a/src/codegeneration/TypeTransformer.js
+++ b/src/codegeneration/TypeTransformer.js
@@ -84,7 +84,7 @@ export class TypeTransformer extends ParseTreeTransformer {
     if (tree.typeAnnotation) {
       tree = new PropertyMethodAssignment(tree.location, tree.isStatic,
           tree.functionKind, tree.name, tree.parameterList, null,
-          tree.annotations, tree.body);
+          tree.annotations, tree.body, tree.debugName);
     }
 
     return super.transformPropertyMethodAssignment(tree);

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -2192,7 +2192,7 @@ export class Parser {
     var body = this.parseFunctionBody_(functionKind, parameterList);
     return new PropertyMethodAssignment(this.getTreeLocation_(start),
         isStatic, functionKind, name, parameterList, typeAnnotation,
-        annotations, body);
+        annotations, body, null);
   }
 
   parsePropertyVariableDeclaration_(start, isStatic, name, annotations) {

--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -58,6 +58,7 @@ import {
   INTERFACE_DECLARATION,
   LABELLED_STATEMENT,
   LITERAL_EXPRESSION,
+  LITERAL_PROPERTY_NAME,
   MEMBER_EXPRESSION,
   MEMBER_LOOKUP_EXPRESSION,
   MODULE_DECLARATION,
@@ -404,6 +405,8 @@ export class ParseTree {
         return this.binding.getStringValue();
       case PROPERTY_NAME_SHORTHAND:
         return this.name.toString();
+      case LITERAL_PROPERTY_NAME:
+        return this.literalToken.toString();
     }
 
     throw new Error('Not yet implemented');

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -904,6 +904,9 @@
     ],
     "body": [
       "FunctionBody"
+    ],
+    "debugName": [
+      "ParseTree"
     ]
   },
   "PropertyNameAssignment": {


### PR DESCRIPTION
For class methods, generate named functions to make debugging easier.

Before:
```
class Foo {
  bar() {}
  static baz() {}
}

// ->

($traceurRuntime.createClass)(Foo, {
  bar: function() {}
}, {
  baz: function() {}
});
```

After:
```
class Foo {
  bar() {}
  static baz() {}
}

// ->

($traceurRuntime.createClass)(Foo, {
  bar: function Foo_bar() {}
}, {
  baz: function Foo$baz() {}
});
```