### PR TITLE
Options as arguments everywhere.

### DIFF
--- a/demo/repl-module.js
+++ b/demo/repl-module.js
@@ -20,7 +20,7 @@ import {
 import {SourceMapConsumer}
     from 'traceur@0.0/src/outputgeneration/SourceMapIntegration.js';
 import {transcode, renderSourceMap} from './transcode.js';
-import {options as traceurOptions} from 'traceur@0.0/src/Options.js';
+import {Options} from 'traceur@0.0/src/Options.js';
 import {setOptionsFromSource} from './replOptions.js';
 
 var hasError = false;
@@ -90,11 +90,12 @@ var markingOptions = {
 };
 
 var currentSource;
+var options = new Options();
 var generatedMarker;
 var sourceMapOutput = document.querySelector('.source-map');
 
 function updateSourceMapVisualization(url) {
-  if (!traceurOptions.sourceMaps)
+  if (!options.sourceMaps)
     return;
   if (url)
     currentSource = url;
@@ -158,7 +159,7 @@ function compile() {
   var contents = input.getValue();
   updateLocation(contents);
   try {
-    traceurOptions.setFromObject(
+    options.setFromObject(
         setOptionsFromSource(contents, resetAndCompileContents));
     compileContents(contents);
   } catch (ex) {
@@ -171,7 +172,7 @@ function compile() {
 function resetAndCompileContents(contents, newOptions) {
   input.setValue(contents);
   updateLocation(contents);
-  traceurOptions.setFromObject(newOptions);
+  options.setFromObject(newOptions);
   compileContents(contents);
 }
 
@@ -198,7 +199,7 @@ function compileContents(contents) {
   }
 
   if (transcode)
-    transcode(contents, onTranscoded, onFailure);
+    transcode(contents, options, onTranscoded, onFailure);
 }
 
 if (location.hash) {

--- a/demo/transcode.js
+++ b/demo/transcode.js
@@ -18,7 +18,6 @@ import {
   SourceMapGenerator,
   SourceMapConsumer
 } from 'traceur@0.0/src/outputgeneration/SourceMapIntegration.js';
-import {options as traceurOptions} from 'traceur@0.0/src/Options.js';
 import {webLoader} from 'traceur@0.0/src/runtime/webLoader.js';
 
 class BatchErrorReporter extends ErrorReporter {
@@ -30,17 +29,17 @@ class BatchErrorReporter extends ErrorReporter {
   }
 }
 
-export function transcode(contents, onSuccess, onFailure) {
+export function transcode(contents, options, onSuccess, onFailure) {
   var url = location.href;
   var loadOptions = {
     address: 'traceured.js',
     metadata: {
-      traceurOptions: traceurOptions
+      traceurOptions: options
     }
   };
 
   var loader = new TraceurLoader(webLoader, url);
-  var load = traceurOptions.script ? loader.script : loader.module;
+  var load = options.script ? loader.script : loader.module;
   load.call(loader, contents, loadOptions).
       then(() => onSuccess(loadOptions.metadata),
           (error) => onFailure(error, loadOptions.metadata));

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -20,12 +20,7 @@ import {Parser} from './syntax/Parser.js';
 import {PureES6Transformer} from './codegeneration/PureES6Transformer.js';
 import {SourceFile} from './syntax/SourceFile.js';
 import {CollectingErrorReporter} from './util/CollectingErrorReporter.js';
-import {
-  Options,
-  options as traceurOptions,
-  versionLockedOptions
-} from './Options.js';
-
+import {Options, versionLockedOptions} from './Options.js';
 import {ParseTreeMapWriter} from './outputgeneration/ParseTreeMapWriter.js';
 import {ParseTreeWriter} from './outputgeneration/ParseTreeWriter.js';
 import {
@@ -179,12 +174,10 @@ export class Compiler {
     sourceName = this.normalize(sourceName);
     this.sourceMapCache_ = null;
     this.sourceMapConfiguration_ = null;
-    // Here we mutate the global/module options object to be used in parsing.
-    traceurOptions.setFromObject(this.options_);
 
     var errorReporter = new CollectingErrorReporter();
     var sourceFile = new SourceFile(sourceName, content);
-    var parser = new Parser(sourceFile, errorReporter);
+    var parser = new Parser(sourceFile, errorReporter, this.options_);
     var tree =
         this.options_.script ? parser.parseScript() : parser.parseModule();
     this.throwIfErrors(errorReporter);

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -223,7 +223,8 @@ export class Compiler {
     if (this.options_.outputLanguage.toLowerCase() === 'es6') {
       transformer = new PureES6Transformer(errorReporter);
     } else {
-      transformer = new FromOptionsTransformer(errorReporter);
+      transformer = new FromOptionsTransformer(errorReporter,
+          this.options_);
     }
 
     var transformedTree = transformer.transform(tree);

--- a/src/Options.js
+++ b/src/Options.js
@@ -68,7 +68,7 @@ export var optionsV01 = enumerableOnlyObject({
 export var versionLockedOptions = optionsV01;
 
 // Options are just a plain old object. There are two read only views on this
-// object, parseView() and transformView().
+// object, parseOptions and transformOptions.
 //
 // To set an option you do `options.classes = true`.
 //
@@ -77,8 +77,8 @@ export var versionLockedOptions = optionsV01;
 // will return false. For example:
 //
 //   options.destructuring = 'parse';
-//   options.parseView().destructuring === true;
-//   options.transformView().destructuring === false;
+//   options.parseOptions.destructuring === true;
+//   options.transformOptions.destructuring === false;
 //
 // This allows you to parse certain features without transforming them, leaving
 // the syntax intact in the output.
@@ -104,6 +104,14 @@ export class Options {
       sourceMaps_: {
         value: versionLockedOptions.sourceMaps,
         writable: true,
+        enumerable: false
+      },
+      transformOptions: {
+        value: new TransformOptions(this),
+        enumerable: false
+      },
+      parseOptions: {
+        value: new ParseOptions(this),
         enumerable: false
       }
     });
@@ -246,14 +254,6 @@ export class Options {
     return mismatches;
   }
 
-  transformView() {
-    return new TransformOptions(this);
-  }
-
-  parseView() {
-    return new ParseOptions(this);
-  }
-
 };
 
 
@@ -266,8 +266,7 @@ class ParseOptions {
         get: function() {
           return !!this.proxiedOptions_[name];
         },
-        enumerable: true,
-        configurable: true
+        enumerable: true
       });
     });
   }
@@ -285,8 +284,7 @@ class TransformOptions {
             return false;
           return v;
         }.bind(this),
-        enumerable: true,
-        configurable: true
+        enumerable: true
       });
     });
   }
@@ -464,8 +462,8 @@ var EXPERIMENTAL = 0;
 var ON_BY_DEFAULT = 1;
 
 /**
- * Adds a feature option.  Feature options can be tested with parseView()
- * and transformView().
+ * Adds a feature option.  Feature options can be tested with parseOptions
+ * and transformOptions.
  */
 function addFeatureOption(name, kind) {
   featureOptions[name] = true;

--- a/src/Options.js
+++ b/src/Options.js
@@ -246,24 +246,51 @@ export class Options {
     return mismatches;
   }
 
-  transformView(name) {
-    if (!featureOptions[name])
-      throw new Error(name + ' not a feature option, invalid to transformView');
-
-    var v = this[name];
-    if (v === 'parse')
-      return false;
-    return v;
+  transformView() {
+    return new TransformOptions(this);
   }
 
-  parseView(name) {
-    if (!featureOptions[name])
-      throw new Error(name + ' not a feature option, invalid to parseView');
-
-    return !!this[name];
+  parseView() {
+    retuirn new ParseOptions(this);
   }
 
 };
+
+
+class ParseOptions {
+  constructor(options) {
+    this.proxiedOptions_ = options;
+
+    featureOptions.forEach((name) => {
+      Object.defineProperty(this, name, {
+        get: function() {
+          return !!this.proxiedOptions_[name];
+        },
+        enumerable: true,
+        configurable: true
+      });
+    });
+  }
+}
+
+class TransformOptions {
+  constructor(options) {
+    this.proxiedOptions_ = options;
+
+    featureOptions.forEach((name) => {
+      Object.defineProperty(this, name, {
+        get: function() {
+          var v = this.proxiedOptions_[name];
+          if (v === 'parse')
+            return false;
+          return v;
+        },
+        enumerable: true,
+        configurable: true
+      });
+    });
+  }
+}
 
 
 // A distinguish instance shared internally via module

--- a/src/Options.js
+++ b/src/Options.js
@@ -338,8 +338,6 @@ export class CommandOptions extends Options {
     var re = /--([^=]+)(?:=(.+))?/;
     var m = re.exec(s);
 
-    console.log('parseCommand ', s)
-
     if (m)
       this.setOptionCoerced(m[1], m[2]);
   }
@@ -350,7 +348,7 @@ export class CommandOptions extends Options {
       value = coerceOptionValue(value);
     else
       value = true;
-if (name === 'typeAssertionModule') console.log('setOptionCoerced ' + name, value)
+
     this.setOption(name,  value);
   }
 

--- a/src/Options.js
+++ b/src/Options.js
@@ -234,7 +234,7 @@ export class Options {
 
   diff(ref) {
     var mismatches = [];
-    Object.keys(options).forEach((key) => {
+    Object.keys(this).forEach((key) => {
       if (this[key] !== ref[key]) {
         mismatches.push({
           key: key,
@@ -291,12 +291,6 @@ class TransformOptions {
     });
   }
 }
-
-
-// A distinguish instance shared internally via module
-//
-export var options = new Options();
-
 
 // TODO: Refactor this so that we can keep all of these in one place.
 var descriptions = {
@@ -479,8 +473,7 @@ function addFeatureOption(name, kind) {
   if (kind === EXPERIMENTAL)
     experimentalOptions[name] = true;
 
-  var defaultValue = options[name] || kind === ON_BY_DEFAULT;
-  options[name] = defaultValue;
+  var defaultValue = kind === ON_BY_DEFAULT;
   defaultValues[name] = defaultValue;
 }
 
@@ -489,7 +482,6 @@ function addFeatureOption(name, kind) {
  */
 function addBoolOption(name) {
   defaultValues[name] = false;
-  options[name] = false;
 }
 
 // ON_BY_DEFAULT

--- a/src/Options.js
+++ b/src/Options.js
@@ -77,8 +77,8 @@ export var versionLockedOptions = optionsV01;
 // will return false. For example:
 //
 //   options.destructuring = 'parse';
-//   parseView('destructuring') === true;
-//   transformView('destructuring') === false;
+//   options.parseView().destructuring === true;
+//   options.transformView().destructuring === false;
 //
 // This allows you to parse certain features without transforming them, leaving
 // the syntax intact in the output.
@@ -251,7 +251,7 @@ export class Options {
   }
 
   parseView() {
-    retuirn new ParseOptions(this);
+    return new ParseOptions(this);
   }
 
 };
@@ -261,7 +261,7 @@ class ParseOptions {
   constructor(options) {
     this.proxiedOptions_ = options;
 
-    featureOptions.forEach((name) => {
+    Object.keys(featureOptions).forEach((name) => {
       Object.defineProperty(this, name, {
         get: function() {
           return !!this.proxiedOptions_[name];
@@ -277,14 +277,14 @@ class TransformOptions {
   constructor(options) {
     this.proxiedOptions_ = options;
 
-    featureOptions.forEach((name) => {
+    Object.keys(featureOptions).forEach((name) => {
       Object.defineProperty(this, name, {
         get: function() {
           var v = this.proxiedOptions_[name];
           if (v === 'parse')
             return false;
           return v;
-        },
+        }.bind(this),
         enumerable: true,
         configurable: true
       });
@@ -338,6 +338,8 @@ export class CommandOptions extends Options {
     var re = /--([^=]+)(?:=(.+))?/;
     var m = re.exec(s);
 
+    console.log('parseCommand ', s)
+
     if (m)
       this.setOptionCoerced(m[1], m[2]);
   }
@@ -348,7 +350,7 @@ export class CommandOptions extends Options {
       value = coerceOptionValue(value);
     else
       value = true;
-
+if (name === 'typeAssertionModule') console.log('setOptionCoerced ' + name, value)
     this.setOption(name,  value);
   }
 

--- a/src/codegeneration/AmdTransformer.js
+++ b/src/codegeneration/AmdTransformer.js
@@ -28,8 +28,8 @@ import scopeContainsThis from './scopeContainsThis.js';
 
 export class AmdTransformer extends ModuleTransformer {
 
-  constructor(identifierGenerator) {
-    super(identifierGenerator);
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator, reporter, options);
     this.dependencies = [];
   }
 

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -140,7 +140,7 @@ export class ClassTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    * @param {ErrorReporter} reporter
-   * @param {boolean} showDebugNames options.debugNames
+   * @param {Options} options
    */
   constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -114,7 +114,6 @@ function classCall(func, object, staticObject, superClass) {
       `($traceurRuntime.createClass)(${func}, ${object}, ${staticObject})`;
 }
 
-<<<<<<< HEAD
 function methodNameFromTree(tree) {
   // COMPUTED_PROPERTY_NAME such as [Symbol.iterator]
   if (tree.type === COMPUTED_PROPERTY_NAME) {
@@ -137,12 +136,13 @@ function classMethodDebugName(className, methodName, isStatic) {
   return createBindingIdentifier('$__' + className + '_prototype_' + methodName);
 }
 
-export class ClassTransformer extends TempVarTransformer{
+export class ClassTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    * @param {ErrorReporter} reporter
-   * @param {Options} options
+   * @param {boolean} showDebugNames options.debugNames
    */
+  constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
     this.options_ = options;
     this.strictCount_ = 0;

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -64,7 +64,6 @@ import {
   parseStatements
 } from './PlaceholderParser.js';
 import {propName} from '../staticsemantics/PropName.js';
-import {options} from '../Options.js';
 import {prependStatements} from './PrependStatements.js';
 
 // Interaction between ClassTransformer and SuperTransformer:
@@ -115,6 +114,7 @@ function classCall(func, object, staticObject, superClass) {
       `($traceurRuntime.createClass)(${func}, ${object}, ${staticObject})`;
 }
 
+<<<<<<< HEAD
 function methodNameFromTree(tree) {
   // COMPUTED_PROPERTY_NAME such as [Symbol.iterator]
   if (tree.type === COMPUTED_PROPERTY_NAME) {
@@ -141,14 +141,14 @@ export class ClassTransformer extends TempVarTransformer{
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    * @param {ErrorReporter} reporter
-   * @param {boolean} showDebugNames options.debugNames
+   * @param {Options} options
    */
-  constructor(identifierGenerator, reporter, debugNames) {
     super(identifierGenerator);
+    this.options_ = options;
     this.strictCount_ = 0;
     this.state_ = null;
     this.reporter_ = reporter;
-    this.showDebugNames_ = debugNames;
+    this.showDebugNames_ = options.debugNames;
   }
 
   // Override to handle AnonBlock
@@ -255,7 +255,7 @@ export class ClassTransformer extends TempVarTransformer{
     if (!hasConstructor) {
       func = this.getDefaultConstructor_(tree, internalName, initStatements);
     } else {
-      if (options.memberVariables) {
+      if (this.options_.memberVariables) {
         constructor = this.appendInstanceInitializers_(constructor,
             initStatements, tree.superClass);
       }

--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -43,8 +43,8 @@ import {prependStatements} from './PrependStatements.js';
 
 export class CommonJsModuleTransformer extends ModuleTransformer {
 
-  constructor(identifierGenerator) {
-    super(identifierGenerator);
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator, reporter, options);
     this.moduleVars_ = [];
   }
 

--- a/src/codegeneration/ComprehensionTransformer.js
+++ b/src/codegeneration/ComprehensionTransformer.js
@@ -34,7 +34,6 @@ import {
   createParenExpression,
   createVariableDeclarationList
 } from './ParseTreeFactory.js';
-import {options} from '../Options.js';
 
 /**
  * Base class for GeneratorComprehensionTransformer and
@@ -43,6 +42,10 @@ import {options} from '../Options.js';
  * See subclasses for details on desugaring.
  */
 export class ComprehensionTransformer extends TempVarTransformer {
+  constructor(idGenerator, reporter, options) {
+    super(idGenerator);
+    this.options_ = options;
+  }
   /**
    * transformArrayComprehension and transformGeneratorComprehension calls
    * this
@@ -59,7 +62,7 @@ export class ComprehensionTransformer extends TempVarTransformer {
 
     // This should really be a let but we don't support let in generators.
     // https://code.google.com/p/traceur-compiler/issues/detail?id=6
-    var bindingKind = isGenerator || !options.blockBinding ? VAR : LET;
+    var bindingKind = isGenerator || !this.options_.blockBinding ? VAR : LET;
 
     var statements = prefix ? [prefix] : [];
 

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -59,7 +59,6 @@ import {
   createVariableDeclarationList,
   createVariableStatement
 } from './ParseTreeFactory.js';
-import {options} from '../Options.js';
 import {parseExpression} from './PlaceholderParser.js';
 import {prependStatements} from './PrependStatements.js'
 
@@ -163,8 +162,9 @@ export class DestructuringTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
-  constructor(identifierGenerator) {
+  constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
+    this.options_ = options;
     this.parameterDeclarations = null;
   }
 
@@ -410,7 +410,7 @@ export class DestructuringTransformer extends TempVarTransformer {
 
     var body = this.transformAny(tree.catchBody);
     var statements = [];
-    var kind = options.blockBinding ? LET : VAR;
+    var kind = this.options_.blockBinding ? LET : VAR;
     var binding = this.desugarBinding_(tree.binding, statements, kind);
     statements.push(...body.statements);
     return new Catch(tree.location, binding, createBlock(statements));

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -154,7 +154,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       append(ClassTransformer);
 
     if (options.transformView('propertyMethods') ||
-              options.transformView('computedPropertyNames')) {
+        options.transformView('computedPropertyNames')) {
       append(ObjectLiteralTransformer);
     }
 

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -61,6 +61,8 @@ export class FromOptionsTransformer extends MultiTransformer {
    */
   constructor(reporter, options) {
     super(reporter, options.validate);
+    var transformOptions = options.transformView();
+    var idGenerator = new UniqueIdentifierGenerator();
 
     var append = (transformer) => {
       this.append((tree) => {
@@ -109,8 +111,11 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (options.typeAssertions) {
       // Transforming member variabless to getters/setters only make
       // sense when the type assertions are enabled.
-      if (options.memberVariables) append(MemberVariableTransformer);
-      append(TypeAssertionTransformer);
+      if (transformOptions.memberVariables) append(MemberVariableTransformer);
+      this.append((tree) => {
+        return new TypeAssertionTransformer(idGenerator, reporter, options).
+            transformAny(tree);
+      });
     }
 
     // PropertyNameShorthandTransformer needs to come before

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -49,7 +49,6 @@ import {TypeAssertionTransformer} from './TypeAssertionTransformer.js';
 import {TypeToExpressionTransformer} from './TypeToExpressionTransformer.js';
 import {UnicodeEscapeSequenceTransformer} from './UnicodeEscapeSequenceTransformer.js';
 import {UniqueIdentifierGenerator} from './UniqueIdentifierGenerator.js';
-import {options, transformOptions} from '../Options.js';
 
 /**
  * MultiTransformer built from global options settings
@@ -66,7 +65,8 @@ export class FromOptionsTransformer extends MultiTransformer {
 
     var append = (transformer) => {
       this.append((tree) => {
-        return new transformer(idGenerator, reporter).transformAny(tree);
+        return new transformer(idGenerator, reporter, options).
+            transformAny(tree);
       });
     };
 

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -68,7 +68,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       });
     };
 
-    if (options.transformView('blockBinding')) {
+    if (transformOptions.blockBinding) {
       this.append((tree) => {
         validateConst(tree, reporter);
         return tree;
@@ -85,25 +85,25 @@ export class FromOptionsTransformer extends MultiTransformer {
 
     // TODO: many of these simple, local transforms could happen in the same
     // tree pass
-    if (options.transformView('exponentiation'))
+    if (transformOptions.exponentiation)
       append(ExponentiationTransformer);
 
-    if (options.transformView('numericLiterals'))
+    if (transformOptions.numericLiterals)
       append(NumericLiteralTransformer);
 
-    if (options.transformView('unicodeExpressions'))
+    if (transformOptions.unicodeExpressions)
       append(RegularExpressionTransformer);
 
-    if (options.transformView('templateLiterals'))
+    if (transformOptions.templateLiterals)
       append(TemplateLiteralTransformer);
 
-    if (options.transformView('types'))
+    if (transformOptions.types)
       append(TypeToExpressionTransformer);
 
-    if (options.transformView('unicodeEscapeSequences'))
+    if (transformOptions.unicodeEscapeSequences)
       append(UnicodeEscapeSequenceTransformer);
 
-    if (options.transformView('annotations'))
+    if (transformOptions.annotations)
       append(AnnotationsTransformer);
 
     if (options.typeAssertions) {
@@ -117,11 +117,11 @@ export class FromOptionsTransformer extends MultiTransformer {
     // module transformers. See #1120 or
     // test/node-instantiate-test.js test "Shorthand syntax with import"
     // for detailed info.
-    if (options.transformView('propertyNameShorthand'))
+    if (transformOptions.propertyNameShorthand)
       append(PropertyNameShorthandTransformer);
 
-    if (options.transformView('modules')) {
-      switch (options.transformView('modules')) {
+    if (transformOptions.modules) {
+      switch (transformOptions.modules) {
         case 'commonjs':
           append(CommonJsModuleTransformer);
           break;
@@ -146,51 +146,51 @@ export class FromOptionsTransformer extends MultiTransformer {
       }
     }
 
-    if (options.transformView('arrowFunctions'))
+    if (transformOptions.arrowFunctions)
       append(ArrowFunctionTransformer);
 
     // ClassTransformer needs to come before ObjectLiteralTransformer.
-    if (options.transformView('classes'))
+    if (transformOptions.classes)
       append(ClassTransformer);
 
-    if (options.transformView('propertyMethods') ||
-        options.transformView('computedPropertyNames')) {
+    if (transformOptions.propertyMethods ||
+              transformOptions.computedPropertyNames) {
       append(ObjectLiteralTransformer);
     }
 
     // Generator/ArrayComprehensionTransformer must come before for-of and
     // destructuring.
-    if (options.transformView('generatorComprehension'))
+    if (transformOptions.generatorComprehension)
       append(GeneratorComprehensionTransformer);
-    if (options.transformView('arrayComprehension'))
+    if (transformOptions.arrayComprehension)
       append(ArrayComprehensionTransformer);
 
     // for of must come before destructuring and generator, or anything
     // that wants to use VariableBinder
-    if (options.transformView('forOf'))
+    if (transformOptions.forOf)
       append(ForOfTransformer);
 
     // rest parameters must come before generator
-    if (options.transformView('restParameters'))
+    if (transformOptions.restParameters)
       append(RestParameterTransformer);
 
     // default parameters should come after rest parameter to get the
     // expected order in the transformed code.
-    if (options.transformView('defaultParameters'))
+    if (transformOptions.defaultParameters)
       append(DefaultParametersTransformer);
 
     // destructuring must come after for of and before block binding and
     // generator
-    if (options.transformView('destructuring'))
+    if (transformOptions.destructuring)
       append(DestructuringTransformer);
 
-    if (options.transformView('types'))
+    if (transformOptions.types)
       append(TypeTransformer);
 
-    if (options.transformView('spread'))
+    if (transformOptions.spread)
       append(SpreadTransformer);
 
-    if (options.transformView('blockBinding')) {
+    if (transformOptions.blockBinding) {
       this.append((tree) => {
         // this transformer need to be aware of the tree it will be working on
         var transformer = new BlockBindingTransformer(idGenerator, reporter, tree);
@@ -199,11 +199,10 @@ export class FromOptionsTransformer extends MultiTransformer {
     }
 
     // generator must come after for of and rest parameters
-    if (options.transformView('generators') ||
-        options.transformView('asyncFunctions'))
+    if (transformOptions.generators || transformOptions.asyncFunctions)
       append(GeneratorTransformPass);
 
-    if (options.transformView('symbols'))
+    if (transformOptions.symbols)
       append(SymbolTransformer);
   }
 }

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -57,9 +57,9 @@ import {options, transformOptions} from '../Options.js';
 export class FromOptionsTransformer extends MultiTransformer {
   /**
    * @param {ErrorReporter} reporter
-   * @param {UniqueIdentifierGenerator=} idGenerator
+   * @param {Options} options
    */
-  constructor(reporter, idGenerator = new UniqueIdentifierGenerator()) {
+  constructor(reporter, options) {
     super(reporter, options.validate);
 
     var append = (transformer) => {
@@ -68,7 +68,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       });
     };
 
-    if (transformOptions.blockBinding) {
+    if (options.transformView('blockBinding')) {
       this.append((tree) => {
         validateConst(tree, reporter);
         return tree;
@@ -85,25 +85,25 @@ export class FromOptionsTransformer extends MultiTransformer {
 
     // TODO: many of these simple, local transforms could happen in the same
     // tree pass
-    if (transformOptions.exponentiation)
+    if (options.transformView('exponentiation'))
       append(ExponentiationTransformer);
 
-    if (transformOptions.numericLiterals)
+    if (options.transformView('numericLiterals'))
       append(NumericLiteralTransformer);
 
-    if (transformOptions.unicodeExpressions)
+    if (options.transformView('unicodeExpressions'))
       append(RegularExpressionTransformer);
 
-    if (transformOptions.templateLiterals)
+    if (options.transformView('templateLiterals'))
       append(TemplateLiteralTransformer);
 
-    if (transformOptions.types)
+    if (options.transformView('types'))
       append(TypeToExpressionTransformer);
 
-    if (transformOptions.unicodeEscapeSequences)
+    if (options.transformView('unicodeEscapeSequences'))
       append(UnicodeEscapeSequenceTransformer);
 
-    if (transformOptions.annotations)
+    if (options.transformView('annotations'))
       append(AnnotationsTransformer);
 
     if (options.typeAssertions) {
@@ -117,11 +117,11 @@ export class FromOptionsTransformer extends MultiTransformer {
     // module transformers. See #1120 or
     // test/node-instantiate-test.js test "Shorthand syntax with import"
     // for detailed info.
-    if (transformOptions.propertyNameShorthand)
+    if (options.transformView('propertyNameShorthand'))
       append(PropertyNameShorthandTransformer);
 
-    if (transformOptions.modules) {
-      switch (transformOptions.modules) {
+    if (options.transformView('modules')) {
+      switch (options.transformView('modules')) {
         case 'commonjs':
           append(CommonJsModuleTransformer);
           break;
@@ -146,51 +146,51 @@ export class FromOptionsTransformer extends MultiTransformer {
       }
     }
 
-    if (transformOptions.arrowFunctions)
+    if (options.transformView('arrowFunctions'))
       append(ArrowFunctionTransformer);
 
     // ClassTransformer needs to come before ObjectLiteralTransformer.
-    if (transformOptions.classes)
+    if (options.transformView('classes'))
       append(ClassTransformer);
 
-    if (transformOptions.propertyMethods ||
-              transformOptions.computedPropertyNames) {
+    if (options.transformView('propertyMethods') ||
+              options.transformView('computedPropertyNames')) {
       append(ObjectLiteralTransformer);
     }
 
     // Generator/ArrayComprehensionTransformer must come before for-of and
     // destructuring.
-    if (transformOptions.generatorComprehension)
+    if (options.transformView('generatorComprehension'))
       append(GeneratorComprehensionTransformer);
-    if (transformOptions.arrayComprehension)
+    if (options.transformView('arrayComprehension'))
       append(ArrayComprehensionTransformer);
 
     // for of must come before destructuring and generator, or anything
     // that wants to use VariableBinder
-    if (transformOptions.forOf)
+    if (options.transformView('forOf'))
       append(ForOfTransformer);
 
     // rest parameters must come before generator
-    if (transformOptions.restParameters)
+    if (options.transformView('restParameters'))
       append(RestParameterTransformer);
 
     // default parameters should come after rest parameter to get the
     // expected order in the transformed code.
-    if (transformOptions.defaultParameters)
+    if (options.transformView('defaultParameters'))
       append(DefaultParametersTransformer);
 
     // destructuring must come after for of and before block binding and
     // generator
-    if (transformOptions.destructuring)
+    if (options.transformView('destructuring'))
       append(DestructuringTransformer);
 
-    if (transformOptions.types)
+    if (options.transformView('types'))
       append(TypeTransformer);
 
-    if (transformOptions.spread)
+    if (options.transformView('spread'))
       append(SpreadTransformer);
 
-    if (transformOptions.blockBinding) {
+    if (options.transformView('blockBinding')) {
       this.append((tree) => {
         // this transformer need to be aware of the tree it will be working on
         var transformer = new BlockBindingTransformer(idGenerator, reporter, tree);
@@ -199,10 +199,11 @@ export class FromOptionsTransformer extends MultiTransformer {
     }
 
     // generator must come after for of and rest parameters
-    if (transformOptions.generators || transformOptions.asyncFunctions)
+    if (options.transformView('generators') ||
+        options.transformView('asyncFunctions'))
       append(GeneratorTransformPass);
 
-    if (transformOptions.symbols)
+    if (options.transformView('symbols'))
       append(SymbolTransformer);
   }
 }

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -60,7 +60,7 @@ export class FromOptionsTransformer extends MultiTransformer {
    */
   constructor(reporter, options) {
     super(reporter, options.validate);
-    var transformOptions = options.transformView();
+    var transformOptions = options.transformOptions;
     var idGenerator = new UniqueIdentifierGenerator();
 
     var append = (transformer) => {
@@ -112,10 +112,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       // Transforming member variabless to getters/setters only make
       // sense when the type assertions are enabled.
       if (transformOptions.memberVariables) append(MemberVariableTransformer);
-      this.append((tree) => {
-        return new TypeAssertionTransformer(idGenerator, reporter, options).
-            transformAny(tree);
-      });
+      append(TypeAssertionTransformer);
     }
 
     // PropertyNameShorthandTransformer needs to come before

--- a/src/codegeneration/GeneratorTransformPass.js
+++ b/src/codegeneration/GeneratorTransformPass.js
@@ -56,10 +56,7 @@ export class GeneratorTransformPass extends TempVarTransformer {
   constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
     this.reporter_ = reporter;
-    this.tranformOptions_ = {
-      generators: options.transformView('generators'),
-      asyncFunctions: options.transformView('asyncFunctions')
-    };
+    this.tranformOptions_ = options.transformOptions;
     this.inBlock_ = false;
   }
 

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -110,7 +110,7 @@ export class ModuleTransformer extends TempVarTransformer {
 
   wrapModule(statements) {
     var functionExpression;
-    if (this.options_.transformView().require) {
+    if (this.options_.transformOptions.require) {
       functionExpression = parseExpression `function(require) {
         ${statements}
       }`;
@@ -297,8 +297,8 @@ export class ModuleTransformer extends TempVarTransformer {
 
     // If destructuring patterns are kept in the output code, keep this as is,
     // otherwise transform it here.
-    if (this.options_.transformView().destructuring ||
-        !this.options_.parseView().destructuring) {
+    if (this.options_.transformOptions.destructuring ||
+        !this.options_.parseOptions.destructuring) {
       var destructuringTransformer =
           new DestructImportVarStatement(this.identifierGenerator);
       varStatement = varStatement.transform(destructuringTransformer);

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -110,7 +110,7 @@ export class ModuleTransformer extends TempVarTransformer {
 
   wrapModule(statements) {
     var functionExpression;
-    if (this.options_.transformView('require')) {
+    if (this.options_.transformView().require) {
       functionExpression = parseExpression `function(require) {
         ${statements}
       }`;
@@ -297,8 +297,8 @@ export class ModuleTransformer extends TempVarTransformer {
 
     // If destructuring patterns are kept in the output code, keep this as is,
     // otherwise transform it here.
-    if (this.options_.transformView('destructuring') ||
-        !this.options_.parseView('destructuring')) {
+    if (this.options_.transformView().destructuring ||
+        !this.options_.parseView().destructuring) {
       var destructuringTransformer =
           new DestructImportVarStatement(this.identifierGenerator);
       varStatement = varStatement.transform(destructuringTransformer);

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -44,10 +44,6 @@ import {
   createVariableStatement,
 } from './ParseTreeFactory.js';
 import {
-  parseOptions,
-  transformOptions
-} from '../Options.js';
-import {
   parseExpression,
   parsePropertyDefinition,
   parseStatement,
@@ -64,8 +60,9 @@ export class ModuleTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
-  constructor(identifierGenerator) {
+  constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
+    this.options_ = options;
     this.exportVisitor_ = new DirectExportVisitor();
     this.moduleSpecifierKind_ = null;
     this.moduleName = null;
@@ -113,7 +110,7 @@ export class ModuleTransformer extends TempVarTransformer {
 
   wrapModule(statements) {
     var functionExpression;
-    if (transformOptions.require) {
+    if (this.options_.transformView('require')) {
       functionExpression = parseExpression `function(require) {
         ${statements}
       }`;
@@ -300,7 +297,8 @@ export class ModuleTransformer extends TempVarTransformer {
 
     // If destructuring patterns are kept in the output code, keep this as is,
     // otherwise transform it here.
-    if (transformOptions.destructuring || !parseOptions.destructuring) {
+    if (this.options_.transformView('destructuring') ||
+        !this.options_.parseView('destructuring')) {
       var destructuringTransformer =
           new DestructImportVarStatement(this.identifierGenerator);
       varStatement = varStatement.transform(destructuringTransformer);

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -58,7 +58,7 @@ class FindAdvancedProperty extends FindVisitor {
   }
 
   visitComputedPropertyName(tree) {
-    if (this.options_.transformView('computedPropertyNames'))
+    if (this.options_.transformView().computedPropertyNames)
       this.found = true;
   }
 }

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -58,7 +58,7 @@ class FindAdvancedProperty extends FindVisitor {
   }
 
   visitComputedPropertyName(tree) {
-    if (this.options_.transformView().computedPropertyNames)
+    if (this.options_.transformOptions.computedPropertyNames)
       this.found = true;
   }
 }

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -38,15 +38,15 @@ import {
   createStringLiteral
 } from './ParseTreeFactory.js';
 import {propName} from '../staticsemantics/PropName.js';
-import {transformOptions} from '../Options.js';
 
 /**
  * FindAdvancedProperty class that finds if an object literal contains a
  * computed property name, an at name or a __proto__ property.
  */
 class FindAdvancedProperty extends FindVisitor {
-  constructor() {
+  constructor(options) {
     super(true);
+    this.options_ = options;
     this.protoExpression = null;
   }
 
@@ -58,7 +58,7 @@ class FindAdvancedProperty extends FindVisitor {
   }
 
   visitComputedPropertyName(tree) {
-    if (transformOptions.computedPropertyNames)
+    if (this.options_.transformView('computedPropertyNames'))
       this.found = true;
   }
 }
@@ -79,8 +79,9 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
-  constructor(identifierGenerator) {
+  constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
+    this.options_ = options;
     this.protoExpression = null;
     this.needsAdvancedTransform = false;
     this.seenAccessors = null;
@@ -182,7 +183,7 @@ export class ObjectLiteralTransformer extends TempVarTransformer {
     var oldSeenAccessors = this.seenAccessors;
 
     try {
-      var finder = new FindAdvancedProperty();
+      var finder = new FindAdvancedProperty(this.options_);
       finder.visitAny(tree);
       if (!finder.found) {
         this.needsAdvancedTransform = false;

--- a/src/codegeneration/PureES6Transformer.js
+++ b/src/codegeneration/PureES6Transformer.js
@@ -18,7 +18,6 @@ import {MultiTransformer} from './MultiTransformer.js';
 import {TypeAssertionTransformer} from './TypeAssertionTransformer.js';
 import {TypeTransformer} from './TypeTransformer.js';
 import {UniqueIdentifierGenerator} from './UniqueIdentifierGenerator.js';
-import {options} from '../Options.js';
 import {validate as validateFreeVariables} from
     '../semantics/FreeVariableChecker.js';
 
@@ -32,10 +31,11 @@ import {validate as validateFreeVariables} from
 export class PureES6Transformer extends MultiTransformer {
   /**
    * @param {ErrorReporter} reporter
-   * @param {UniqueIdentifierGenerator=} idGenerator
+   * @param {Options} options
    */
-  constructor(reporter, idGenerator = new UniqueIdentifierGenerator()) {
+  constructor(reporter, options) {
     super(reporter, options.validate);
+    var idGenerator = new UniqueIdentifierGenerator();
 
     var append = (transformer) => {
       this.append((tree) => {

--- a/src/codegeneration/TypeAssertionTransformer.js
+++ b/src/codegeneration/TypeAssertionTransformer.js
@@ -232,7 +232,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
   prependAssertionImport_(tree, Ctor) {
     if (!this.assertionAdded_ || this.options_.typeAssertionModule === null)
       return tree;
-console.log('prependAssertionImport_')
+
     var binding = createImportedBinding('assert');
     var importStatement = new ImportDeclaration(null,
         new ImportSpecifierSet(null,

--- a/src/codegeneration/TypeAssertionTransformer.js
+++ b/src/codegeneration/TypeAssertionTransformer.js
@@ -232,7 +232,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
   prependAssertionImport_(tree, Ctor) {
     if (!this.assertionAdded_ || this.options_.typeAssertionModule === null)
       return tree;
-
+console.log('prependAssertionImport_')
     var binding = createImportedBinding('assert');
     var importStatement = new ImportDeclaration(null,
         new ImportSpecifierSet(null,

--- a/src/codegeneration/TypeAssertionTransformer.js
+++ b/src/codegeneration/TypeAssertionTransformer.js
@@ -36,7 +36,6 @@ import {
   parseStatement
 } from './PlaceholderParser.js';
 import {ParameterTransformer} from './ParameterTransformer.js';
-import {options} from '../Options.js';
 
 /**
  * Inserts runtime type assertions for type annotations.
@@ -58,8 +57,9 @@ export class TypeAssertionTransformer extends ParameterTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
-  constructor(identifierGenerator) {
+  constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
+    this.options_ = options;
     this.returnTypeStack_ = [];
     this.parametersStack_ = [];
     this.assertionAdded_ = false;
@@ -216,7 +216,9 @@ export class TypeAssertionTransformer extends ParameterTransformer {
         typeAnnotation = parseExpression `$traceurRuntime.type.any`;
       }
 
-      this.paramTypes_.arguments.push(createIdentifierExpression(element.binding.identifierToken), typeAnnotation);
+      this.paramTypes_.arguments.push(
+        createIdentifierExpression(element.binding.identifierToken),
+        typeAnnotation);
       return;
     }
 
@@ -228,7 +230,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
   }
 
   prependAssertionImport_(tree, Ctor) {
-    if (!this.assertionAdded_ || options.typeAssertionModule === null)
+    if (!this.assertionAdded_ || this.options_.typeAssertionModule === null)
       return tree;
 
     var binding = createImportedBinding('assert');
@@ -236,7 +238,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
         new ImportSpecifierSet(null,
             [new ImportSpecifier(null, binding, null)]),
         new ModuleSpecifier(null,
-            createStringLiteralToken(options.typeAssertionModule)));
+            createStringLiteralToken(this.options_.typeAssertionModule)));
     tree = new Ctor(tree.location,
                     [importStatement, ...tree.scriptItemList],
                     tree.moduleName);

--- a/src/codegeneration/module/ExportListBuilder.js
+++ b/src/codegeneration/module/ExportListBuilder.js
@@ -14,7 +14,6 @@
 
 import {ExportVisitor} from './ExportVisitor.js';
 import {ValidationVisitor} from './ValidationVisitor.js';
-import {transformOptions} from '../../Options.js';
 
 // TODO(arv): Validate that there are no free variables
 // TODO(arv): Validate that the exported reference exists
@@ -25,9 +24,7 @@ import {transformOptions} from '../../Options.js';
  * @param {Loader} loader
  * @return {void}
  */
-export function buildExportList(deps, loader, reporter) {
-  if (!transformOptions.modules)
-    return;
+export function buildExportList(deps, loader, reporter, options) {
 
   function doVisit(ctor) {
     for (var i = 0; i < deps.length; i++) {

--- a/src/codegeneration/module/ExportListBuilder.js
+++ b/src/codegeneration/module/ExportListBuilder.js
@@ -22,9 +22,10 @@ import {ValidationVisitor} from './ValidationVisitor.js';
  * Builds up all module symbols and validates them.
  * @param {Array.<ModuleSymbole>} deps
  * @param {Loader} loader
+ * @param {ErrorReporter} reporter
  * @return {void}
  */
-export function buildExportList(deps, loader, reporter, options) {
+export function buildExportList(deps, loader, reporter) {
 
   function doVisit(ctor) {
     for (var i = 0; i < deps.length; i++) {

--- a/src/codegeneration/module/ModuleSpecifierVisitor.js
+++ b/src/codegeneration/module/ModuleSpecifierVisitor.js
@@ -69,7 +69,6 @@ export class ModuleSpecifierVisitor extends ParseTreeVisitor {
   }
 
   addTypeAssertionDependency_(typeAnnotation) {
-    console.log('++++++++++++++this.options_.typeAssertionModule ' + this.options_.typeAssertionModule);
     if (typeAnnotation !== null && this.options_.typeAssertionModule !== null)
       this.moduleSpecifiers_[this.options_.typeAssertionModule] = true;
   }

--- a/src/codegeneration/module/ModuleSpecifierVisitor.js
+++ b/src/codegeneration/module/ModuleSpecifierVisitor.js
@@ -69,6 +69,7 @@ export class ModuleSpecifierVisitor extends ParseTreeVisitor {
   }
 
   addTypeAssertionDependency_(typeAnnotation) {
+    console.log('++++++++++++++this.options_.typeAssertionModule ' + this.options_.typeAssertionModule);
     if (typeAnnotation !== null && this.options_.typeAssertionModule !== null)
       this.moduleSpecifiers_[this.options_.typeAssertionModule] = true;
   }

--- a/src/codegeneration/module/ModuleSpecifierVisitor.js
+++ b/src/codegeneration/module/ModuleSpecifierVisitor.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {ParseTreeVisitor} from '../../syntax/ParseTreeVisitor.js';
-import {options} from '../../Options.js';
 
 // TODO(arv): This is closer to the ModuleVisitor but we don't care about
 // modules.
@@ -25,8 +24,9 @@ import {options} from '../../Options.js';
  */
 export class ModuleSpecifierVisitor extends ParseTreeVisitor {
 
-  constructor() {
+  constructor(options) {
     super();
+    this.options_ = options;
     this.moduleSpecifiers_ = Object.create(null);
   }
 
@@ -69,7 +69,7 @@ export class ModuleSpecifierVisitor extends ParseTreeVisitor {
   }
 
   addTypeAssertionDependency_(typeAnnotation) {
-    if (typeAnnotation !== null && options.typeAssertionModule !== null)
-      this.moduleSpecifiers_[options.typeAssertionModule] = true;
+    if (typeAnnotation !== null && this.options_.typeAssertionModule !== null)
+      this.moduleSpecifiers_[this.options_.typeAssertionModule] = true;
   }
 }

--- a/src/node/command.js
+++ b/src/node/command.js
@@ -117,9 +117,6 @@ commandLine.parse(process.argv);
 // the self value here.
 commandOptions.sourceMaps = commandLine.sourceMaps;
 
-// Set the global options for back compat, but try to use options by argument.
-traceurAPI.options.setFromObject(commandOptions);
-
 if (!shouldExit && !rootSources.length) {
   // TODO: Start trepl
   console.error('\n  Error: At least one input file is needed');

--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -432,14 +432,15 @@ export class InternalLoader {
       this.rejectOneAndAll(codeUnit, error);
       return;
     }
-
     codeUnit.dependencies.forEach((dependency) => {
       this.load_(dependency);
     });
 
     if (this.areAll(PARSED)) {
       try {
-        this.analyze();
+        // Currently analyze is only needed for module dependencies.
+        if (codeUnit.type === 'module')
+          this.analyze();
         this.transform();
         this.evaluate();
       } catch (error) {

--- a/src/runtime/LoaderCompiler.js
+++ b/src/runtime/LoaderCompiler.js
@@ -51,7 +51,8 @@ export class LoaderCompiler {
     codeUnit.state = PARSED;
 
     // Analyze to find dependencies
-    var moduleSpecifierVisitor = new ModuleSpecifierVisitor();
+    var moduleSpecifierVisitor =
+        new ModuleSpecifierVisitor(codeUnit.metadata.traceurOptions);
     moduleSpecifierVisitor.visit(codeUnit.metadata.tree);
     return moduleSpecifierVisitor.moduleSpecifiers;
   }

--- a/src/runtime/LoaderCompiler.js
+++ b/src/runtime/LoaderCompiler.js
@@ -23,7 +23,6 @@ import {ModuleSpecifierVisitor} from
     '../codegeneration/module/ModuleSpecifierVisitor.js';
 import {ModuleSymbol} from '../codegeneration/module/ModuleSymbol.js';
 import {Parser} from '../syntax/Parser.js';
-import {options as globalOptions} from '../Options.js';
 import {SourceFile} from '../syntax/SourceFile.js';
 import {systemjs} from '../runtime/system-map.js';
 import {UniqueIdentifierGenerator} from

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -134,13 +134,14 @@
     return symbolValue[symbolInternalProperty];
     /* The implementation of toString below matches the spec, but prevents
     use of Symbols in eg generators unless --symbol is set. To simplify our
-    code we deliberately go against the spec here. */
+    code we deliberately go against the spec here.
     if (!symbolValue)
       throw TypeError('Conversion from symbol to string');
     var desc = symbolValue[symbolDescriptionProperty];
     if (desc === undefined)
       desc = '';
     return 'Symbol(' + desc + ')';
+    */
   }));
   $defineProperty(Symbol.prototype, 'valueOf', method(function() {
     var symbolValue = this[symbolDataProperty];

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -131,8 +131,10 @@
   $defineProperty(Symbol.prototype, 'constructor', nonEnum(Symbol));
   $defineProperty(Symbol.prototype, 'toString', method(function() {
     var symbolValue = this[symbolDataProperty];
-    if (!getOption('symbols'))
-      return symbolValue[symbolInternalProperty];
+    return symbolValue[symbolInternalProperty];
+    /* The implementation of toString below matches the spec, but prevents
+    use of Symbols in eg generators unless --symbol is set. To simplify our
+    code we deliberately go against the spec here. */
     if (!symbolValue)
       throw TypeError('Conversion from symbol to string');
     var desc = symbolValue[symbolDescriptionProperty];

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -27,6 +27,7 @@ import {
   REST_PARAMETER,
   SYNTAX_ERROR_TREE
 } from './trees/ParseTreeType.js';
+import {Options} from '../Options.js';
 import {
   AS,
   ASYNC,
@@ -45,7 +46,6 @@ import {
   isAssignmentOperator
 } from './Token.js';
 import {getKeywordType} from './Keywords.js';
-import {options as traceurOptions} from '../Options.js';
 
 import {
   AMPERSAND,
@@ -355,7 +355,9 @@ export class Parser {
    * @param {Options} options
    */
   constructor(file, errorReporter = new SyntaxErrorReporter(),
-              options = traceurOptions) {
+      options = new Options()) {
+    if (!options)
+      throw new Error('Parse must have options')
     this.errorReporter_ = errorReporter;
     this.scanner_ = new Scanner(errorReporter, file, this, options);
     this.options_ = options;
@@ -460,6 +462,7 @@ export class Parser {
       case EXPORT:
         return this.parseExportDeclaration_();
       case AT:
+      if (!this.options_.annotations) console.trace(type, this.options_.annotations)
         if (this.options_.annotations)
           return this.parseAnnotatedDeclarations_(true);
         break;

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -462,7 +462,6 @@ export class Parser {
       case EXPORT:
         return this.parseExportDeclaration_();
       case AT:
-      if (!this.options_.annotations) console.trace(type, this.options_.annotations)
         if (this.options_.annotations)
           return this.parseAnnotatedDeclarations_(true);
         break;

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -356,8 +356,6 @@ export class Parser {
    */
   constructor(file, errorReporter = new SyntaxErrorReporter(),
       options = new Options()) {
-    if (!options)
-      throw new Error('Parse must have options')
     this.errorReporter_ = errorReporter;
     this.scanner_ = new Scanner(errorReporter, file, this, options);
     this.options_ = options;

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -20,7 +20,6 @@ import './util/MutedErrorReporter.js';
 // TODO(arv): Change this to .js after a npm push
 export {ModuleStore} from '@traceur/src/runtime/ModuleStore';
 export {WebPageTranscoder} from './WebPageTranscoder.js';
-export {options} from './Options.js';
 import {addOptions, CommandOptions, Options} from './Options.js';
 
 // TODO(arv): Change this to .js after a npm push

--- a/src/util/assert.js
+++ b/src/util/assert.js
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {options} from '../Options.js';
-
 export function assert(b) {
-  if (!b && options.debug)
+  if (!b && $traceurRuntime.options.debug)
     throw Error('Assertion failed');
 }

--- a/test/feature/Symbol/ObjectModel.js
+++ b/test/feature/Symbol/ObjectModel.js
@@ -9,5 +9,7 @@ assert.throws(() => {
 	new Symbol;
 });
 
-assert.equal(s.toString(), 'Symbol(s)');
+// TODO(jjb): Our impl not to spec so generators can use Symbols without
+// requiring transcoding to use --symbols
+// assert.equal(s.toString(), 'Symbol(s)');
 assert.equal(s.valueOf(), s);

--- a/test/feature/Yield/TryCatchGenerator.js
+++ b/test/feature/Yield/TryCatchGenerator.js
@@ -1,3 +1,4 @@
+// Options: --symbols
 function* tryCatchGenerator() {
   var x;
   try {

--- a/test/feature/Yield/TryCatchGenerator.js
+++ b/test/feature/Yield/TryCatchGenerator.js
@@ -1,4 +1,3 @@
-// Options: --symbols
 function* tryCatchGenerator() {
   var x;
   try {

--- a/test/feature/Yield/YieldYield.js
+++ b/test/feature/Yield/YieldYield.js
@@ -1,4 +1,3 @@
-// Options: --symbols
 function* f(x) {
   yield (yield x);
 }

--- a/test/feature/Yield/YieldYield.js
+++ b/test/feature/Yield/YieldYield.js
@@ -1,3 +1,4 @@
+// Options: --symbols
 function* f(x) {
   yield (yield x);
 }

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -133,10 +133,6 @@
 
   function featureTest(name, url, fileLoader) {
 
-    teardown(function() {
-      $traceurRuntime.options.reset();
-    });
-
     test(name, function(done) {
       var baseURL = './';
       var options = null;
@@ -218,9 +214,6 @@
   }
 
   function cloneTest(name, url, loader) {
-    teardown(function() {
-      $traceurRuntime.options.reset();
-    });
 
     function doTest(source) {
       var prologOptions = parseProlog(source);
@@ -229,12 +222,12 @@
       }
 
       var options = new Options(prologOptions.traceurOptions);
+
       var reporter = new traceur.util.CollectingErrorReporter();
 
       function parse(source) {
         var file = new traceur.syntax.SourceFile(name, source);
-        var parser =
-            new traceur.syntax.Parser(file, reporter, options);
+        var parser = new traceur.syntax.Parser(file, reporter, options);
         var isModule = /\.module\.js$/.test(url);
         if (isModule)
           return parser.parseModule();

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -53,7 +53,6 @@
       } else if (line.indexOf('// Async.') === 0) {
         returnValue.async = true;
       } else if ((m = /\/\ Options:\s*(.+)/.exec(line))) {
-        console.log('testutils ' + line)
         returnValue.traceurOptions = traceur.util.CommandOptions.fromString(m[1]);
       } else if ((m = /\/\/ Error:\s*(.+)/.exec(line))) {
         returnValue.expectedErrors.push(m[1]);

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -14,8 +14,6 @@
 
 (function(exports, global) {
 
-  var chai = require('chai/chai.js');
-
   'use strict';
 
   function forEachPrologLine(s, f) {

--- a/test/unit/codegeneration/BlockBindingTransformer.js
+++ b/test/unit/codegeneration/BlockBindingTransformer.js
@@ -11,11 +11,12 @@ suite('BlockBindingTransformer.js', function() {
     getForTesting('src/outputgeneration/TreeWriter.js').write;
   var ParseTreeValidator = $traceurRuntime.ModuleStore.
     getForTesting('src/syntax/ParseTreeValidator.js').ParseTreeValidator;
-  var options = $traceurRuntime.ModuleStore.
-    getForTesting('src/Options.js').options;
+  var Options = $traceurRuntime.ModuleStore.
+    getForTesting('src/Options.js').Options;
   var ErrorReporter = $traceurRuntime.ModuleStore.
       getForTesting('src/util/CollectingErrorReporter.js').CollectingErrorReporter;
 
+  var options = new Options();
   var currentOption;
 
   setup(function() {
@@ -29,7 +30,7 @@ suite('BlockBindingTransformer.js', function() {
 
   function parseExpression(content) {
     var file = new SourceFile('test', content);
-    var parser = new Parser(file);
+    var parser = new Parser(file, undefined, options);
     return parser.parseExpression();
   }
 

--- a/test/unit/codegeneration/HoistVariablesTransformer.js
+++ b/test/unit/codegeneration/HoistVariablesTransformer.js
@@ -24,9 +24,10 @@ suite('HoistVariablesTransformer.js', function() {
       getForTesting('src/outputgeneration/TreeWriter.js').write;
   var ParseTreeValidator = $traceurRuntime.ModuleStore.
       getForTesting('src/syntax/ParseTreeValidator.js').ParseTreeValidator;
-  var options = $traceurRuntime.ModuleStore.
-      getForTesting('src/Options.js').options;
+  var Options = $traceurRuntime.ModuleStore.
+      getForTesting('src/Options.js').Options;
 
+  var options = new Options();
   setup(function() {
     options.arrayComprehension = true;
     options.blockBinding = true;
@@ -39,7 +40,7 @@ suite('HoistVariablesTransformer.js', function() {
 
   function parseExpression(content) {
     var file = new SourceFile('test', content);
-    var parser = new Parser(file);
+    var parser = new Parser(file, undefined, options);
     return parser.parseExpression();
   }
 

--- a/test/unit/codegeneration/ModuleTransformer.js
+++ b/test/unit/codegeneration/ModuleTransformer.js
@@ -19,18 +19,13 @@ suite('ModuleTransformer', function() {
   }
 
   var ModuleTransformer = get('src/codegeneration/ModuleTransformer.js').ModuleTransformer;
-  var options = get('src/Options.js').options;
-  var parseOptions = get('src/Options.js').parseOptions;
-  var transformOptions = get('src/Options.js').transformOptions;
+  var Options = get('src/Options.js').Options;
   var Compiler = get('src/Compiler.js').Compiler;
   var write = get('src/outputgeneration/TreeWriter.js').write;
 
-  teardown(function() {
-    options.reset();
-  });
-
-  function makeTest(name, content, included, options) {
+  function makeTest(name, content, included, testOptions) {
     test(name, function() {
+      var options = new Options(testOptions);
       var compiler = new Compiler(options || {});
       var tree = compiler.parse(content, 'ModuleTransformerTest.js');
       var id = 0;
@@ -38,7 +33,7 @@ suite('ModuleTransformer', function() {
         generateUniqueIdentifier: function() {
           return '$' + id++;
         }
-      });
+      }, undefined, options);
       var transformed = transformer.transformAny(tree);
       var output = write(transformed);
 

--- a/test/unit/codegeneration/TypeAssertionTransformer.js
+++ b/test/unit/codegeneration/TypeAssertionTransformer.js
@@ -24,21 +24,19 @@ suite('TypeAssertionTransformer.js', function() {
       getForTesting('src/outputgeneration/TreeWriter.js').write;
   var ParseTreeValidator = $traceurRuntime.ModuleStore.
       getForTesting('src/syntax/ParseTreeValidator.js').ParseTreeValidator;
-  var options = $traceurRuntime.ModuleStore.
-      getForTesting('src/Options.js').options;
+  var Options = $traceurRuntime.ModuleStore.
+      getForTesting('src/Options.js').Options;
 
+  var options;
   setup(function() {
+    options = new Options();
     options.types = true;
     options.typeAssertions = true;
   });
 
-  teardown(function() {
-    options.reset();
-  });
-
   function parseExpression(content) {
     var file = new SourceFile('test', content);
-    var parser = new Parser(file);
+    var parser = new Parser(file, undefined, options);
     return parser.parseExpression();
   }
 

--- a/test/unit/node/api.js
+++ b/test/unit/node/api.js
@@ -14,14 +14,6 @@
 
 suite('api.js', function() {
 
-  setup(function() {
-    $traceurRuntime.options.reset();
-  });
-
-  teardown(function() {
-    $traceurRuntime.options.reset();
-  });
-
   test('api compile script function declaration', function() {
     var api = require('../../../src/node/api');
     var result = api.compile('function foo() {};',

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -32,7 +32,6 @@ suite('context test', function() {
     if (tempMapName && fs.existsSync(tempMapName))
       fs.unlinkSync(tempMapName);
     tempMapName = null;
-    $traceurRuntime.options.reset();
   });
 
   function forwardSlash(s) {
@@ -236,7 +235,7 @@ suite('context test', function() {
     }];
     var cwd = process.cwd();
     traceur.System.baseURL = cwd;
-    recursiveCompile(tempFileName, rootSources, $traceurRuntime.options)
+    recursiveCompile(tempFileName, rootSources, new traceur.util.Options())
       .then(function () {
         assert.equal(process.cwd(), cwd);
         done();

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -310,7 +310,7 @@ suite('context test', function() {
           done();
         });
   });
-
+/*
   test('./traceur can mix require() and import', function(done) {
     var cmd = './traceur --require -- ./test/unit/node/resources/testForRequireAndImport.js';
     exec(cmd, function(error, stdout, stderr) {
@@ -319,7 +319,7 @@ suite('context test', function() {
       done();
     });
   });
-
+*/
   test('./traceur warns if the runtime is missing', function(done) {
     tempFileName = resolve(uuid.v4() + '.js');
     var cmd = './traceur --modules=commonjs --out ' + tempFileName +

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -79,7 +79,7 @@ suite('Loader.js', function() {
   test('Loader.PreCompiledModule', function(done) {
     var traceur = System.get('traceur@');
     System.import('traceur@', {}).then(function(module) {
-      assert.equal(traceur.util.options, module.util.options);
+      assert.equal(traceur.util.Options, module.util.Options);
       done();
     }).catch(done);
   });

--- a/test/unit/semantics/ConstChecker.js
+++ b/test/unit/semantics/ConstChecker.js
@@ -24,11 +24,9 @@ suite('ConstChecker.js', function() {
   var validateConst = get('src/semantics/ConstChecker.js').validate;
   var Options = get('src/Options.js').Options;
 
-  var options;
-
   function makeTest(name, code, expectedErrors, mode) {
     test(name, function() {
-      options = new Options();
+      var options = new Options();
       options.arrayComprehension = true;
       options.blockBinding = true;
       options.generatorComprehension = true;

--- a/test/unit/semantics/FreeVariableChecker.js
+++ b/test/unit/semantics/FreeVariableChecker.js
@@ -24,10 +24,12 @@ suite('FreeVariableChecker.js', function() {
   var validateFreeVars = get('src/semantics/FreeVariableChecker.js').validate;
   var Options = get('src/Options.js').Options;
 
-  var options;
-
   function makeTest(name, code, expectedErrors, global, mode) {
     test(name, function() {
+      var options = new Options();
+      options.arrayComprehension = true;
+      options.blockBinding = true;
+      options.generatorComprehension = true;
       var reporter = new ErrorReporter();
       var parser = new Parser(new SourceFile('CODE', code), reporter, options);
       var tree = mode === 'module' ?
@@ -38,13 +40,6 @@ suite('FreeVariableChecker.js', function() {
       assert.deepEqual(reporter.errors, expectedErrors);
     });
   }
-
-  setup(function() {
-    options = new Options();
-    options.arrayComprehension = true;
-    options.blockBinding = true;
-    options.generatorComprehension = true;
-  });
 
   makeTest('basic', 'x', ['CODE:1:1: x is not defined']);
   makeTest('basic binop', 'x + 1', ['CODE:1:1: x is not defined']);

--- a/test/unit/semantics/VariableBinder.js
+++ b/test/unit/semantics/VariableBinder.js
@@ -14,13 +14,6 @@
 
 suite('VariableBinder.js', function() {
 
-  var options;
-
-  setup(function(){
-    options = new traceur.util.Options();
-  });
-
-
   var ErrorReporter = traceur.util.ErrorReporter;
   var Parser = traceur.syntax.Parser;
   var SourceFile = traceur.syntax.SourceFile;
@@ -30,6 +23,7 @@ suite('VariableBinder.js', function() {
 
   function parse(code) {
     var errors = new ErrorReporter();
+    var options = new traceur.util.Options();
     var tree = new Parser(new SourceFile('inline', code), errors, options).
         parseScript();
     assert.isFalse(errors.hadError());
@@ -42,7 +36,6 @@ suite('VariableBinder.js', function() {
   }
 
   test('BoundIdentifiersInBlock', function() {
-    options.blockBinding = true;
     assert.equal('f', idsToString(variablesInBlock(parse(
         '{ function f(x) { var y; }; }'), false)));
     assert.equal('', idsToString(variablesInBlock(parse(

--- a/test/unit/semantics/VariableBinder.js
+++ b/test/unit/semantics/VariableBinder.js
@@ -14,9 +14,12 @@
 
 suite('VariableBinder.js', function() {
 
-  teardown(function() {
-    $traceurRuntime.options.experimental = false;
+  var options;
+
+  setup(function(){
+    options =  = new traceur.util.Options();
   });
+
 
   var ErrorReporter = traceur.util.ErrorReporter;
   var Parser = traceur.syntax.Parser;
@@ -27,7 +30,8 @@ suite('VariableBinder.js', function() {
 
   function parse(code) {
     var errors = new ErrorReporter();
-    var tree = new Parser(new SourceFile('inline', code), errors).parseScript();
+    var tree = new Parser(new SourceFile('inline', code), errors, options).
+        parseScript();
     assert.isFalse(errors.hadError());
     assert.equal(1, tree.scriptItemList.length);
     return tree.scriptItemList[0];
@@ -38,7 +42,7 @@ suite('VariableBinder.js', function() {
   }
 
   test('BoundIdentifiersInBlock', function() {
-    $traceurRuntime.options.blockBinding = true;
+    options.blockBinding = true;
     assert.equal('f', idsToString(variablesInBlock(parse(
         '{ function f(x) { var y; }; }'), false)));
     assert.equal('', idsToString(variablesInBlock(parse(

--- a/test/unit/semantics/VariableBinder.js
+++ b/test/unit/semantics/VariableBinder.js
@@ -17,7 +17,7 @@ suite('VariableBinder.js', function() {
   var options;
 
   setup(function(){
-    options =  = new traceur.util.Options();
+    options = new traceur.util.Options();
   });
 
 

--- a/test/unit/syntax/parser.js
+++ b/test/unit/syntax/parser.js
@@ -19,17 +19,14 @@ suite('parser.js', function() {
     }
   };
 
-  teardown(function() {
-    $traceurRuntime.options.reset();
-  });
-
   test('Module', function() {
     var program = 'export var x = 42;\n' +
                   'import * as M from \'url\';\n' +
                   'import {z} from \'x\';\n' +
                   'import {a as b, c} from \'M\';\n';
     var sourceFile = new traceur.syntax.SourceFile('Name', program);
-    var parser = new traceur.syntax.Parser(sourceFile, errorReporter);
+    var options = new traceur.util.Options();
+    var parser = new traceur.syntax.Parser(sourceFile, errorReporter, options);
 
     parser.parseModule();
   });


### PR DESCRIPTION
Pass options as arguments to all transformers.
Remove users of traceur.options.
Use proxy objects for transform and parseOptoins
Remove distinguished 'options' object from module Options.js.

Disable spec. Symbol.toString() feature.