### PR TITLE
Do not add an initializer to for-of loops

### DIFF
--- a/test/feature/Scope/ForInInitializers.js
+++ b/test/feature/Scope/ForInInitializers.js
@@ -1,0 +1,10 @@
+// Options: --block-binding
+
+(function() {
+  var y;
+  for (var x in {a: 'A'}) {
+    assert.equal(x, 'a');
+    y = x;
+  }
+  assert.equal(y, 'a');
+})();

--- a/test/unit/codegeneration/BlockBindingTransformer.js
+++ b/test/unit/codegeneration/BlockBindingTransformer.js
@@ -341,4 +341,22 @@ suite('BlockBindingTransformer.js', function() {
       '  }' +
       '}');
 
+  makeTest('for in',
+      'function g() {' +
+      '  for (var x in {}) {}' +
+      '}',
+      // ======
+      'function g() {' +
+      '  for (var x in {}) {}' +
+      '}');
+
+  makeTest('for of',
+      'function g() {' +
+      '  for (var x of []) {}' +
+      '}',
+      // ======
+      'function g() {' +
+      '  for (var x of []) {}' +
+      '}');
+
 });


### PR DESCRIPTION
Check if the current loop is a for-in (or for-of) loop before we
add an RHS to the loop initializer.

Fixes #1647