### PR TITLE
Update source-map and skip validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "node-uuid": "1.x",
     "regexpu": "0.3.0",
     "requirejs": "2.x",
-    "semver": "2.x",
     "traceur": "0.0.79",
     "promises-aplus-tests": "2.x"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "source-map-support": "~0.2.8"
   },
   "devDependencies": {
-    "source-map": "0.1.34",
+    "source-map": "0.1.43",
     "express": "4.x",
     "serve-index": "1.x",
     "mocha": "1.20.x",

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -230,7 +230,8 @@ export class Compiler {
       return {
         sourceMapGenerator: new SourceMapGenerator({
           file: outputName,
-          sourceRoot: sourceRoot
+          sourceRoot: sourceRoot,
+          skipValidation: true
         }),
         sourceRoot: sourceRoot
       };

--- a/src/outputgeneration/SourceMapIntegration.js-template.js
+++ b/src/outputgeneration/SourceMapIntegration.js-template.js
@@ -43,6 +43,8 @@ define = makeDefine(m, './base64-vlq');
 // #include ../../node_modules/source-map/lib/source-map/base64-vlq.js
 define = makeDefine(m, './binary-search');
 // #include ../../node_modules/source-map/lib/source-map/binary-search.js
+define = makeDefine(m, './mapping-list');
+// #include ../../node_modules/source-map/lib/source-map/mapping-list.js
 define = makeDefine(m, './source-map-generator');
 // #include ../../node_modules/source-map/lib/source-map/source-map-generator.js
 define = makeDefine(m, './source-map-consumer');

--- a/src/outputgeneration/toSource.js
+++ b/src/outputgeneration/toSource.js
@@ -33,7 +33,8 @@ export function toSource(tree, options = undefined,
   if (!sourceMapGenerator && sourcemaps)  {
     sourceMapGenerator = new SourceMapGenerator({
       file: outputName,
-      sourceRoot: sourceRoot
+      sourceRoot: sourceRoot,
+      skipValidation: true
     });
   }
 


### PR DESCRIPTION
Leverage the new `skipValidation` flag in `source-map` to disable unneeded safety checks during source map generation.

Yields large performance boosts, both passively from using the latest version and additionally from using the flag (see https://github.com/mozilla/source-map/pull/150)