### PR TITLE
Delegate moduleName option to Transformers

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -43,7 +43,7 @@ export var optionsV01 = enumerableOnlyObject({
   lowResolutionSourceMap: false,
   inputSourceMap: false,
   memberVariables: false,
-  moduleName: false,
+  moduleName: 'default',
   modules: 'register',
   numericLiterals: true,
   outputLanguage: 'es5',
@@ -305,7 +305,7 @@ export class Options {
    */
   setDefaults() {
     this.modules = 'register';
-    this.moduleName = false;
+    this.moduleName = 'default';
     this.outputLanguage = 'es5';
     this.referrer = '';
     this.sourceMaps = false;
@@ -468,11 +468,15 @@ export function addOptions(flags, commandOptions) {
       (moduleFormat) => {
         commandOptions.modules = moduleFormat;
       });
-  flags.option('--moduleName <string>',
-    '__moduleName value, + sign to use source name, or empty to omit',
+  flags.option('--moduleName [true|false|default]',
+    'true for named, false for anonymous modules; default depends on --modules',
     (moduleName) => {
-      if (moduleName === '+')
+      if (moduleName === 'true')
         moduleName = true;
+      else if (moduleName === 'false')
+        moduleName = false;
+      else
+        moduleName = 'default';
       commandOptions.moduleName = moduleName;
     });
   flags.option('--outputLanguage <es6|es5>',

--- a/src/codegeneration/AmdTransformer.js
+++ b/src/codegeneration/AmdTransformer.js
@@ -31,6 +31,14 @@ export class AmdTransformer extends ModuleTransformer {
   constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator, reporter, options);
     this.dependencies = [];
+    this.anonymousModule =
+        options && !options.bundle && options.moduleName !== true;
+  }
+
+  getModuleName(tree) {
+    if (this.anonymousModule)
+      return null;
+    return tree.moduleName;
   }
 
   getExportProperties() {
@@ -78,7 +86,6 @@ export class AmdTransformer extends ModuleTransformer {
     // AMD does not allow .js
     var value = tree.token.processedValue
     var stringLiteral = createStringLiteralToken(value.replace(/\.js$/, ''));
-
     this.dependencies.push({path: stringLiteral, local: localName});
     return createIdentifierExpression(localName);
   }

--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -46,6 +46,14 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
   constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator, reporter, options);
     this.moduleVars_ = [];
+    this.anonymousModule =
+        options && !options.bundle && options.moduleName !== true;
+  }
+
+  getModuleName(tree) {
+    if (this.anonymousModule)
+      return null;
+    return tree.moduleName;
   }
 
   moduleProlog() {

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -74,6 +74,10 @@ export class ModuleTransformer extends TempVarTransformer {
     }) + '__';
   }
 
+  getModuleName(tree) {
+    return tree.moduleName;
+  }
+
   getTempVarNameForModuleSpecifier(moduleSpecifier) {
     var normalizedName = System.normalize(moduleSpecifier.token.processedValue, this.moduleName);
     return this.getTempVarNameForModuleName(normalizedName);
@@ -85,7 +89,7 @@ export class ModuleTransformer extends TempVarTransformer {
   }
 
   transformModule(tree) {
-    this.moduleName = tree.moduleName;
+    this.moduleName = this.getModuleName(tree);
 
     this.pushTempScope();
 

--- a/src/node/NodeCompiler.js
+++ b/src/node/NodeCompiler.js
@@ -58,7 +58,7 @@ NodeCompiler.prototype = {
       }
 
       var parsed = this.parse(contents.toString(), inputFilePath);
-      this.writeTreeToFile(this.transform(parsed, undefined, inputFilePath),
+      this.writeTreeToFile(this.transform(parsed, inputFilePath),
                            outputFilePath);
     }.bind(this));
   },

--- a/src/node/recursiveModuleCompile.js
+++ b/src/node/recursiveModuleCompile.js
@@ -39,6 +39,7 @@ function recursiveModuleCompileToSingleFile(outputFile, includes, options) {
     return include;
   });
 
+  options.bundle = includes.length > 1;
   var compiler = new NodeCompiler(options);
 
   mkdirRecursive(outputDir);

--- a/src/runtime/LoaderCompiler.js
+++ b/src/runtime/LoaderCompiler.js
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  AttachModuleNameTransformer
-} from '../codegeneration/module/AttachModuleNameTransformer.js';
-import {FromOptionsTransformer} from '../codegeneration/FromOptionsTransformer.js';
 import {buildExportList} from '../codegeneration/module/ExportListBuilder.js';
 import {CollectingErrorReporter} from '../util/CollectingErrorReporter.js';
 import {Compiler} from '../Compiler.js';

--- a/test/node-api-test.js
+++ b/test/node-api-test.js
@@ -30,7 +30,7 @@ suite('node public api', function() {
       // build ES6 style modules rather then cjs
       modules: 'register',
 
-      // node defaults to moduleName false
+      // single file compile defaults to moduleName false
       moduleName: true,
 
       // ensure the source map works
@@ -99,7 +99,7 @@ suite('node public api', function() {
       // build ES6 style modules rather then cjs
       modules: 'register',
 
-      // node defaults to moduleName false
+      // single file compile defaults to moduleName false
       moduleName: true,
 
       // ensure the source map works
@@ -120,22 +120,41 @@ suite('node public api', function() {
 
   test('named amd', function() {
     var compiled = traceurAPI.compile(contents, {
-      // build ES6 style modules rather then cjs
+      // build requirejs style modules rather then cjs
       modules: 'amd',
 
       // enforce a module name in the AMD define
-      moduleName: 'test-module'
-    }, nativeFilename);
+      moduleName: true
+    }, 'test-module');
 
     assert.ok(compiled, 'can compile');
 
     var gotName;
-    var define = function(name) {
+    function define(name) {
       gotName = name;
     }
-
+    // eval locally to capture the define() mock
     eval(compiled);
 
-    assert.ok(gotName == 'test-module', 'module defines into named AMD');
+    assert.equal(gotName, 'test-module');
+  });
+
+  test('default amd', function() {
+    var compiled = traceurAPI.compile(contents, {
+      // build requirejs style modules rather then cjs
+      modules: 'amd',
+      moduleName: true
+    }, 'test-module');
+
+    assert.ok(compiled, 'can compile');
+
+    var gotName;
+    function define(name) {
+      gotName = name;
+    }
+    // eval locally to capture the define() mock
+    eval(compiled);
+
+    assert.equal(gotName, 'test-module');
   });
 });


### PR DESCRIPTION
Change moduleName option to [true|false|default] and delegate
  'default' to each module transformer.
Set the default for moduleName to 'default'.

Add internal option 'bundle', set when multiple modules are input
and one file is output, eg for AMD/register bundles.

mdouleName true for named, registered modules; generates __moduleName
  statement.
moduleName false for anonymous modules.

Set moduleName false for single file compile, true for bundles

Fixes #1588