### PR TITLE
Add support for initializing member variables

### DIFF
--- a/src/codegeneration/MemberVariableTransformer.js
+++ b/src/codegeneration/MemberVariableTransformer.js
@@ -71,7 +71,7 @@ export class MemberVariableTransformer extends ParseTreeTransformer{
     var identifier = this.identifierGenerator_.generateUniqueIdentifier();
     var getter = this.createGetAccessor_(identifier, tree);
     var setter = this.createSetAccessor_(identifier, tree);
-    return new AnonBlock(tree.location, [getter, setter]);
+    return new AnonBlock(tree.location, [getter, setter, tree]);
   }
 
   createGetAccessor_(identifier, tree) {

--- a/src/codegeneration/PrependStatements.js
+++ b/src/codegeneration/PrependStatements.js
@@ -12,18 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  EXPRESSION_STATEMENT,
-  LITERAL_EXPRESSION
-} from '../syntax/trees/ParseTreeType.js';
-import {STRING} from '../syntax/TokenType.js';
-
-function isStringExpressionStatement(tree) {
-  return tree.type === EXPRESSION_STATEMENT &&
-      tree.expression.type === LITERAL_EXPRESSION &&
-      tree.expression.literalToken.type === STRING;
-}
-
 /**
  * Prepends |statements| with the |statementsToPrepend| making sure that any
  * leading directives, like 'use strict', are kept at the top of the statements.
@@ -41,7 +29,7 @@ export function prependStatements(statements, ...statementsToPrepend) {
   var transformed  = [];
   var inProlog = true;
   statements.forEach((statement) => {
-    if (inProlog && !isStringExpressionStatement(statement)) {
+    if (inProlog && !statement.isDirectivePrologue()) {
       transformed.push(...statementsToPrepend);
       inProlog = false;
     }

--- a/src/codegeneration/SuperTransformer.js
+++ b/src/codegeneration/SuperTransformer.js
@@ -110,7 +110,7 @@ export class SuperTransformer extends ParseTreeTransformer {
   // We should never get to these if ClassTransformer is doing its job.
   transformGetAccessor(tree) { return tree; }
   transformSetAccessor(tree) { return tree; }
-  transformPropertyMethodAssignMent(tree) { return tree; }
+  transformPropertyMethodAssignment(tree) { return tree; }
 
   /**
    * @param {CallExpression} tree

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -1121,6 +1121,12 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     }
     this.visitAny(tree.name);
     this.writeTypeAnnotation_(tree.typeAnnotation);
+    if (tree.initalizer) {
+      this.writeSpace_();
+      this.write_(EQUAL);
+      this.writeSpace_();
+      this.visitAny(tree.initializer);
+    }
     this.write_(SEMI_COLON);
   }
 

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -2197,9 +2197,10 @@ export class Parser {
 
   parsePropertyVariableDeclaration_(start, isStatic, name, annotations) {
     var typeAnnotation = this.parseTypeAnnotationOpt_();
+    var initializer = this.parseInitializerOpt_(Expression.NORMAL);
     this.eat_(SEMI_COLON);
     return new PropertyVariableDeclaration(this.getTreeLocation_(start),
-        isStatic, name, typeAnnotation, annotations);
+        isStatic, name, typeAnnotation, annotations, initializer);
   }
 
   parseClassElement2_(start, isStatic, annotations) {
@@ -3843,7 +3844,7 @@ export class Parser {
     var start = this.getTreeStartLocation_();
     this.eat_(NEW);
     var typeParameters = this.parseTypeParametersOpt_();
-    this.eat_(OPEN_PAREN)
+    this.eat_(OPEN_PAREN);
     var parameterList = this.parseFormalParameters_();
     this.eat_(CLOSE_PAREN);
     this.eat_(ARROW);

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -940,6 +940,9 @@
     ],
     "annotations": [
       "Array<ParseTree>"
+    ],
+    "initializer": [
+      "ParseTree"
     ]
   },
   "PropertySignature": {

--- a/test/feature/MemberVariables/Error_ChildNoCtor.js
+++ b/test/feature/MemberVariables/Error_ChildNoCtor.js
@@ -1,0 +1,11 @@
+// Options: --member-variables --types
+// Error: :8:3: Constructors of derived class must contain a super call
+
+class A {
+}
+
+class C extends A {
+  constructor() {
+    // "super()" is required in derived class
+  }
+}

--- a/test/feature/MemberVariables/Error_ChildSuperNotFirst.js
+++ b/test/feature/MemberVariables/Error_ChildSuperNotFirst.js
@@ -1,0 +1,15 @@
+// Options: --member-variables --types
+// Error: :10:5: The first statement of the constructor must be a super call
+
+class A {
+}
+
+class C extends A {
+  shouldFail: boolean = true;
+  constructor() {
+    this.value = 5;
+    // super() should be first when a derived class contains initialized
+    // instance variable
+    super();
+  }
+}

--- a/test/feature/MemberVariables/Initializers.js
+++ b/test/feature/MemberVariables/Initializers.js
@@ -1,0 +1,30 @@
+// Options: --member-variables --types
+
+class A {
+  one: number = 1;
+  static str: string = 'str';
+}
+
+class B {
+  one: number = 1;
+  static str: string = 'str';
+  constructor() {
+  }
+}
+
+var C = class {
+  one: number = 1;
+  static str: string = 'str';
+}
+
+assert.equal(A.str, 'str');
+assert.equal(B.str, 'str');
+assert.equal(C.str, 'str');
+
+var a = new A();
+var b = new B();
+var c = new C();
+
+assert.equal(a.one, 1);
+assert.equal(b.one, 1);
+assert.equal(c.one, 1);

--- a/test/feature/MemberVariables/InitializersAndInheritance.js
+++ b/test/feature/MemberVariables/InitializersAndInheritance.js
@@ -1,0 +1,31 @@
+// Options: --member-variables --types
+
+class Base {
+  base: boolean;
+  baseInitValue: boolean = true;
+  initIn: string = 'Base';
+
+  constructor() {
+    this.base = this.baseInitValue;
+  }
+}
+
+class DerivedImplicitCtor extends Base {
+  initIn: string = 'DerivedImplicitCtor';
+}
+
+var derivedImplicitCtor = new DerivedImplicitCtor();
+assert.equal(derivedImplicitCtor.initIn, 'DerivedImplicitCtor');
+assert.equal(derivedImplicitCtor.base, true);
+
+class DerivedWithCtor extends Base {
+  initIn: string = 'DerivedWithCtor';
+
+  constructor() {
+    super();
+  }
+}
+
+var derivedWithCtor = new DerivedWithCtor();
+assert.equal(derivedWithCtor.initIn, 'DerivedWithCtor');
+assert.equal(derivedWithCtor.base, true);

--- a/test/feature/MemberVariables/InitializersEvaluation.js
+++ b/test/feature/MemberVariables/InitializersEvaluation.js
@@ -1,0 +1,14 @@
+// Options: --member-variables --types
+
+var globalValue = 0;
+
+class A {
+  instanceValue: number = globalValue;
+}
+
+var a0 = new A();
+globalValue++;
+var a1 = new A();
+
+assert.equal(a0.instanceValue, 0);
+assert.equal(a1.instanceValue, 1);


### PR DESCRIPTION
The implementation follow TS rules:
- when the memberVariables option is enabled, the constructor must call the super constructor,
- when the memberVariables option is enabled and a class has initialized instance variables, the call to the super constructor must be the first statement in the class own constructor,
- instance variables initializers are evaluated when the class is instantiated.