### PR TITLE
Write to module.exports for CommonJS

### DIFF
--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -83,7 +83,7 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
     // "module.exports", so we don't append "module.exports = {}" to the output.
     if (this.hasExports()) {
       var descriptors = this.transformObjectLiteralToDescriptors(exportObject);
-      var exportStatement = parseStatement `Object.defineProperties(exports, ${descriptors});`;
+      var exportStatement = parseStatement `Object.defineProperties(module.exports, ${descriptors});`;
       statements = prependStatements(statements, exportStatement);
     }
     return statements;

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -370,8 +370,8 @@ suite('context test', function() {
       assert.isNull(error);
       var fileContents = fs.readFileSync(path.resolve(outDir, 'file.js'));
       var depContents = fs.readFileSync(path.resolve(outDir, 'dep.js'));
-      assert.equal(fileContents + '', "\"use strict\";\nObject.defineProperties(exports, {\n  p: {get: function() {\n      return p;\n    }},\n  __esModule: {value: true}\n});\nvar $__dep_46_js__;\nvar q = ($__dep_46_js__ = require(\"./dep.js\"), $__dep_46_js__ && $__dep_46_js__.__esModule && $__dep_46_js__ || {default: $__dep_46_js__}).q;\nvar p = 'module';\n");
-      assert.equal(depContents + '', "\"use strict\";\nObject.defineProperties(exports, {\n  q: {get: function() {\n      return q;\n    }},\n  __esModule: {value: true}\n});\nvar q = 'q';\n");
+      assert.equal(fileContents + '', "\"use strict\";\nObject.defineProperties(module.exports, {\n  p: {get: function() {\n      return p;\n    }},\n  __esModule: {value: true}\n});\nvar $__dep_46_js__;\nvar q = ($__dep_46_js__ = require(\"./dep.js\"), $__dep_46_js__ && $__dep_46_js__.__esModule && $__dep_46_js__ || {default: $__dep_46_js__}).q;\nvar p = 'module';\n");
+      assert.equal(depContents + '', "\"use strict\";\nObject.defineProperties(module.exports, {\n  q: {get: function() {\n      return q;\n    }},\n  __esModule: {value: true}\n});\nvar q = 'q';\n");
       done();
     });
   });


### PR DESCRIPTION
The automatic module detection in SystemJS only works when CommonJS modules use `exports.prop` or `module.exports` without the presence of any requires.

This would make the module detection always work for Traceur-generated CommonJS output.

From https://github.com/systemjs/systemjs/issues/297.