### PR TITLE
For-on loops (part of ES7's async generators)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ INDIVIDUAL_RUNTIME_MODULES = \
   src/runtime/destructuring.js \
   src/runtime/classes.js \
   src/runtime/generators.js \
+  src/runtime/async.js \
   src/runtime/type-assertions.js \
   #end runtime modules
 SRC = \

--- a/src/Options.js
+++ b/src/Options.js
@@ -37,6 +37,7 @@ export var optionsV01 = enumerableOnlyObject({
   destructuring: true,
   exponentiation: false,
   forOf: true,
+  forOn: false,
   freeVariableChecker: false,
   generatorComprehension: false,
   generators: true,
@@ -139,12 +140,12 @@ addFeatureOption('annotations', EXPERIMENTAL);
 addFeatureOption('arrayComprehension', EXPERIMENTAL); // 11.4.1.2
 addFeatureOption('asyncFunctions', EXPERIMENTAL);
 addFeatureOption('exponentiation', EXPERIMENTAL);
+addFeatureOption('forOn', EXPERIMENTAL);
 addFeatureOption('generatorComprehension', EXPERIMENTAL);
+addFeatureOption('memberVariables', EXPERIMENTAL);
 addFeatureOption('require', EXPERIMENTAL);
 addFeatureOption('symbols', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
-addFeatureOption('memberVariables', EXPERIMENTAL);
-
 
 var transformOptionsPrototype = {};
 

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -36,7 +36,8 @@ import {
   BindingElement,
   Catch,
   ForInStatement,
-  ForOfStatement
+  ForOfStatement,
+  ForOnStatement
 } from '../syntax/trees/ParseTrees.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
 import {
@@ -270,15 +271,21 @@ export class DestructuringTransformer extends TempVarTransformer {
   }
 
   transformForInStatement(tree) {
-    return this.transformForInOrOf_(tree,
-                                    super.transformForInStatement,
-                                    ForInStatement);
+    return this.transformForInOrOfOrOn_(tree,
+                                        super.transformForInStatement,
+                                        ForInStatement);
   }
 
   transformForOfStatement(tree) {
-    return this.transformForInOrOf_(tree,
-                                    super.transformForOfStatement,
-                                    ForOfStatement);
+    return this.transformForInOrOfOrOn_(tree,
+                                        super.transformForOfStatement,
+                                        ForOfStatement);
+  }
+
+  transformForOnStatement(tree) {
+    return this.transformForInOrOfOrOn_(tree,
+                                        super.transformForOnStatement,
+                                        ForOnStatement);
   }
 
   /**
@@ -291,7 +298,7 @@ export class DestructuringTransformer extends TempVarTransformer {
    * @return {ForInStatement|ForOfStatement} The transformed tree.
    * @private
    */
-  transformForInOrOf_(tree, superMethod, constr) {
+  transformForInOrOfOrOn_(tree, superMethod, constr) {
     if (!tree.initializer.isPattern() &&
         (tree.initializer.type !== VARIABLE_DECLARATION_LIST ||
          !this.destructuringInDeclaration_(tree.initializer))) {

--- a/src/codegeneration/FnExtractAbruptCompletions.js
+++ b/src/codegeneration/FnExtractAbruptCompletions.js
@@ -65,7 +65,7 @@ export class FnExtractAbruptCompletions extends ParseTreeTransformer {
     this.variableDeclarations_ = [];
     this.extractedStatements_ = [];
     this.requestParentLabel_ = requestParentLabel;
-    this.labelledStatements_ = {};
+    this.labelledStatements_ = Object.create(null);
   }
 
   createIIFE(body, paramList, argsList) {

--- a/src/codegeneration/ForOnTransformer.js
+++ b/src/codegeneration/ForOnTransformer.js
@@ -1,0 +1,92 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  FOR_ON_STATEMENT,
+  LABELLED_STATEMENT
+} from '../syntax/trees/ParseTreeType.js';
+import {TempVarTransformer} from './TempVarTransformer.js';
+import {InnerForOnTransformer} from './InnerForOnTransformer.js';
+import {
+  createIdentifierExpression as id,
+  createVariableStatement
+} from './ParseTreeFactory.js';
+
+/**
+ * Transforms for-on loops into calls to async functions
+ *
+ * Example:
+ *
+ * for (let i on o) {
+ *   if (continue) continue;
+ *   if (break) break;
+ *   if (return) return;
+ * }
+ *
+ * Becomes:
+ *
+ * do {
+ *   var $result = undefined;
+ *   let i;
+ *   await $traceurRuntime.observableForEach(o, async function ($value) {
+ *     $observer = this;
+ *     i = $value;
+ *     if (continue) return;
+ *     if (break) { $result = 0; $observer.return(); return; }
+ *     if (return) { $result = {v: undefined}; $observer.return(); return; }
+ *   });
+ *   switch ($result) {
+ *   case 0:
+ *     continue;
+ *   case undefined:
+ *     continue;
+ *   default:
+ *     return $result.v;
+ *   }
+ * } while (false)
+ */
+
+/**
+ * Desugars for-on statement.
+ */
+export class ForOnTransformer extends TempVarTransformer {
+  /**
+   * @param {ForOnStatement} original
+   * @return {ParseTree}
+   */
+  transformForOnStatement(original) {
+    return this.transformForOnStatement_(original, []);
+  }
+
+  transformForOnStatement_(original, labelSet) {
+    return InnerForOnTransformer.transform(this,
+        super.transformForOnStatement(original), labelSet);
+  }
+
+  // keep track of labels in the tree
+  transformLabelledStatement(tree) {
+    var labelSet = [tree];
+    var statement;
+    for (statement = tree.statement; statement.type === LABELLED_STATEMENT;
+        statement = statement.statement) {
+      labelSet.push(statement);
+    }
+    if (statement.type !== FOR_ON_STATEMENT) {
+      return super.transformLabelledStatement(tree);
+      // Slightly inefficient in the (unlikely) case of more than one label
+    }
+    return this.transformForOnStatement_(statement, labelSet);
+  }
+}
+

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -25,6 +25,7 @@ import {validate as validateConst} from '../semantics/ConstChecker.js';
 import {DefaultParametersTransformer} from './DefaultParametersTransformer.js';
 import {DestructuringTransformer} from './DestructuringTransformer.js';
 import {ForOfTransformer} from './ForOfTransformer.js';
+import {ForOnTransformer} from './ForOnTransformer.js';
 import {validate as validateFreeVariables} from
     '../semantics/FreeVariableChecker.js';
 import {GeneratorComprehensionTransformer} from
@@ -172,6 +173,10 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (transformOptions.forOf)
       append(ForOfTransformer);
 
+    // for on must come before async functions
+    if (transformOptions.forOn)
+      append(ForOnTransformer);
+
     // rest parameters must come before generator
     if (transformOptions.restParameters)
       append(RestParameterTransformer);
@@ -200,7 +205,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       });
     }
 
-    // generator must come after for of and rest parameters
+    // generator must come after for of, for on and rest parameters
     if (transformOptions.generators || transformOptions.asyncFunctions)
       append(GeneratorTransformPass);
 

--- a/src/codegeneration/HoistVariablesTransformer.js
+++ b/src/codegeneration/HoistVariablesTransformer.js
@@ -229,6 +229,10 @@ class HoistVariablesTransformer extends ParseTreeTransformer {
     return this.transformLoop_(tree, ForOfStatement);
   }
 
+  transformForOnStatement(tree) {
+    return this.transformLoop_(tree, ForOfStatement);
+  }
+
   transformLoop_(tree, ctor) {
     var initializer = this.transformLoopIninitaliser_(tree.initializer);
     var collection = this.transformAny(tree.collection);

--- a/src/codegeneration/InnerForOnTransformer.js
+++ b/src/codegeneration/InnerForOnTransformer.js
@@ -1,0 +1,234 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ParseTreeTransformer} from './ParseTreeTransformer.js';
+import alphaRenameThisAndArguments from './alphaRenameThisAndArguments.js';
+import {
+  parseStatement,
+  parseStatements
+} from './PlaceholderParser.js';
+import {
+  AnonBlock,
+  Block,
+  BreakStatement,
+  ContinueStatement,
+  LabelledStatement,
+  ReturnStatement
+} from '../syntax/trees/ParseTrees.js';
+import {
+  createArgumentList,
+  createAssignmentStatement,
+  createAssignmentExpression,
+  createCaseClause,
+  createDefaultClause,
+  createIdentifierExpression as id,
+  createNumberLiteral,
+  createSwitchStatement,
+  createThisExpression,
+  createVariableDeclaration,
+  createVariableDeclarationList,
+  createVariableStatement,
+  createVoid0
+} from './ParseTreeFactory.js';
+import {ARGUMENTS} from '../syntax/PredefinedName.js';
+import {VAR} from '../syntax/TokenType.js';
+import {VARIABLE_DECLARATION_LIST} from '../syntax/trees/ParseTreeType.js';
+
+export class InnerForOnTransformer extends ParseTreeTransformer {
+  // TODO: This class has considerable overlap with
+  // FnExtractAbruptCompletions. The common code should really be refactored
+  // into an abstract base class.
+  
+  constructor(tempIdGenerator, labelSet) {
+    this.idGenerator_ = tempIdGenerator;
+    this.inLoop_ = 0;
+    this.inBreakble_ = 0;
+    this.variableDeclarations_ = [];
+    this.extractedStatements_ = [];
+    this.labelSet_ = labelSet;
+    this.labelledStatements_ = {};
+    this.observer_ = id(this.idGenerator_.getTempIdentifier());
+    this.result_ = id(this.idGenerator_.getTempIdentifier());
+    this.parentLabels_ = Object.create(null);
+    this.labelSet_.forEach((tree) => {
+      this.parentLabels_[tree.name.value] = true;
+    });
+  }
+
+  transform(tree) {
+    var value = id(this.idGenerator_.getTempIdentifier());
+    var assignment;
+    if (tree.initializer.type === VARIABLE_DECLARATION_LIST) {
+      // {var,let,const} initializer = $value;
+      assignment = createVariableStatement(
+          tree.initializer.declarationType,
+          tree.initializer.declarations[0].lvalue, value);
+    } else {
+      assignment = parseStatement `
+          ${tree.initializer} = ${value};`;
+    }
+
+    var body = new Block(tree.body.location,
+        [assignment, ...tree.body.statements]);
+    body = this.transformAny(body);
+    body = alphaRenameThisAndArguments(this, body);
+
+    // var $result = undefined
+    this.variableDeclarations_.push(
+        createVariableDeclaration(this.result_, createVoid0()));
+
+    var caseClauses = this.extractedStatements_.map(
+        (statement, index) => {
+          return createCaseClause(createNumberLiteral(index), [statement])
+        });
+    caseClauses.push(createCaseClause(createVoid0(), [
+        new ContinueStatement(null, null)]));
+    caseClauses.push(createDefaultClause(parseStatements `
+        return ${this.result_}.v;`));
+
+    var switchStatement = createSwitchStatement(this.result_, caseClauses);
+    var statement = parseStatement `
+        do {
+          ${createVariableStatement(
+            createVariableDeclarationList(VAR, this.variableDeclarations_))}
+            await $traceurRuntime.observeForEach(
+              ${tree.observable}[$traceurRuntime.toProperty(Symbol.observer)].
+                  bind(${tree.observable}),
+              async function (${value}) {
+                var ${this.observer_} = this;
+                ${body}
+              });
+          ${switchStatement}
+        } while (false);`;
+
+    var labelledStatement;
+    while (labelledStatement = this.labelSet_.pop()) {
+      statement = new LabelledStatement(labelledStatement.location,
+      labelledStatement.name, statement);
+    }
+
+    return statement;
+  }
+
+  // alphaRenameThisAndArguments
+  addTempVarForArguments() {
+    var tmpVarName = this.idGenerator_.generateUniqueIdentifier();
+    this.variableDeclarations_.push(createVariableDeclaration(
+        tmpVarName, id(ARGUMENTS)));
+    return tmpVarName;
+  }
+  // alphaRenameThisAndArguments
+  addTempVarForThis() {
+    var tmpVarName = this.idGenerator_.generateUniqueIdentifier();
+    this.variableDeclarations_.push(createVariableDeclaration(
+        tmpVarName, createThisExpression()));
+    return tmpVarName;
+  }
+
+  transformAny(tree) {
+    if (tree) {
+      if (tree.isBreakableStatement()) this.inBreakble_++;
+      if (tree.isIterationStatement()) this.inLoop_++;
+      tree = super.transformAny(tree);
+      if (tree.isBreakableStatement()) this.inBreakble_--;
+      if (tree.isIterationStatement()) this.inLoop_--;
+    }
+    return tree;
+  }
+
+  transformReturnStatement(tree) {
+    return new AnonBlock(tree.location, parseStatements `
+        ${this.observer_}.return();
+        ${this.result_} = {v: ${tree.expression || createVoid0()}};
+        return;`);
+  }
+
+  transformAbruptCompletion_(tree) {
+    this.extractedStatements_.push(tree);
+
+    var index = this.extractedStatements_.length - 1;
+    return new AnonBlock(null, parseStatements `
+        ${this.observer_}.return();
+        ${this.result_} = ${index};
+        return;`);
+  }
+
+  transformBreakStatement(tree) {
+    if (!tree.name) {
+      if (this.inBreakble_) {
+        return super.transformBreakStatement(tree);
+      }
+      return this.transformAbruptCompletion_(
+        new ContinueStatement(tree.location, null));
+    }
+    if (this.labelledStatements_[tree.name.value]) {
+      return super.transformBreakStatement(tree);
+    }
+    return this.transformAbruptCompletion_(tree);
+  }
+
+  transformContinueStatement(tree) {
+    if (!tree.name) {
+      if (this.inLoop_) {
+        return super.transformContinueStatement(tree);
+      }
+      return new ReturnStatement(tree.location, null);
+    }
+    if (this.labelledStatements_[tree.name.value]) {
+      return super.transformContinueStatement(tree);
+    }
+    if (this.parentLabels_[tree.name.value]) {
+      return new ReturnStatement(tree.location, null);
+    }
+    return this.transformAbruptCompletion_(tree);
+  }
+
+  // keep track of labels in the tree
+  transformLabelledStatement(tree) {
+    this.labelledStatements_[tree.name.value] = true;
+    return super.transformLabelledStatement(tree);
+  }
+
+  transformVariableStatement(tree) {
+    if (tree.declarations.declarationType === VAR) {
+      var assignments = [];
+      tree.declarations.declarations.forEach((variableDeclaration) => {
+        var variableName = variableDeclaration.lvalue.getStringValue();
+        var initializer = super.transformAny(variableDeclaration.initializer);
+
+        this.variableDeclarations_.push(
+            createVariableDeclaration(variableName, null));
+
+        assignments.push(createAssignmentStatement(
+            id(variableName), initializer));
+      });
+
+      return new AnonBlock(null, assignments);
+    }
+
+    return super.transformVariableStatement(tree);
+  }
+
+  // don't transform children functions
+  transformFunctionDeclaration(tree) {return tree;}
+  transformFunctionExpression(tree) {return tree;}
+  transformSetAccessor(tree) {return tree;}
+  transformGetAccessor(tree) {return tree;}
+  transformPropertyMethodAssignment(tree) {return tree;}
+  transformArrowFunctionExpression(tree) {return tree;}
+
+  static transform(tempIdGenerator, tree, labelSet) {
+    return new InnerForOnTransformer(tempIdGenerator, labelSet).transform(tree);
+  }
+}

--- a/src/codegeneration/ScopeTransformer.js
+++ b/src/codegeneration/ScopeTransformer.js
@@ -107,12 +107,21 @@ export class ScopeTransformer extends ParseTreeTransformer {
   }
 
   /**
-   * @param {ForInStatement} tree
+   * @param {ForOfStatement} tree
    * @return {ParseTree}
    */
   transformForOfStatement(tree) {
     return this.sameTreeIfNameInLoopInitializer_(tree) ||
         super.transformForOfStatement(tree);
+  }
+
+  /**
+   * @param {ForOnStatement} tree
+   * @return {ParseTree}
+   */
+  transformForOnStatement(tree) {
+    return this.sameTreeIfNameInLoopInitializer_(tree) ||
+        super.transformForOnStatement(tree);
   }
 
   transformThisExpression(tree) {

--- a/src/codegeneration/generator/BreakContinueTransformer.js
+++ b/src/codegeneration/generator/BreakContinueTransformer.js
@@ -99,6 +99,14 @@ export class BreakContinueTransformer extends ParseTreeTransformer {
   }
 
   /**
+   * @param {ForOnStatement} tree
+   * @return {ParseTree}
+   */
+  transformForOnStatement(tree) {
+    return tree;
+  }
+
+  /**
    * @param {ForStatement} tree
    * @return {ParseTree}
    */

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -29,6 +29,7 @@ import {
   FROM,
   GET,
   OF,
+  ON,
   SET
 } from '../syntax/PredefinedName.js';
 import {
@@ -602,6 +603,22 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     this.write_(OF);
     this.writeSpace_();
     this.visitAny(tree.collection);
+    this.write_(CLOSE_PAREN);
+    this.visitAnyBlockOrIndent_(tree.body);
+  }
+
+  /**
+   * @param {ForOnStatement} tree
+   */
+  visitForOnStatement(tree) {
+    this.write_(FOR);
+    this.writeSpace_();
+    this.write_(OPEN_PAREN);
+    this.visitAny(tree.initializer);
+    this.writeSpace_();
+    this.write_(ON);
+    this.writeSpace_();
+    this.visitAny(tree.observable);
     this.write_(CLOSE_PAREN);
     this.visitAnyBlockOrIndent_(tree.body);
   }

--- a/src/runtime/async.js
+++ b/src/runtime/async.js
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** @fileoverview import all runtime modules, eg for Traceur self-build. */
+function observeForEach(observe, next) {
+  return new Promise((resolve, reject) => {
+    var generator = observe({
+      next(value) {
+        return next.call(generator, value);
+      },
+      throw(error) {
+        reject(error);
+      },
+      return(value) {
+        resolve();
+      }
+    });
+  });
+}
 
-import './relativeRequire.js';
-import './spread.js';
-import './destructuring.js';
-import './classes.js';
-import './async.js';
-import './generators.js';
-import './type-assertions.js';
+$traceurRuntime.observeForEach = observeForEach;
+

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -348,6 +348,9 @@
     if (!global.Symbol.iterator) {
       global.Symbol.iterator = Symbol('Symbol.iterator');
     }
+    if (!global.Symbol.observer) {
+      global.Symbol.observer = Symbol('Symbol.observer');
+    }
   }
 
   function setupGlobals(global) {

--- a/src/syntax/PredefinedName.js
+++ b/src/syntax/PredefinedName.js
@@ -39,6 +39,7 @@ export var NEW = 'new';
 export var OBJECT = 'Object';
 export var OBJECT_NAME = 'Object';
 export var OF = 'of';
+export var ON = 'on';
 export var PREVENT_EXTENSIONS = 'preventExtensions';
 export var PROTOTYPE = 'prototype';
 export var PUSH = 'push';

--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -47,6 +47,7 @@ import {
   FORMAL_PARAMETER,
   FOR_IN_STATEMENT,
   FOR_OF_STATEMENT,
+  FOR_ON_STATEMENT,
   FOR_STATEMENT,
   FUNCTION_DECLARATION,
   FUNCTION_EXPRESSION,
@@ -311,6 +312,7 @@ export class ParseTree {
       case DO_WHILE_STATEMENT:
       case FOR_IN_STATEMENT:
       case FOR_OF_STATEMENT:
+      case FOR_ON_STATEMENT:
       case FOR_STATEMENT:
       case WHILE_STATEMENT:
         return true;

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -458,6 +458,21 @@
       "ParseTree"
     ]
   },
+  "ForOnStatement": {
+    "location": [
+      "SourceRange"
+    ],
+    "initializer": [
+      "ParseTree"
+    ],
+    "observable": [
+      "ParseTree"
+    ],
+    "body": [
+      "Block",
+      "ParseTree"
+    ]
+  },
   "ForStatement": {
     "location": [
       "SourceRange"

--- a/test/feature/AsyncGenerators/ForOn.module.js
+++ b/test/feature/AsyncGenerators/ForOn.module.js
@@ -1,0 +1,76 @@
+// Async.
+// Options: --async-functions --for-on --symbols
+
+import {AsyncGeneratorFunction} from './resources/observable.js';
+
+var o1 = new AsyncGeneratorFunction(function* () {
+  // TODO(mnieper): As soon as proper async generators are implemented, they
+  // should be used here.
+  yield 1;
+  yield 2;
+  yield 3;
+  return 4;
+});
+
+(async function () {
+
+  // test for on
+  var squares = [];
+  for (var i on o1) {
+    squares.push(i * i);
+  }
+  assert.deepEqual(squares, [1, 4, 9]);
+
+  // test break
+  var cubes = [];
+  for (var i on o1) {
+    if (i > 2) {
+      break;
+    }
+    cubes.push(i * i * i);
+  }
+  assert.deepEqual(cubes, [1, 8]);
+
+  // test continue
+  var list = [];
+  for (var i on o1) {
+    if (i === 2) {
+      continue;
+    }
+    list.push(i);
+  }
+  assert.deepEqual(list, [1, 3]);
+
+  // test outer continue
+  var almostEmpty = [];
+  label: do {
+    for (var i on o1) {
+      if (i === 2) {
+        continue label;
+      }
+      almostEmpty.push(i);
+    }
+  } while (false);
+  assert.deepEqual(almostEmpty, [1]);
+
+  // test return
+  var value = await (async function () {
+    for (var i on o1) {
+      if (i === 1) {
+        return 42;
+      }
+    }
+  })();
+  assert.equal(value, 42);
+
+  // test asynchronous loop body
+  var sum = 0;
+  for (var i on o1) {
+    sum += i;
+    await Promise.resolve();
+  }
+  assert.equal(sum, 6);
+
+  done();
+}()).catch(done);
+

--- a/test/feature/AsyncGenerators/resources/observable.js
+++ b/test/feature/AsyncGenerators/resources/observable.js
@@ -1,0 +1,71 @@
+const generator = Symbol();
+const onDone = Symbol();
+const generatorFunction = Symbol();
+
+function schedule(asyncF) {
+  return Promise.resolve().then(asyncF);
+}
+
+class DecoratedGenerator {
+  constructor(_generator, _onDone) {
+    this[generator] = _generator;
+    this[onDone] = _onDone;
+  }
+
+  next(value) {
+    var result = this[generator].next();
+    if (result.done) {
+      this[onDone].call(this);
+    }
+    return result;
+  }
+
+  throw(error) {
+    this[onDone].call(this);
+    return this[generator].throw(error);
+  }
+
+  return(value) {
+    this[onDone].call(this);
+    return this[generator].return(value);
+  }
+}
+
+
+export class AsyncGeneratorFunction {
+  constructor(_generatorFunction) {
+    this[generatorFunction] = _generatorFunction;
+  }
+
+  [Symbol.observer](observer) {
+    var generator = this[generatorFunction].call(this);
+    var done = false;
+    schedule(async function () {
+      var result;
+      while (!done) {
+        try {
+          result = generator.next();
+        } catch (e) {
+          observer.throw(e);
+          return;
+        }
+        if (result.done) {
+          observer.return(result.value);
+          return;
+        }
+        try {
+          result = observer.next(result.value);
+        } catch (e) {
+          generator.throw(e);
+        }
+        if (result.done) {
+          generator.return();
+          return;
+        }
+        await result.value;
+      }
+      generator.return();
+    });
+    return new DecoratedGenerator(observer, () => { done = true });
+  }
+}


### PR DESCRIPTION
This is my first try to implement parts of the async generators proposal at https://github.com/jhusain/asyncgenerator; see also #1673. This pull request adds a new option `--for-on` that allows asynchronous for-on-loops inside async functions. At the moment, only the basic cases are handled, so this pull request should not be merged yet. But it can be used to discuss implementation details.

As there is no formal spec for async generators and for-on loops yet, the hope is that this implementation will finally allow to shape such a spec. During this process, the implementation will likely have to be adjusted.