### PR TITLE
Support composing with input source maps

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -241,8 +241,16 @@ export class Compiler {
   }
 
   getSourceMap() {
-    if (this.sourceMapConfiguration_)
-      return this.sourceMapConfiguration_.sourceMapGenerator.toString();
+    if (this.sourceMapConfiguration_) {
+      var sourceMap = this.sourceMapConfiguration_.sourceMapGenerator.toString();
+      var inputSourceMap = this.sourceMapConfiguration_.inputSourceMap;
+      if (inputSourceMap) {
+        var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(sourceMap));
+        generator.applySourceMap(new SourceMapConsumer(inputSourceMap));
+        sourceMap = generator.toJSON();
+      }
+      return sourceMap;
+    }
   }
 
   get sourceMapInfo() {
@@ -282,12 +290,6 @@ export class Compiler {
       var sourceMappingURL =
           this.sourceMappingURL(outputName || sourceURL || 'unnamed.js');
       var sourceMap = this.getSourceMap();
-      var inputSourceMap = this.sourceMapConfiguration_.inputSourceMap;
-      if (inputSourceMap) {
-        var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(sourceMap));
-        generator.applySourceMap(new SourceMapConsumer(inputSourceMap));
-        sourceMap = generator.toJSON();
-      }
       compiledCode += '\n//# sourceMappingURL=' + sourceMappingURL + '\n';
       // The source map info for in-memory maps
       this.sourceMapInfo_ = {

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -28,8 +28,10 @@ import {
 
 import {ParseTreeMapWriter} from './outputgeneration/ParseTreeMapWriter.js';
 import {ParseTreeWriter} from './outputgeneration/ParseTreeWriter.js';
-import {SourceMapConsumer} from './outputgeneration/SourceMapIntegration.js';
-import {SourceMapGenerator} from './outputgeneration/SourceMapIntegration.js';
+import {
+  SourceMapConsumer,
+  SourceMapGenerator
+} from './outputgeneration/SourceMapIntegration.js';
 
 function merge(...srcs) {
   var dest = Object.create(null);

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -67,6 +67,8 @@ export class Compiler {
     this.sourceMapConfiguration_ = null;
     // Only used if this.options_sourceMaps = 'memory'.
     this.sourceMapInfo_ = null;
+    // Used to cache source map calculation
+    this.sourceMapCache_ = null;
   }
   /**
    * Use Traceur to compile ES6 type=script source code to ES5 script.
@@ -173,6 +175,7 @@ export class Compiler {
    */
   parse(content, sourceName = '<compiler-parse-input>') {
     sourceName = this.normalize(sourceName);
+    this.sourceMapCache_ = null;
     this.sourceMapConfiguration_ = null;
     // Here we mutate the global/module options object to be used in parsing.
     traceurOptions.setFromObject(this.options_);
@@ -241,6 +244,10 @@ export class Compiler {
   }
 
   getSourceMap() {
+    if (this.sourceMapCache_) {
+      return this.sourceMapCache_;
+    }
+
     if (this.sourceMapConfiguration_) {
       var sourceMap = this.sourceMapConfiguration_.sourceMapGenerator.toString();
       var inputSourceMap = this.sourceMapConfiguration_.inputSourceMap;
@@ -249,6 +256,7 @@ export class Compiler {
         generator.applySourceMap(new SourceMapConsumer(inputSourceMap));
         sourceMap = generator.toJSON();
       }
+      this.sourceMapCache_ = sourceMap;
       return sourceMap;
     }
   }
@@ -271,6 +279,7 @@ export class Compiler {
     sourceRoot = this.normalize(sourceRoot) || basePath(outputName);
 
     var writer;
+    this.sourceMapCache_ = null;
     this.sourceMapConfiguration_ =
         this.createSourceMapConfiguration_(outputName, sourceRoot);
     if (this.sourceMapConfiguration_) {

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -28,6 +28,7 @@ import {
 
 import {ParseTreeMapWriter} from './outputgeneration/ParseTreeMapWriter.js';
 import {ParseTreeWriter} from './outputgeneration/ParseTreeWriter.js';
+import {SourceMapConsumer} from './outputgeneration/SourceMapIntegration.js';
 import {SourceMapGenerator} from './outputgeneration/SourceMapIntegration.js';
 
 function merge(...srcs) {
@@ -233,7 +234,8 @@ export class Compiler {
           sourceRoot: sourceRoot,
           skipValidation: true
         }),
-        sourceRoot: sourceRoot
+        sourceRoot: sourceRoot,
+        inputSourceMap: this.options_.inputSourceMap
       };
     }
   }
@@ -279,12 +281,19 @@ export class Compiler {
     if (this.sourceMapConfiguration_) {
       var sourceMappingURL =
           this.sourceMappingURL(outputName || sourceURL || 'unnamed.js');
+      var sourceMap = this.getSourceMap();
+      var inputSourceMap = this.sourceMapConfiguration_.inputSourceMap;
+      if (inputSourceMap) {
+        var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(sourceMap));
+        generator.applySourceMap(new SourceMapConsumer(inputSourceMap));
+        sourceMap = generator.toJSON();
+      }
       compiledCode += '\n//# sourceMappingURL=' + sourceMappingURL + '\n';
       // The source map info for in-memory maps
       this.sourceMapInfo_ = {
         url: sourceURL,
         outputName: outputName,
-        map: this.getSourceMap()
+        map: sourceMap
       };
     }
 

--- a/src/Options.js
+++ b/src/Options.js
@@ -40,6 +40,7 @@ export var optionsV01 = enumerableOnlyObject({
   generatorComprehension: false,
   generators: true,
   lowResolutionSourceMap: false,
+  inputSourceMap: false,
   memberVariables: false,
   moduleName: false,
   modules: 'register',
@@ -203,6 +204,7 @@ export class Options {
     this.referrer = '';
     this.sourceMaps = false;
     this.lowResolutionSourceMap = false;
+    this.inputSourceMap = false;
     this.typeAssertionModule = null;
   }
   /**


### PR DESCRIPTION
Adds option `.inputSourceMap`; when set to a SourceMap object, the output sourcemap is composed with the inputSourceMap.