### PR TITLE
Fix the logic in recursiveModuleCompileToSingleFile to always revert the cwd no matter what

### DIFF
--- a/src/node/recursiveModuleCompile.js
+++ b/src/node/recursiveModuleCompile.js
@@ -53,8 +53,7 @@ function recursiveModuleCompileToSingleFile(outputFile, includes, options) {
   return recursiveModuleCompile(resolvedIncludes, options)
       .then(function(tree) {
         compiler.writeTreeToFile(tree, resolvedOutputFile);
-        revertCwd();
-      }, function(err) {
+      }).then(revertCwd, function(err) {
         revertCwd();
         throw err;
       });


### PR DESCRIPTION
As mentioned in the discussion for the last pull request, I had a small error in logic for reverting the current working directory in the case that writeTreeToFile caused an exception to be thrown. This should now be fixed.
