### PR TITLE
Fix parsing of ArrowFunction (no LineTerminator allowed)

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -2482,16 +2482,13 @@ export class Parser {
       }
     }
 
-    if (type === ARROW) {
+    if (type === ARROW && this.peekTokenNoLineTerminator_() !== null) {
       if (left.type === COVER_FORMALS || left.type === IDENTIFIER_EXPRESSION)
         return this.parseArrowFunction_(start, left, null);
 
       if (validAsyncParen && left.type === CALL_EXPRESSION) {
-        var arrowToken = this.peekTokenNoLineTerminator_();
-        if (arrowToken !== null) {
-          var asyncToken = left.operand.identifierToken;
-          return this.parseArrowFunction_(start, left.args, asyncToken);
-        }
+        var asyncToken = left.operand.identifierToken;
+        return this.parseArrowFunction_(start, left.args, asyncToken);
       }
     }
 
@@ -3115,8 +3112,8 @@ export class Parser {
    * CoverParenthesizedExpressionAndArrowParameterList :
    *   ( Expression )
    *   ( )
-   *   ( ... Identifier )
-   *   ( Expression , ... Identifier )
+   *   ( ... BindingIdentifier )
+   *   ( Expression , ... BindingIdentifier )
    *
    * ConciseBody :
    *   [lookahead not {] AssignmentExpression

--- a/test/feature/ArrowFunctions/Error_LineTerminator.js
+++ b/test/feature/ArrowFunctions/Error_LineTerminator.js
@@ -1,0 +1,4 @@
+// Error: :4:1: Unexpected token =>
+
+x
+=>1


### PR DESCRIPTION
This should not be parsed as an ArrowFunction:
```
x
=>1
```

I noticed over at http://kangax.github.io/compat-table/es6/#arrow_functions that Traceur doesn't handle this correctly (in all cases), but hopefully it does now.