### PR TITLE
Options.experimental() and Options.atscript().

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -247,6 +247,13 @@ export class Options {
     return value;
   }
 
+  /**
+   * @return {Options} with every experimental option set true.
+   */
+  static experimental() {
+    return new Options(experimentalOptions);
+  }
+
   get atscript() {
     return this.types && this.annotations && this.memberVariables;
   }
@@ -255,6 +262,13 @@ export class Options {
     this.types = value;
     this.annotations = value;
     this.memberVariables = value;
+  }
+
+  /**
+   * @return {Options} with every atScript option set true.
+   */
+  static atscript() {
+    return new Options({types: true, annotations: true, memberVariables: true});
   }
 
   get modules() {

--- a/test/unit/CompileOptions.js
+++ b/test/unit/CompileOptions.js
@@ -85,6 +85,32 @@ suite('options', function() {
         'memory');
   });
 
+  test('experimental static', function(){
+    var experimental = Options.experimental();
+
+    assert.equal(experimental.annotations, true);
+    assert.equal(experimental.arrayComprehension, true);
+    assert.equal(experimental.asyncFunctions, true);
+    assert.equal(experimental.exponentiation, true);
+    assert.equal(experimental.generatorComprehension, true);
+    assert.equal(experimental.require, true);
+    assert.equal(experimental.symbols, true);
+    assert.equal(experimental.types, true);
+    assert.equal(experimental.memberVariables, true);
+
+    var butNotTypes = Options.experimental().setFromObject({types: false});
+    assert.equal(butNotTypes.types, false);
+    assert.equal(butNotTypes.diff(experimental).length, 1);
+  });
+
+  test('atscript static', function() {
+    var options = Options.atscript();
+
+    assert.equal(options.types, true);
+    assert.equal(options.annotations, true);
+    assert.equal(options.memberVariables, true);
+  });
+
   test('atscript setter', function() {
     var options = new Options();
 


### PR DESCRIPTION
Add static methods returning new Options objects with option
properties set for --experimental and --atscript multi-options.

Fixes #1490
Fixes #1670