### PR TITLE
Change --source-root option to allow omitting sourceRoot

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -259,12 +259,12 @@ export class Compiler {
       sourceURL = undefined) {
     outputName = this.normalize(outputName);
 
-    if (typeof sourceRoot === 'undefined')
+    if (sourceRoot === undefined)
       sourceRoot = this.options_.sourceRoot;
 
-    if (sourceRoot === 'default')
+    if (sourceRoot === true)
       sourceRoot = basePath(outputName);
-    else if (!sourceRoot) // false or ''
+    else if (!sourceRoot) // false or '' or undefined
       sourceRoot = undefined;
     else
       sourceRoot = this.normalize(sourceRoot);

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -153,7 +153,7 @@ export class Compiler {
     // Attach the sourceURL only if the input and output names differ.
     var sourceURL = sourceName !== outputName ? sourceName : undefined;
     // The sourceRoot argument takes precidence over the option.
-    if (typeof sourceRoot === 'undefined')
+    if (sourceRoot === undefined)
       sourceRoot = this.options_.sourceRoot;
 
     return this.write(tree, outputName, sourceRoot, sourceURL);

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -219,6 +219,7 @@ export class Compiler {
           sourceRoot: sourceRoot,
           skipValidation: true
         }),
+        basepath: basePath(outputName),
         sourceRoot: sourceRoot,
         inputSourceMap: this.options_.inputSourceMap
       };

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -152,6 +152,10 @@ export class Compiler {
     tree = this.transform(tree, sourceName);
     // Attach the sourceURL only if the input and output names differ.
     var sourceURL = sourceName !== outputName ? sourceName : undefined;
+    // The sourceRoot argument takes precidence over the option.
+    if (typeof sourceRoot === 'undefined')
+      sourceRoot = this.options_.sourceRoot;
+
     return this.write(tree, outputName, sourceRoot, sourceURL);
   }
 
@@ -254,7 +258,16 @@ export class Compiler {
   write(tree, outputName = undefined, sourceRoot = undefined,
       sourceURL = undefined) {
     outputName = this.normalize(outputName);
-    sourceRoot = this.normalize(sourceRoot) || basePath(outputName);
+
+    if (typeof sourceRoot === 'undefined')
+      sourceRoot = this.options_.sourceRoot;
+
+    if (sourceRoot === 'default')
+      sourceRoot = basePath(outputName);
+    else if (!sourceRoot) // false or ''
+      sourceRoot = undefined;
+    else
+      sourceRoot = this.normalize(sourceRoot);
 
     var writer;
     this.sourceMapCache_ = null;

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -288,7 +288,7 @@ export class Compiler {
 
     if (this.sourceMapConfiguration_) {
       var sourceMappingURL =
-          this.sourceMappingURL(outputName || sourceURL || 'unnamed.js');
+          this.sourceMappingURL(sourceURL || outputName || 'unnamed.js');
       var sourceMap = this.getSourceMap();
       compiledCode += '\n//# sourceMappingURL=' + sourceMappingURL + '\n';
       // The source map info for in-memory maps

--- a/src/Options.js
+++ b/src/Options.js
@@ -54,6 +54,7 @@ export var optionsV01 = enumerableOnlyObject({
   restParameters: true,
   script: false,
   sourceMaps: false,
+  sourceRoot: 'default',
   spread: true,
   symbols: false,
   templateLiterals: true,
@@ -196,6 +197,11 @@ export class Options {
         writable: true,
         enumerable: false
       },
+      sourceRoot_: {
+        value: versionLockedOptions.sourceRoot,
+        writable: true,
+        enumerable: false
+      },
       transformOptions: {
         value: Object.create(transformOptionsPrototype, {
           proxiedOptions_: {
@@ -301,6 +307,15 @@ export class Options {
           '[false|inline|file|memory], not ' + value);
     }
   }
+
+  get sourceRoot() {
+    return this.sourceRoot_;
+  }
+
+  set sourceRoot(value) {
+    this.sourceRoot_ = value ? String(value) : '';
+  }
+
   /**
    * Resets all options to the default value or to false if |allOff| is
    * true.
@@ -323,6 +338,7 @@ export class Options {
     this.outputLanguage = 'es5';
     this.referrer = '';
     this.sourceMaps = false;
+    this.sourceRoot = 'default';
     this.lowResolutionSourceMap = false;
     this.inputSourceMap = false;
     this.typeAssertionModule = null;
@@ -340,6 +356,8 @@ export class Options {
         typeof object.sourceMaps === 'string') {
       this.sourceMaps = object.sourceMaps;
     }
+    if (typeof object.sourceRoot !== 'undefined')
+      this.sourceRoot = object.sourceRoot;
     return this;
   }
 
@@ -504,6 +522,14 @@ export function addOptions(flags, commandOptions) {
   flags.option('--source-maps [file|inline|memory]',
     'sourceMaps generated to file or inline with data: URL',
     (to) => { return commandOptions.sourceMaps = to; }
+  );
+  flags.option('--source-root <false|string|default>',
+    'absolute path to source at execution time',
+    (to) => {
+      if (to==='false')
+        to = false;
+      return commandOptions.sourceRoot = to;
+    }
   );
   flags.option('--low-resolution-source-maps',
     'Lower sourceMaps granularity to one mapping per output line',

--- a/src/Options.js
+++ b/src/Options.js
@@ -521,7 +521,7 @@ export function addOptions(flags, commandOptions) {
     (to) => {
       if (to === 'false')
         to = false;
-      if (to === 'true')
+      else if (to === 'true')
         to = true;
       return commandOptions.sourceRoot = to;
     }

--- a/src/Options.js
+++ b/src/Options.js
@@ -54,7 +54,7 @@ export var optionsV01 = enumerableOnlyObject({
   restParameters: true,
   script: false,
   sourceMaps: false,
-  sourceRoot: 'default',
+  sourceRoot: true,
   spread: true,
   symbols: false,
   templateLiterals: true,
@@ -308,14 +308,6 @@ export class Options {
     }
   }
 
-  get sourceRoot() {
-    return this.sourceRoot_;
-  }
-
-  set sourceRoot(value) {
-    this.sourceRoot_ = value ? String(value) : '';
-  }
-
   /**
    * Resets all options to the default value or to false if |allOff| is
    * true.
@@ -338,7 +330,7 @@ export class Options {
     this.outputLanguage = 'es5';
     this.referrer = '';
     this.sourceMaps = false;
-    this.sourceRoot = 'default';
+    this.sourceRoot = true;
     this.lowResolutionSourceMap = false;
     this.inputSourceMap = false;
     this.typeAssertionModule = null;
@@ -356,7 +348,7 @@ export class Options {
         typeof object.sourceMaps === 'string') {
       this.sourceMaps = object.sourceMaps;
     }
-    if (typeof object.sourceRoot !== 'undefined')
+    if (object.sourceRoot !== undefined)
       this.sourceRoot = object.sourceRoot;
     return this;
   }
@@ -523,11 +515,14 @@ export function addOptions(flags, commandOptions) {
     'sourceMaps generated to file or inline with data: URL',
     (to) => { return commandOptions.sourceMaps = to; }
   );
-  flags.option('--source-root <false|string|default>',
-    'absolute path to source at execution time',
+  flags.option('--source-root <true|false|string>',
+    'absolute path to source at execution time. false to omit, ' +
+        'true for directory of output file.',
     (to) => {
-      if (to==='false')
+      if (to === 'false')
         to = false;
+      if (to === 'true')
+        to = true;
       return commandOptions.sourceRoot = to;
     }
   );

--- a/src/outputgeneration/ParseTreeMapWriter.js
+++ b/src/outputgeneration/ParseTreeMapWriter.js
@@ -27,6 +27,7 @@ export class ParseTreeMapWriter extends ParseTreeWriter {
     this.sourceMapGenerator_ = sourceMapConfiguration.sourceMapGenerator;
     this.sourceRoot_ = sourceMapConfiguration.sourceRoot;
     this.lowResolution_ = sourceMapConfiguration.lowResolution;
+    this.basepath_ = sourceMapConfiguration.basepath;
     this.outputLineCount_ = 1;
     this.isFirstMapping_ = true;
   }
@@ -117,8 +118,8 @@ export class ParseTreeMapWriter extends ParseTreeWriter {
     };
     if (position.source.name !== this.sourceName_) {
       this.sourceName_ = position.source.name;
-      this.relativeSourceName_ = relativeToSourceRoot(position.source.name,
-              this.sourceRoot_);
+      this.relativeSourceName_ = relativePath(position.source.name,
+              this.basepath_);
       this.sourceMapGenerator_.setSourceContent(position.source.name,
           position.source.contents);
     }
@@ -162,7 +163,7 @@ export class ParseTreeMapWriter extends ParseTreeWriter {
   }
 }
 
-export function relativeToSourceRoot(name, sourceRoot) {
+export function relativePath(name, sourceRoot) {
   if (!name || name[0] === '@')  // @ means internal name
     return name;
   if (!sourceRoot)

--- a/src/runtime/LoaderCompiler.js
+++ b/src/runtime/LoaderCompiler.js
@@ -79,8 +79,11 @@ export class LoaderCompiler {
     var outputName = metadata.outputName || metadata.sourceName ||
         '<loaderOutput>';
     var sourceRoot = metadata.sourceRoot;
+    var sourceURL = metadata.sourceName
+        || codeUnit.normalizedName
+        || codeUnit.address;
     metadata.transcoded = metadata.compiler.write(metadata.transformedTree,
-        outputName, undefined, codeUnit.address || codeUnit.normalizedName);
+        outputName, undefined, sourceURL);
   }
 
   evaluateCodeUnit(codeUnit) {

--- a/test/node-api-test.js
+++ b/test/node-api-test.js
@@ -4,7 +4,8 @@ suite('node public api', function() {
   var traceurAPI = require('../src/node/api.js');
   var sourceMapUtil = require('source-map/lib/source-map/util.js');
 
-  var nativeFilename = path.join(__dirname + '/commonjs/BasicImport.js');
+  var relativeFilename = '/commonjs/BasicImport.js';
+  var nativeFilename = path.join(__dirname + relativeFilename);
   var nativeDirname = __dirname;
   assert(nativeDirname[nativeDirname.length - 1] !== path.sep,
       'expect no trailing slash');
@@ -66,8 +67,12 @@ suite('node public api', function() {
     var sourceMap = JSON.parse(compiler.getSourceMap());
     assert.equal(traceurDirname, sourceMap.sourceRoot,
         'has correct sourceRoot');
+    // The sourceRoot given here, when combined with the 'sources'
+    // entry is not a filename.
+    var notAFileName = traceurDirname  + '/BasicImport.js';
     assert(sourceMap.sources.some(function(name) {
-      return sourceMapUtil.join(sourceMap.sourceRoot, name) === traceurFilename;
+      var fromSourceRoot = sourceMapUtil.join(sourceMap.sourceRoot, name);
+      return fromSourceRoot === notAFileName;
     }), 'One of the sources is the source');
   });
 
@@ -88,8 +93,11 @@ suite('node public api', function() {
     var sourceMap = JSON.parse(compiler.getSourceMap());
     assert.equal(traceurDirname, sourceMap.sourceRoot,
         'has correct sourceRoot');
+    // The sourceRoot given here, when combined with the 'sources'
+    // entry is not a filename.
+    var notAFileName = traceurDirname  + '/BasicImport.js';
     assert(sourceMap.sources.some(function(name) {
-      return (sourceMap.sourceRoot + '/' + name) === traceurFilename;
+      return (sourceMap.sourceRoot + '/' + name) === notAFileName;
     }), 'One of the sources is the source');
   });
 

--- a/test/unit/CompileOptions.js
+++ b/test/unit/CompileOptions.js
@@ -138,7 +138,7 @@ suite('options', function() {
 
   test('sourceRoot', function() {
     var options = new Options();
-    assert.equal(options.sourceRoot, 'default');
+    assert.equal(options.sourceRoot, true);
 
     options.sourceRoot = false;
     assert.equal(options.sourceRoot, '');
@@ -152,8 +152,8 @@ suite('options', function() {
     from = new Options(options);
     assert.equal(from.sourceRoot, '/tmp');
 
-    options.sourceRoot = 'default';
-    assert.equal(options.sourceRoot, 'default');
+    options.sourceRoot = true;
+    assert.equal(options.sourceRoot, true);
 
   });
 });

--- a/test/unit/CompileOptions.js
+++ b/test/unit/CompileOptions.js
@@ -135,4 +135,25 @@ suite('options', function() {
     options.memberVariables = true;
     assert.equal(options.atscript, true);
   });
+
+  test('sourceRoot', function() {
+    var options = new Options();
+    assert.equal(options.sourceRoot, 'default');
+
+    options.sourceRoot = false;
+    assert.equal(options.sourceRoot, '');
+
+    var from = new Options(options);
+    assert.equal(from.sourceRoot, '');
+
+    options.sourceRoot = '/tmp';
+    assert.equal(options.sourceRoot, '/tmp');
+
+    from = new Options(options);
+    assert.equal(from.sourceRoot, '/tmp');
+
+    options.sourceRoot = 'default';
+    assert.equal(options.sourceRoot, 'default');
+
+  });
 });

--- a/test/unit/Compiler.js
+++ b/test/unit/Compiler.js
@@ -46,15 +46,16 @@ suite('Compiler', function() {
 
   test('Compiler options locked', function() {
     var Options = get('src/Options.js').Options;
-    var checkDiff =
-        new Options({blockBinding: !versionLockedOptions.blockBinding});
-    assert.equal(checkDiff.diff(versionLockedOptions).length, 1);
 
     var options = new Options();
     var mismatches = options.diff(versionLockedOptions);
     if (mismatches.length)
       console.error('Options changed ', mismatches);
     assert.equal(mismatches.length, 0);
+
+    var checkDiff =
+        new Options({blockBinding: !versionLockedOptions.blockBinding});
+    assert.equal(checkDiff.diff(versionLockedOptions).length, 1);
   });
 
 });

--- a/test/unit/codegeneration/SourceMap.js
+++ b/test/unit/codegeneration/SourceMap.js
@@ -30,24 +30,24 @@ suite('SourceMap.js', function() {
                                            lowResolutionSourceMap: true});
 
   test('relativeToSource', function() {
-    var relativeToSourceRoot =
-        get('src/outputgeneration/ParseTreeMapWriter.js').relativeToSourceRoot;
-    assert.equal(relativeToSourceRoot('@foo', '/w/t/out/'), '@foo',
+    var relativePath =
+        get('src/outputgeneration/ParseTreeMapWriter.js').relativePath;
+    assert.equal(relativePath('@foo', '/w/t/out/'), '@foo',
         '@ names are unchanged');
 
-    assert.equal(relativeToSourceRoot('/w/t/src/foo.js', '/w/t/out/'), '../src/foo.js',
+    assert.equal(relativePath('/w/t/src/foo.js', '/w/t/out/'), '../src/foo.js',
         'relative to sourceRoot in /out');
 
-    assert.equal(relativeToSourceRoot('/w/t/src/bar/foo.js', '/w/t/out/'),
+    assert.equal(relativePath('/w/t/src/bar/foo.js', '/w/t/out/'),
         '../src/bar/foo.js', 'deeper left side');
 
-    assert.equal(relativeToSourceRoot('/w/t/src/bar/foo.js', '/w/t/out/baz/'),
+    assert.equal(relativePath('/w/t/src/bar/foo.js', '/w/t/out/baz/'),
         '../../src/bar/foo.js', 'deeper both side');
 
-    assert.equal(relativeToSourceRoot('/w/t/src/foo.js', '/w/t/src/'),
+    assert.equal(relativePath('/w/t/src/foo.js', '/w/t/src/'),
         'foo.js', 'same directory  ');
 
-    assert.equal(relativeToSourceRoot('/w/t/src/foo.js', '/w/t/out'),
+    assert.equal(relativePath('/w/t/src/foo.js', '/w/t/out'),
         '../src/foo.js', 'missing trailing slash');
   });
 

--- a/test/unit/codegeneration/SourceMap.js
+++ b/test/unit/codegeneration/SourceMap.js
@@ -216,8 +216,12 @@ suite('SourceMap.js', function() {
     var filename = 'sourceMapImportSpecifierSet.js';
     var tree = moduleCompiler.parse(src, filename);
     var actual = moduleCompiler.write(tree);
+    // The sourceMappingURL should be relativel
+    assert.notEqual(actual.indexOf('//# sourceMappingURL=unnamed.map'), -1);
 
-    var consumer = new SourceMapConsumer(moduleCompiler.getSourceMap(filename));
+    var sourceMap = moduleCompiler.getSourceMap(filename);
+    assert.equal(JSON.parse(sourceMap).sources[0], filename);
+    var consumer = new SourceMapConsumer(sourceMap);
 
     var sourceContent = consumer.sourceContentFor(filename);
     assert.equal(sourceContent, src);

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -172,7 +172,7 @@ suite('context test', function() {
     tempFileName = resolve('./out/sourceroot-test.js');
     var executable = 'node ' + resolve('src/node/command.js');
     var inputFileName = resolve('test/unit/node/resources/import-x.js');
-    var commandLine = executable + ' --source-maps --source-root=\"/tmp\"' +
+    var commandLine = executable + ' --source-maps --source-root="/tmp"' +
      ' --out ' + tempFileName + ' -- ' + inputFileName;
     exec(commandLine, function(error, stdout, stderr) {
       assert.isNull(error);

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -159,8 +159,12 @@ suite('context test', function() {
       assert.equal(actualSourceRoot, resolve('./out') + '/',
           'has the correct sourceroot');
       var foundInput = map.sources.some(function(name) {
-        return inputFileName ===
-            forwardSlash(path.resolve(actualSourceRoot, name));
+        var resolved = forwardSlash(path.resolve(actualSourceRoot, name));
+        if (inputFileName === resolved) {
+          // The 'sources' entry is relative
+          assert.equal(name.indexOf('.'), 0);
+          return true;
+        }
       });
       assert(foundInput,
           'the inputFileName is one of the sourcemap sources');


### PR DESCRIPTION
Now --source-root <false|string|default>.
The default option is as before.

Fixes #1676