### PR TITLE
Options.setFromObject now parses "experimental" and "atscript" props

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -322,6 +322,13 @@ export class Options {
         this.setOption(name, object[name]);
     });
     this.modules = object.modules || this.modules;
+    if (!!object.atscript) {
+      this.atscript = !!object.atscript;      
+    }
+    if (!!object.experimental) {
+      this.experimental = !!object.experimental;
+    }
+    this.atscript = object.atscript || this.atscript;
     if (typeof object.sourceMaps === 'boolean' ||
         typeof object.sourceMaps === 'string') {
       this.sourceMaps = object.sourceMaps;


### PR DESCRIPTION
Since experimental and atscript are setters in the Options object they do not get parsed when calling setFromObject.

We could also do:
this.atscript = object.atscript || this.atscript;

To keep it consistent with modules line above but since these are booleans I though if() check was clearer, either way really.