### PR TITLE
Allocate new object for exception, since stack property

### DIFF
--- a/src/runtime/ModuleStore.js
+++ b/src/runtime/ModuleStore.js
@@ -152,9 +152,12 @@
               evaled.push(frame);
             }
           });
-          ex.stack = evaled.join('\n');
+          // Allocate new object, some platforms make ex.stack read-only.
+          ex = {
+            stack: evaled.join('\n'),
+            message: ex.message
+          };
         }
-
         throw new ModuleEvaluationError(this.url, ex);
       }
     }


### PR DESCRIPTION
is (evidently) read only on some platforms.

Fixes #1611