### PR TITLE
Set runtime options by emitting code.

### DIFF
--- a/demo/await.html
+++ b/demo/await.html
@@ -27,7 +27,7 @@
 <div id="box">Traceur<br>Rocks!</div>
 
 <script>
-traceur.options.asyncFunctions = true;
+$traceurRuntime.options.asyncFunctions = true;
 </script>
 <script type="module">
 

--- a/demo/repl.js
+++ b/demo/repl.js
@@ -17,7 +17,7 @@ var vm = require('vm');
 var util = require('util');
 
 var traceur = require('../src/node/traceur.js');
-traceur.options.freeVariableChecker = false;
+$traceurRuntime.options.freeVariableChecker = false;
 
 // Debug functions.
 

--- a/src/Options.js
+++ b/src/Options.js
@@ -239,7 +239,7 @@ export class Options {
       if (this[key] !== ref[key]) {
         mismatches.push({
           key: key,
-          now: traceur.options[key],
+          now: $traceurRuntime.options[key],
           v01: ref[key]
         });
       }

--- a/src/WebPageTranscoder.js
+++ b/src/WebPageTranscoder.js
@@ -44,7 +44,7 @@ export class WebPageTranscoder {
   }
 
   addFileFromScriptElement(scriptElement, name, content) {
-    var options = traceur.options;
+    var options = $traceurRuntime.options;
     var nameInfo = {
       address: name,
       referrerName: window.location.href,

--- a/src/codegeneration/SymbolTransformer.js
+++ b/src/codegeneration/SymbolTransformer.js
@@ -41,6 +41,7 @@ import {
   parseExpression,
   parseStatement
 } from './PlaceholderParser.js';
+import {prependStatements} from './PrependStatements.js';
 
 
 class ExplodeSymbolExpression extends ExplodeExpressionTransformer {
@@ -101,10 +102,7 @@ var runtimeOption = parseStatement `$traceurRuntime.options.symbols = true`;
 export class SymbolTransformer extends TempVarTransformer {
 
   prependRuntimeOption_(scriptItemList) {
-    return [
-      runtimeOption,
-      ...scriptItemList
-    ];
+    return prependStatements(scriptItemList, runtimeOption);
   }
 
   transformModule(tree) {

--- a/src/codegeneration/SymbolTransformer.js
+++ b/src/codegeneration/SymbolTransformer.js
@@ -15,7 +15,9 @@
 import {
   BinaryExpression,
   MemberLookupExpression,
+  Module,
   ForInStatement,
+  Script,
   UnaryExpression
 } from '../syntax/trees/ParseTrees.js';
 import {ExplodeExpressionTransformer} from './ExplodeExpressionTransformer.js';
@@ -80,6 +82,8 @@ function isSafeTypeofString(tree) {
   return true;
 }
 
+var runtimeOption = parseStatement `$traceurRuntime.options.symbols = true`;
+
 /**
  * This transformer is used with symbol values to ensure that symbols can be
  * used as member expressions.
@@ -95,6 +99,25 @@ function isSafeTypeofString(tree) {
  *   operand[$traceurRuntime.toProperty(memberExpression)] = value
  */
 export class SymbolTransformer extends TempVarTransformer {
+
+  prependRuntimeOption_(scriptItemList) {
+    return [
+      runtimeOption,
+      ...scriptItemList
+    ];
+  }
+
+  transformModule(tree) {
+    return new Module(tree.location,
+        this.prependRuntimeOption_(this.transformList(tree.scriptItemList)),
+        this.moduleName_);
+  }
+
+  transformScript(tree) {
+    return new Script(tree.location,
+        this.prependRuntimeOption_(this.transformList(tree.scriptItemList)),
+        this.moduleName_);
+  }
 
   /**
    * Helper for the case where we only want to transform the operand of

--- a/src/codegeneration/SymbolTransformer.js
+++ b/src/codegeneration/SymbolTransformer.js
@@ -101,19 +101,17 @@ var runtimeOption = parseStatement `$traceurRuntime.options.symbols = true`;
  */
 export class SymbolTransformer extends TempVarTransformer {
 
-  prependRuntimeOption_(scriptItemList) {
-    return prependStatements(scriptItemList, runtimeOption);
-  }
-
   transformModule(tree) {
     return new Module(tree.location,
-        this.prependRuntimeOption_(this.transformList(tree.scriptItemList)),
+        prependStatements(this.transformList(tree.scriptItemList),
+            runtimeOption),
         this.moduleName_);
   }
 
   transformScript(tree) {
     return new Script(tree.location,
-        this.prependRuntimeOption_(this.transformList(tree.scriptItemList)),
+        prependStatements(this.transformList(tree.scriptItemList),
+            runtimeOption),
         this.moduleName_);
   }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -276,7 +276,6 @@
   }
 
   function getOption(name) {
-    //console.log('getOption ' + name, global.$traceurRuntime.options[name]);
     return global.$traceurRuntime.options[name];
   }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -276,7 +276,8 @@
   }
 
   function getOption(name) {
-    return global.traceur && global.traceur.options[name];
+    //console.log('getOption ' + name, global.$traceurRuntime.options[name]);
+    return global.$traceurRuntime.options[name];
   }
 
   function defineProperty(object, name, descriptor) {
@@ -370,6 +371,7 @@
     isPrivateName: isPrivateName,
     isSymbolString: isSymbolString,
     keys: $keys,
+    options: {},
     setupGlobals: setupGlobals,
     toObject: toObject,
     toProperty: toProperty,

--- a/test/feature/Symbol/Inherited.js
+++ b/test/feature/Symbol/Inherited.js
@@ -1,6 +1,8 @@
 // Options: --symbols
 'use strict';
 
+assert.equal($traceurRuntime.options.symbols, true);
+
 var s = Symbol();
 var p = {};
 Object.defineProperty(p, s, {

--- a/test/unit/Compiler.js
+++ b/test/unit/Compiler.js
@@ -22,7 +22,6 @@ suite('Compiler', function() {
   setup(function() {
     Compiler = get('src/Compiler.js').Compiler;
     versionLockedOptions = get('src/Options.js').versionLockedOptions;
-    $traceurRuntime.options.reset();
   });
 
   test('Compiler synchronous', function() {
@@ -51,7 +50,8 @@ suite('Compiler', function() {
         new Options({blockBinding: !versionLockedOptions.blockBinding});
     assert.equal(checkDiff.diff(versionLockedOptions).length, 1);
 
-    var mismatches = $traceurRuntime.options.diff(versionLockedOptions);
+    var options = new Options();
+    var mismatches = options.diff(versionLockedOptions);
     if (mismatches.length)
       console.error('Options changed ', mismatches);
     assert.equal(mismatches.length, 0);

--- a/test/unit/Compiler.js
+++ b/test/unit/Compiler.js
@@ -22,7 +22,7 @@ suite('Compiler', function() {
   setup(function() {
     Compiler = get('src/Compiler.js').Compiler;
     versionLockedOptions = get('src/Options.js').versionLockedOptions;
-    traceur.options.reset();
+    $traceurRuntime.options.reset();
   });
 
   test('Compiler synchronous', function() {
@@ -51,7 +51,7 @@ suite('Compiler', function() {
         new Options({blockBinding: !versionLockedOptions.blockBinding});
     assert.equal(checkDiff.diff(versionLockedOptions).length, 1);
 
-    var mismatches = traceur.options.diff(versionLockedOptions);
+    var mismatches = $traceurRuntime.options.diff(versionLockedOptions);
     if (mismatches.length)
       console.error('Options changed ', mismatches);
     assert.equal(mismatches.length, 0);

--- a/test/unit/node/api.js
+++ b/test/unit/node/api.js
@@ -15,11 +15,11 @@
 suite('api.js', function() {
 
   setup(function() {
-    traceur.options.reset();
+    $traceurRuntime.options.reset();
   });
 
   teardown(function() {
-    traceur.options.reset();
+    $traceurRuntime.options.reset();
   });
 
   test('api compile script function declaration', function() {

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -32,7 +32,7 @@ suite('context test', function() {
     if (tempMapName && fs.existsSync(tempMapName))
       fs.unlinkSync(tempMapName);
     tempMapName = null;
-    traceur.options.reset();
+    $traceurRuntime.options.reset();
   });
 
   function forwardSlash(s) {
@@ -236,7 +236,7 @@ suite('context test', function() {
     }];
     var cwd = process.cwd();
     traceur.System.baseURL = cwd;
-    recursiveCompile(tempFileName, rootSources, traceur.options)
+    recursiveCompile(tempFileName, rootSources, $traceurRuntime.options)
       .then(function () {
         assert.equal(process.cwd(), cwd);
         done();

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -30,7 +30,7 @@ suite('Loader.js', function() {
 
   teardown(function() {
     assert.isFalse(reporter.hadError());
-    traceur.options.reset();
+    $traceurRuntime.options.reset();
     System.baseURL = baseURL;
   });
 
@@ -73,13 +73,13 @@ suite('Loader.js', function() {
   test('traceur@', function() {
     var traceur = System.get('traceur@');
     var optionsModule = $traceurRuntime.ModuleStore.getForTesting('src/Options.js');
-    assert.equal(traceur.options, optionsModule.options);
+    assert.equal(traceur.util.Options, optionsModule.Options);
   });
 
   test('Loader.PreCompiledModule', function(done) {
     var traceur = System.get('traceur@');
     System.import('traceur@', {}).then(function(module) {
-      assert.equal(traceur.options, module.options);
+      assert.equal(traceur.util.options, module.util.options);
       done();
     }).catch(done);
   });
@@ -99,7 +99,7 @@ suite('Loader.js', function() {
     var metadata = {traceurOptions: {sourceMaps: true}};
     loader.script(src, {name: name, metadata: metadata}).then(
       function(result) {
-        traceur.options.sourceMaps = false;
+        $traceurRuntime.options.sourceMaps = false;
         var normalizedName = System.normalize(name);
         var sourceMap = loader.getSourceMap(normalizedName);
         assert(sourceMap, 'the sourceMap is defined');
@@ -244,7 +244,7 @@ suite('Loader.js', function() {
   // TODO: Update Traceur loader implementation to support new instantiate output
   /* test('LoaderDefine.Instantiate', function(done) {
     var loader = getLoader();
-    traceur.options.modules = 'instantiate';
+    $traceurRuntime.options.modules = 'instantiate';
     var name = './test_instantiate.js';
     var src = 'export {name as a} from \'./test_a.js\';\n' +
     'export var dd = 8;\n';
@@ -388,7 +388,7 @@ suite('Loader.js', function() {
     var src = "  import {name} from './test_a.js';";
 
     var loader = getLoader();
-    traceur.options.sourceMaps = true;
+    $traceurRuntime.options.sourceMaps = true;
 
     loader.module(src, {}).then(function (mod) {
       // TODO(jjb): where is the test that the source map exists?

--- a/test/unit/semantics/ConstChecker.js
+++ b/test/unit/semantics/ConstChecker.js
@@ -18,22 +18,23 @@ suite('ConstChecker.js', function() {
     return $traceurRuntime.ModuleStore.getForTesting(name);
   }
 
-  teardown(function() {
-    traceur.options.reset();
-  });
-
   var Parser = traceur.syntax.Parser;
   var SourceFile = traceur.syntax.SourceFile;
   var ErrorReporter = get('src/util/CollectingErrorReporter.js').CollectingErrorReporter;
   var validateConst = get('src/semantics/ConstChecker.js').validate;
+  var Options = get('src/Options.js').Options;
+
+  var options;
 
   function makeTest(name, code, expectedErrors, mode) {
     test(name, function() {
-      traceur.options.arrayComprehension = true;
-      traceur.options.blockBinding = true;
-      traceur.options.generatorComprehension = true;
+      options = new Options();
+      options.arrayComprehension = true;
+      options.blockBinding = true;
+      options.generatorComprehension = true;
       var reporter = new ErrorReporter();
-      var parser = new Parser(new SourceFile('SOURCE', code), reporter);
+      var parser =
+          new Parser(new SourceFile('SOURCE', code), reporter, options);
       var tree = mode === 'script' ?
           parser.parseScript() : parser.parseModule();
       assert.deepEqual(reporter.errors, []);

--- a/test/unit/semantics/FreeVariableChecker.js
+++ b/test/unit/semantics/FreeVariableChecker.js
@@ -22,11 +22,14 @@ suite('FreeVariableChecker.js', function() {
   var SourceFile = traceur.syntax.SourceFile;
   var ErrorReporter = get('src/util/CollectingErrorReporter.js').CollectingErrorReporter;
   var validateFreeVars = get('src/semantics/FreeVariableChecker.js').validate;
+  var Options = get('src/Options.js').Options;
+
+  var options;
 
   function makeTest(name, code, expectedErrors, global, mode) {
     test(name, function() {
       var reporter = new ErrorReporter();
-      var parser = new Parser(new SourceFile('CODE', code), reporter);
+      var parser = new Parser(new SourceFile('CODE', code), reporter, options);
       var tree = mode === 'module' ?
           parser.parseModule() : parser.parseScript();
       assert.deepEqual(reporter.errors, []);
@@ -37,14 +40,10 @@ suite('FreeVariableChecker.js', function() {
   }
 
   setup(function() {
-    traceur.options.reset();
-    traceur.options.arrayComprehension = true;
-    traceur.options.blockBinding = true;
-    traceur.options.generatorComprehension = true;
-  });
-
-  teardown(function() {
-    traceur.options.reset();
+    options = new Options();
+    options.arrayComprehension = true;
+    options.blockBinding = true;
+    options.generatorComprehension = true;
   });
 
   makeTest('basic', 'x', ['CODE:1:1: x is not defined']);

--- a/test/unit/semantics/VariableBinder.js
+++ b/test/unit/semantics/VariableBinder.js
@@ -15,7 +15,7 @@
 suite('VariableBinder.js', function() {
 
   teardown(function() {
-    traceur.options.experimental = false;
+    $traceurRuntime.options.experimental = false;
   });
 
   var ErrorReporter = traceur.util.ErrorReporter;
@@ -38,7 +38,7 @@ suite('VariableBinder.js', function() {
   }
 
   test('BoundIdentifiersInBlock', function() {
-    traceur.options.blockBinding = true;
+    $traceurRuntime.options.blockBinding = true;
     assert.equal('f', idsToString(variablesInBlock(parse(
         '{ function f(x) { var y; }; }'), false)));
     assert.equal('', idsToString(variablesInBlock(parse(

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -20,7 +20,7 @@ suite('parser.js', function() {
   };
 
   teardown(function() {
-    traceur.options.reset();
+    $traceurRuntime.options.reset();
   });
 
   test('Module', function() {
@@ -35,13 +35,14 @@ suite('parser.js', function() {
   });
 
   test('handleComment', function() {
-    traceur.options.commentCallback = true;
+    var options = new traceur.util.Options();
+    options.commentCallback = true;
 
     var program = '// AAA\n' +
                   'var b = \'c\';\n' +
                   '/* DDD */ function e() {}\n';
     var sourceFile = new traceur.syntax.SourceFile('Name', program);
-    var parser = new traceur.syntax.Parser(sourceFile, errorReporter);
+    var parser = new traceur.syntax.Parser(sourceFile, errorReporter, options);
     var comments = [];
     parser.handleComment = function(sourceRange) {
       comments.push(sourceRange);

--- a/test/unit/system/ScriptTypeTextTraceur.html
+++ b/test/unit/system/ScriptTypeTextTraceur.html
@@ -5,7 +5,7 @@
     <script src="../../../bin/traceur.js"></script>
     <script src="../../../src/bootstrap.js"></script>
     <script>
-        traceur.options.experimental = true;
+        $traceurRuntime.options.experimental = true;
     </script>
 </head>
 <body>


### PR DESCRIPTION
Removes `traceur.options` in favor of `$traceurRuntime.options`.
Only --symbols needs runtime options