### PR TITLE
Use chai.assert in typeAssertionModule tests.

### DIFF
--- a/test/feature/TypeAssertions/resources/assert.js
+++ b/test/feature/TypeAssertions/resources/assert.js
@@ -1,4 +1,4 @@
-export var assert = this.assert;
+export var assert = chai.assert;
 
 assert.type = function (actual, type) {
   if (type === $traceurRuntime.type.any) {


### PR DESCRIPTION
Using this.assert picks up some assert not equal to the chai.assert used in our testing
under some circumstances I am no able to determine.