### PR TITLE
A for-of loop that exits prematurely should close its iterator

### DIFF
--- a/src/codegeneration/ForOfTransformer.js
+++ b/src/codegeneration/ForOfTransformer.js
@@ -12,14 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {VARIABLE_DECLARATION_LIST} from '../syntax/trees/ParseTreeType.js';
+import {
+  FOR_OF_STATEMENT,
+  VARIABLE_DECLARATION_LIST,
+  LABELLED_STATEMENT
+} from '../syntax/trees/ParseTreeType.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
 import {
   createIdentifierExpression as id,
   createMemberExpression,
   createVariableStatement
 } from './ParseTreeFactory.js';
-import {parseStatement} from './PlaceholderParser.js';
+import {
+  parseStatement,
+  parseStatements
+} from './PlaceholderParser.js';
+import {
+  AnonBlock,
+  LabelledStatement
+} from '../syntax/trees/ParseTrees.js';
 
 /**
  * Desugars for-of statement.
@@ -27,12 +38,24 @@ import {parseStatement} from './PlaceholderParser.js';
 export class ForOfTransformer extends TempVarTransformer {
   /**
    * @param {ForOfStatement} original
+   * @param {Array.<LabelledStatement>=} labelSet
    * @return {ParseTree}
    */
   transformForOfStatement(original) {
+    return this.transformForOfStatement_(original, []);
+  }
+
+  transformForOfStatement_(original, labelSet) {
     var tree = super.transformForOfStatement(original);
     var iter = id(this.getTempIdentifier());
     var result = id(this.getTempIdentifier());
+    var label = id(this.getTempIdentifier());
+    var normalCompletion = id(this.getTempIdentifier());
+    var throwCompletion = id(this.getTempIdentifier());
+    var exception = id(this.getTempIdentifier());
+    var ex = id(this.getTempIdentifier());
+    var labelledStatement;
+    var innerStatement;
 
     var assignment;
     if (tree.initializer.type === VARIABLE_DECLARATION_LIST) {
@@ -45,14 +68,54 @@ export class ForOfTransformer extends TempVarTransformer {
       assignment = parseStatement `${tree.initializer} = ${result}.value;`;
     }
 
-    return parseStatement `
-        for (var ${iter} =
-                 ${tree.collection}[
-                     $traceurRuntime.toProperty(Symbol.iterator)](),
-                 ${result};
-             !(${result} = ${iter}.next()).done; ) {
-          ${assignment};
-          ${tree.body};
+    innerStatement = parseStatement `
+        for (var ${result},
+                 ${iter} = ${tree.collection}[
+                     $traceurRuntime.toProperty(Symbol.iterator)]();
+             !(${normalCompletion} = (${result} = ${iter}.next()).done);
+             ${normalCompletion} = true) {
+          ${assignment}
+          ${tree.body}
         }`;
+  
+    while (labelledStatement = labelSet.pop()) {
+      innerStatement = new LabelledStatement(labelledStatement.location,
+          labelledStatement.name, innerStatement);
+    }
+
+    return new AnonBlock(null, parseStatements `
+        var ${normalCompletion} = true;
+        var ${throwCompletion} = false;
+        var ${exception} = undefined;
+        try {
+          ${innerStatement}
+        } catch (${ex}) {
+          ${throwCompletion} = true;
+          ${exception} = ${ex};
+        } finally {
+          try {
+            if (!${normalCompletion} && ${iter}.return != null) {
+              ${iter}.return();
+            }
+          } finally {
+            if (${throwCompletion}) {
+              throw ${exception};
+            }
+          }
+        }`);
+  }
+
+  transformLabelledStatement(tree) {
+    var labelSet = [tree];
+    var statement = tree.statement;
+    while (statement.type === LABELLED_STATEMENT) {
+      labelSet.push(statement);
+      statement = statement.statement;
+    }
+    if (statement.type !== FOR_OF_STATEMENT) {
+      return super.transformLabelledStatement(tree);
+      // Slightly inefficient in the (unlikely) case of more than one label
+    }
+    return this.transformForOfStatement_(statement, labelSet);
   }
 }

--- a/test/feature/Yield/BreakForOf.js
+++ b/test/feature/Yield/BreakForOf.js
@@ -1,0 +1,54 @@
+var g, x;
+
+function* f() {
+  try {
+    yield 1;
+    yield 2;
+  } finally {
+    x = 42;
+  }
+}
+
+g = f();
+x = 0;
+
+for (let i of g) {
+  break;
+}
+
+assert.equal(x, 42);
+
+g = f();
+x = 10;
+
+(function () {
+  for (let i of g) {
+    return;
+  }
+}());
+
+assert.equal(x, 42);
+
+g = f();
+x = 20;
+
+label1:
+for (let i of g) {
+  if (i == 1) {
+    continue label1;
+  }
+  assert.equal(x, 20);
+}
+
+g = f();
+x = 30;
+
+label2:
+label3:
+for (let i of g) {
+  if (i == 1) {
+    continue label2;
+  }
+  assert.equal(x, 30);
+}
+

--- a/test/feature/Yield/ForOfIteratorException.js
+++ b/test/feature/Yield/ForOfIteratorException.js
@@ -1,0 +1,27 @@
+class Iterable {
+  constructor() {
+    this.returnCalled = false;
+  }
+  [Symbol.iterator]() {
+    return {
+      iterable: this,
+      next(v) {
+        throw "ex";
+      },
+      throw(e) {
+        throw e;
+      },
+      return(v) {
+        this.iterable.returnCalled = true;
+      }
+    }
+  }
+}
+
+var iterable = new Iterable();
+var i;
+assert.throws(() => {
+  for (i of iterable) {
+  }
+}, "ex");
+assert.isFalse(iterable.returnCalled);


### PR DESCRIPTION
By https://people.mozilla.org/~jorendorff/es6-draft.html#sec-runtime-semantics-forin-div-ofbodyevaluation, a for-of-loop's iterator shall be closed when execution control breaks out of the for-of-loop.

The test proves that traceur currently does not handle this problem properly.

I'll see whether I can come up with a solution in the next days.