### PR TITLE
Optional low resolution source maps

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -263,6 +263,8 @@ export class Compiler {
     this.sourceMapConfiguration_ =
         this.createSourceMapConfiguration_(outputName, sourceRoot);
     if (this.sourceMapConfiguration_) {
+      this.sourceMapConfiguration_.lowResolution =
+          this.options_.lowResolutionSourceMap;
       writer =
           new ParseTreeMapWriter(this.sourceMapConfiguration_, this.options_);
     } else {

--- a/src/Options.js
+++ b/src/Options.js
@@ -39,6 +39,7 @@ export var optionsV01 = enumerableOnlyObject({
   freeVariableChecker: false,
   generatorComprehension: false,
   generators: true,
+  lowResolutionSourceMap: false,
   memberVariables: false,
   moduleName: false,
   modules: 'register',
@@ -201,6 +202,7 @@ export class Options {
     this.outputLanguage = 'es5';
     this.referrer = '';
     this.sourceMaps = false;
+    this.lowResolutionSourceMap = false;
     this.typeAssertionModule = null;
   }
   /**

--- a/src/Options.js
+++ b/src/Options.js
@@ -366,6 +366,10 @@ export function addOptions(flags, commandOptions) {
     'sourceMaps generated to file or inline with data: URL',
     (to) => { return commandOptions.sourceMaps = to; }
   );
+  flags.option('--low-resolution-source-maps',
+    'Lower sourceMaps granularity to one mapping per output line',
+    () => { return commandOptions.lowResolutionSourceMap = true; }
+  );
   flags.option('--experimental',
     'Turns on all experimental features',
     () => { commandOptions.experimental = true; }

--- a/src/outputgeneration/ParseTreeMapWriter.js
+++ b/src/outputgeneration/ParseTreeMapWriter.js
@@ -26,6 +26,7 @@ export class ParseTreeMapWriter extends ParseTreeWriter {
     super(options);
     this.sourceMapGenerator_ = sourceMapConfiguration.sourceMapGenerator;
     this.sourceRoot_ = sourceMapConfiguration.sourceRoot;
+    this.lowResolution_ = sourceMapConfiguration.lowResolution;
     this.outputLineCount_ = 1;
     this.isFirstMapping_ = true;
   }
@@ -135,16 +136,19 @@ export class ParseTreeMapWriter extends ParseTreeWriter {
     return lhs.line === rhs.line && lhs.column === rhs.column;
   }
 
-  isSameMapping() {
+  skipMapping() {
     if (!this.previousMapping_)
       return false;
+    if (this.lowResolution_ &&
+        this.previousMapping_.generated.line == this.generated_.line)
+      return true;
     if (this.isSame(this.previousMapping_.generated, this.generated_) &&
         this.isSame(this.previousMapping_.original, this.original_))
-      return true;;
+      return true;
   }
 
   addMapping() {
-    if (this.isSameMapping())
+    if (this.skipMapping())
       return;
 
     var mapping = {

--- a/src/outputgeneration/toSource.js
+++ b/src/outputgeneration/toSource.js
@@ -37,9 +37,14 @@ export function toSource(tree, options = undefined,
     });
   }
 
+  var sourceMapConfiguration = {
+    sourceMapGenerator: sourceMapGenerator,
+    sourceRoot: sourceRoot
+  };
+
   var writer;
   if (sourceMapGenerator)
-    writer = new ParseTreeMapWriter(sourceMapGenerator, sourceRoot, options);
+    writer = new ParseTreeMapWriter(sourceMapConfiguration, options);
   else
     writer = new ParseTreeWriter(options);
 

--- a/src/outputgeneration/toSource.js
+++ b/src/outputgeneration/toSource.js
@@ -39,7 +39,8 @@ export function toSource(tree, options = undefined,
 
   var sourceMapConfiguration = {
     sourceMapGenerator: sourceMapGenerator,
-    sourceRoot: sourceRoot
+    sourceRoot: sourceRoot,
+    lowResolution: options && options.lowResolutionSourceMap
   };
 
   var writer;


### PR DESCRIPTION
In many situations most of the value in a source map is given by the set of all first-in-their-line mappings.

In large builds, the cost of generating source maps is considerable, and emitting only this "blurrier" source map seems to be a good trade-off.

@johnjbarton please confirm if https://github.com/crisptrutski/traceur-compiler/commit/68b58bdcc86dbc02dbd6b660cb85684e428aa60a was a bug or not