### PR TITLE
Change annotations to annotate

### DIFF
--- a/src/codegeneration/AnnotationsTransformer.js
+++ b/src/codegeneration/AnnotationsTransformer.js
@@ -293,7 +293,7 @@ class AnnotationsScope {
       annotations = this.transformAnnotations_(annotations);
       if (annotations.length > 0) {
         metadataStatements.push(this.createDefinePropertyStatement_(target,
-            'annotations', createArrayLiteralExpression(annotations)));
+            'annotate', createArrayLiteralExpression(annotations)));
       }
     }
 

--- a/test/feature/Annotations/AnnotatedTypedClass.module.js
+++ b/test/feature/Annotations/AnnotatedTypedClass.module.js
@@ -15,6 +15,6 @@ class AnnotatedTypedClass {
   bar(a:X) {}
 }
 
-assertArrayEquals([new Anno('class'), new Anno2('ctor')], AnnotatedTypedClass.annotations);
+assertArrayEquals([new Anno('class'), new Anno2('ctor')], AnnotatedTypedClass.annotate);
 assertArrayEquals([[X, new Anno], [new Anno('b')]], AnnotatedTypedClass.parameters);
 assertArrayEquals([[X]], AnnotatedTypedClass.prototype.bar.parameters);

--- a/test/feature/Annotations/Class.module.js
+++ b/test/feature/Annotations/Class.module.js
@@ -13,15 +13,14 @@ class AnnotatedClass {
   set prop(x) {}
 }
 
-assertArrayEquals([new Anno], AnnotatedClass.annotations);
+assertArrayEquals([new Anno], AnnotatedClass.annotate);
 assertArrayEquals([new Anno],
-    AnnotatedClass.prototype.annotatedMethod.annotations);
+    AnnotatedClass.prototype.annotatedMethod.annotate);
 
 assertArrayEquals([new Anno],
     Object.getOwnPropertyDescriptor(AnnotatedClass.prototype, 'prop').
-        get.annotations);
+        get.annotate);
 
 assertArrayEquals([new Anno],
     Object.getOwnPropertyDescriptor(AnnotatedClass.prototype, 'prop').
-        set.annotations);
-
+        set.annotate);

--- a/test/feature/Annotations/ClassConstructor.module.js
+++ b/test/feature/Annotations/ClassConstructor.module.js
@@ -10,4 +10,4 @@ class AnnotatedClassCtor {
   constructor() {}
 }
 
-assertArrayEquals([new Anno, new Anno2], AnnotatedClassCtor.annotations);
+assertArrayEquals([new Anno, new Anno2], AnnotatedClassCtor.annotate);

--- a/test/feature/Annotations/ClassGeneratorMethod.module.js
+++ b/test/feature/Annotations/ClassGeneratorMethod.module.js
@@ -13,6 +13,6 @@ class AnnotatedClass {
 }
 
 assertArrayEquals([new Anno],
-    AnnotatedClass.prototype.generate.annotations);
+    AnnotatedClass.prototype.generate.annotate);
 assertArrayEquals([new Anno2],
-    AnnotatedClass.staticGenerate.annotations);
+    AnnotatedClass.staticGenerate.annotate);

--- a/test/feature/Annotations/ClassInClass.module.js
+++ b/test/feature/Annotations/ClassInClass.module.js
@@ -23,8 +23,8 @@ class Outer {
 }
 
 var Inner = Outer.nested;
-assertArrayEquals([new Anno('outer'), new Anno2('outerCtor')], Outer.annotations);
-assertArrayEquals([new Anno('inner'), new Anno2('innerCtor')], Inner.annotations);
-assertArrayEquals([new Anno('innerMethod')], Inner.prototype.method.annotations);
+assertArrayEquals([new Anno('outer'), new Anno2('outerCtor')], Outer.annotate);
+assertArrayEquals([new Anno('inner'), new Anno2('innerCtor')], Inner.annotate);
+assertArrayEquals([new Anno('innerMethod')], Inner.prototype.method.annotate);
 assertArrayEquals([[X, new Anno('innerMethodParam')]],
     Inner.prototype.method.parameters);

--- a/test/feature/Annotations/ClassInsideObjectGetter.module.js
+++ b/test/feature/Annotations/ClassInsideObjectGetter.module.js
@@ -12,5 +12,4 @@ var object = {
 };
 
 assertArrayEquals([new Anno],
-    Object.getOwnPropertyDescriptor(object.foo.prototype, 'b').get.annotations);
-
+    Object.getOwnPropertyDescriptor(object.foo.prototype, 'b').get.annotate);

--- a/test/feature/Annotations/Constructor.module.js
+++ b/test/feature/Annotations/Constructor.module.js
@@ -6,4 +6,4 @@ class AnnotatedCtor {
   constructor() {}
 }
 
-assertArrayEquals([new Anno2], AnnotatedCtor.annotations);
+assertArrayEquals([new Anno2], AnnotatedCtor.annotate);

--- a/test/feature/Annotations/ExportedClass.module.js
+++ b/test/feature/Annotations/ExportedClass.module.js
@@ -7,9 +7,9 @@ import {
 } from './resources/exported-classes.js';
 
 
-assertArrayEquals([new Anno], ExportedAnnotatedClass.annotations);
+assertArrayEquals([new Anno], ExportedAnnotatedClass.annotate);
 assertArrayEquals([new Anno],
-    ExportedAnnotatedClass.prototype.annotatedMethod.annotations);
+    ExportedAnnotatedClass.prototype.annotatedMethod.annotate);
 
 assertArrayEquals([new Anno],
-    ExportedUnannotatedClass.prototype.annotatedMethod.annotations);
+    ExportedUnannotatedClass.prototype.annotatedMethod.annotate);

--- a/test/feature/Annotations/ExportedFunction.module.js
+++ b/test/feature/Annotations/ExportedFunction.module.js
@@ -7,7 +7,7 @@ import {
   exportedUnannotated
 } from './resources/exported-functions.js';
 
-assertArrayEquals([new Anno], exportedAnnotated.annotations);
+assertArrayEquals([new Anno], exportedAnnotated.annotate);
 assertArrayEquals([[new Anno]], exportedAnnotated.parameters);
-assert.isUndefined(exportedUnannotated.annotations);
+assert.isUndefined(exportedUnannotated.annotate);
 assertArrayEquals([[new Anno]], exportedUnannotated.parameters);

--- a/test/feature/Annotations/FunctionInsideClassGetter.module.js
+++ b/test/feature/Annotations/FunctionInsideClassGetter.module.js
@@ -10,5 +10,5 @@ class Test {
   }
 }
 
-assertArrayEquals([new Anno('Test')], Test.annotations);
-assertArrayEquals([new Anno('x')], new Test().annotatedFn.annotations);
+assertArrayEquals([new Anno('Test')], Test.annotate);
+assertArrayEquals([new Anno('x')], new Test().annotatedFn.annotate);

--- a/test/feature/Annotations/GeneratorFunction.module.js
+++ b/test/feature/Annotations/GeneratorFunction.module.js
@@ -4,4 +4,4 @@ import {Anno} from './resources/setup.js';
 @Anno
 function* generate() {}
 
-assertArrayEquals([new Anno], generate.annotations);
+assertArrayEquals([new Anno], generate.annotate);

--- a/test/feature/Annotations/GetAccessorStringName.module.js
+++ b/test/feature/Annotations/GetAccessorStringName.module.js
@@ -9,6 +9,6 @@ class C {
 }
 
 assertArrayEquals([new Anno('x y z')],
-    Object.getOwnPropertyDescriptor(C.prototype, 'x y z').get.annotations);
+    Object.getOwnPropertyDescriptor(C.prototype, 'x y z').get.annotate);
 assertArrayEquals([new Anno('xyz')],
-    Object.getOwnPropertyDescriptor(C.prototype, 'xyz').get.annotations);
+    Object.getOwnPropertyDescriptor(C.prototype, 'xyz').get.annotate);

--- a/test/feature/Annotations/MemberExpressionAnnotation.js
+++ b/test/feature/Annotations/MemberExpressionAnnotation.js
@@ -23,10 +23,10 @@ class NestedWithArgs {
   annotatedMethod() {}
 }
 
-assertArrayEquals([new x.Simple], SimpleAnnotation.annotations);
+assertArrayEquals([new x.Simple], SimpleAnnotation.annotate);
 assertArrayEquals([new x.Simple],
-    SimpleAnnotation.prototype.annotatedMethod.annotations);
+    SimpleAnnotation.prototype.annotatedMethod.annotate);
 
-assertArrayEquals([new x.nested.Args('class')], NestedWithArgs.annotations);
+assertArrayEquals([new x.nested.Args('class')], NestedWithArgs.annotate);
 assertArrayEquals([new x.nested.Args('method')],
-    NestedWithArgs.prototype.annotatedMethod.annotations);
+    NestedWithArgs.prototype.annotatedMethod.annotate);

--- a/test/feature/Annotations/MultipleAnnotatedFunction.module.js
+++ b/test/feature/Annotations/MultipleAnnotatedFunction.module.js
@@ -8,5 +8,4 @@ import {
 @Anno2('val')
 function Multi() {}
 
-assertArrayEquals([new Anno, new Anno2('val')], Multi.annotations);
-
+assertArrayEquals([new Anno, new Anno2('val')], Multi.annotate);

--- a/test/feature/Annotations/PropertyMethodStringName.module.js
+++ b/test/feature/Annotations/PropertyMethodStringName.module.js
@@ -8,5 +8,5 @@ class C {
   xyz() { return 1; }
 }
 
-assertArrayEquals([new Anno('x y z')], C.prototype['x y z'].annotations);
-assertArrayEquals([new Anno('xyz')], C.prototype.xyz.annotations);
+assertArrayEquals([new Anno('x y z')], C.prototype['x y z'].annotate);
+assertArrayEquals([new Anno('xyz')], C.prototype.xyz.annotate);

--- a/test/feature/Annotations/SimpleFunction.module.js
+++ b/test/feature/Annotations/SimpleFunction.module.js
@@ -4,4 +4,4 @@ import {Anno} from './resources/setup.js';
 @Anno
 function Simple() {}
 
-assertArrayEquals([new Anno], Simple.annotations);
+assertArrayEquals([new Anno], Simple.annotate);

--- a/test/feature/Annotations/StaticGetter.module.js
+++ b/test/feature/Annotations/StaticGetter.module.js
@@ -7,4 +7,4 @@ class StaticGetter {
 }
 
 assertArrayEquals([new Anno],
-    Object.getOwnPropertyDescriptor(StaticGetter, 'prop').get.annotations);
+    Object.getOwnPropertyDescriptor(StaticGetter, 'prop').get.annotate);

--- a/test/feature/Annotations/StaticMethod.module.js
+++ b/test/feature/Annotations/StaticMethod.module.js
@@ -6,5 +6,5 @@ class StaticMethod {
   static method(@Anno x) {}
 }
 
-assertArrayEquals([new Anno], StaticMethod.method.annotations);
+assertArrayEquals([new Anno], StaticMethod.method.annotate);
 assertArrayEquals([[new Anno]], StaticMethod.method.parameters);

--- a/test/feature/Annotations/StaticSetter.module.js
+++ b/test/feature/Annotations/StaticSetter.module.js
@@ -7,6 +7,6 @@ class StaticSetter {
 }
 
 assertArrayEquals([new Anno],
-    Object.getOwnPropertyDescriptor(StaticSetter, 'prop').set.annotations);
+    Object.getOwnPropertyDescriptor(StaticSetter, 'prop').set.annotate);
 assertArrayEquals([[new Anno]],
     Object.getOwnPropertyDescriptor(StaticSetter, 'prop').set.parameters);

--- a/test/feature/Annotations/UnannotatedUntypedFunction.js
+++ b/test/feature/Annotations/UnannotatedUntypedFunction.js
@@ -1,4 +1,4 @@
 function UnannotatedUntypedParams(x, y) {}
 
-assert(!UnannotatedUntypedParams.annotations);
+assert(!UnannotatedUntypedParams.annotate);
 assert(!UnannotatedUntypedParams.parameters);

--- a/test/feature/AtScript/AtScript.js
+++ b/test/feature/AtScript/AtScript.js
@@ -13,5 +13,5 @@ class Foo {
 
 var foo = new Foo(new Bar());
 
-assertArrayEquals([new Inject], Foo.annotations);
+assertArrayEquals([new Inject], Foo.annotate);
 assertArrayEquals([[Bar]], Foo.parameters);

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -1,4 +1,3 @@
-
 var traceurSystem = global.System;
 var System = require('../third_party/es6-module-loader/index').System;
 global.System = traceurSystem;
@@ -43,8 +42,8 @@ suite('instantiate', function() {
   test('Circular annotations', function(done) {
     System.import('./circular_annotation1.js').then(function(m1) {
       System.import('./circular_annotation2.js').then(function(m2) {
-        assert.instanceOf(m1.BarAnnotation.annotations[0], m2.FooAnnotation);
-        assert.instanceOf(m2.FooAnnotation.annotations[0], m1.BarAnnotation);
+        assert.instanceOf(m1.BarAnnotation.annotate[0], m2.FooAnnotation);
+        assert.instanceOf(m2.FooAnnotation.annotate[0], m1.BarAnnotation);
         done();
       }).catch(done);
     }).catch(done);


### PR DESCRIPTION
Brings name of annotations metadata in line with AtScript spec by changing name to 'annotate'.

resolve #1642 