### PR TITLE
Fix issue with ropes in writer

### DIFF
--- a/src/outputgeneration/TreeWriter.js
+++ b/src/outputgeneration/TreeWriter.js
@@ -18,8 +18,6 @@ import {toSource} from './toSource.js';
  * Create a ParseTreeWriter configured with options, apply it to tree
  * @param {ParseTree} tree
  * @param {Object=} options:
- *     highlighted: {ParseTree} branch of tree to highlight
- *     showLineNumbers: {boolean} add comments giving input line numbers
  *     prettyPrint: {boolean}
  *     sourceMapGenerator: {SourceMapGenerator} see third-party/source-maps
  * @param {string} outputName output filename.

--- a/src/outputgeneration/toSource.js
+++ b/src/outputgeneration/toSource.js
@@ -20,8 +20,6 @@ import {SourceMapGenerator} from './SourceMapIntegration.js';
  * Create a ParseTreeWriter configured with options, apply it to tree
  * @param {ParseTree} tree
  * @param {Object=} options:
- *     highlighted: {ParseTree} branch of tree to highlight
- *     showLineNumbers: {boolean} add comments giving input line numbers
  *     prettyPrint: {boolean}
  *     sourceMapGenerator: {SourceMapGenerator} see third-party/source-maps
  * @param {string} outputName the sourcemap file value.

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -1140,8 +1140,6 @@ ParseTreeValidator.validate = function(tree) {
         '(unknown)';
     throw new Error(
         `Parse tree validation failure '${e.message}' at ${locationString}:` +
-        '\n\n' +
-        TreeWriter.write(tree, {highlighted: e.tree, showLineNumbers: true}) +
-        '\n');
+        `\n\n${TreeWriter.write(tree)}\n`);
   }
 };


### PR DESCRIPTION
We were constantly appending to the current line string. We then did
s.charCodeAt(s.length - 1) which, when the string is a rope is O(n)
where n is the number of internal strings. We did this on every
append. The code is now refactored to keep track of the last char
code so we never have to go through the rope.

This also removes the feature to highlight a node and print line
number comments.

Also, removed some branches in hot code.

Fixes #1596
