### PR TITLE
Remove .js hack for module names

### DIFF
--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -59,17 +59,9 @@ export class TraceurLoader extends Loader {
   }
 
   locate(load) {
-    var normalizedModuleName = load.normalizedName;
     load.metadata.traceurOptions = load.metadata.traceurOptions || {};
+    var url = load.normalizedName;
     var options = load.metadata.traceurOptions;
-    var asJS;
-    if (/\.js$/.test(normalizedModuleName) || options && options.script) {
-      asJS = normalizedModuleName;
-    } else {
-      // Backwards compat.
-      asJS = normalizedModuleName + '.js';
-    }
-
     var baseURL = load.metadata && load.metadata.baseURL;
     baseURL = baseURL || this.baseURL;
 
@@ -90,20 +82,20 @@ export class TraceurLoader extends Loader {
       if (commonChars) {
         var packageName = referrer.slice(0, -commonChars);
         var rootDirectory = baseURL.slice(0, -commonChars);
-        if (asJS.indexOf(packageName) === 0) {
-          asJS = asJS.replace(packageName, rootDirectory);
+        if (url.indexOf(packageName) === 0) {
+          url = url.replace(packageName, rootDirectory);
         }
       }
 
     }
 
-    if (!isAbsolute(asJS)) {
+    if (!isAbsolute(url)) {
       if (baseURL) {
         load.metadata.baseURL = baseURL;
-        asJS = resolveUrl(baseURL, asJS);
+        url = resolveUrl(baseURL, url);
       }
     }
-    return asJS;
+    return url;
   }
 
   // The name set into the tree, and used for sourcemaps

--- a/src/semantics/ScopeChainBuilderWithReferences.js
+++ b/src/semantics/ScopeChainBuilderWithReferences.js
@@ -22,8 +22,8 @@ import {
   MODULE,
   PROPERTY_METHOD_ASSIGNMENT,
   SET_ACCESSOR
-} from '../syntax/trees/ParseTreeType';
-import {TYPEOF} from '../syntax/TokenType';
+} from '../syntax/trees/ParseTreeType.js';
+import {TYPEOF} from '../syntax/TokenType.js';
 
 function hasArgumentsInScope(scope) {
   for (; scope; scope = scope.parent) {

--- a/src/semantics/ScopeReferences.js
+++ b/src/semantics/ScopeReferences.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Scope} from './Scope';
+import {Scope} from './Scope.js';
 
 export class ScopeReferences extends Scope {
   /**

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -17,13 +17,11 @@ export {System} from './runtime/System.js';
 // Used by unit tests only
 import './util/MutedErrorReporter.js';
 
-// TODO(arv): Change this to .js after a npm push
-export {ModuleStore} from '@traceur/src/runtime/ModuleStore';
+export {ModuleStore} from '@traceur/src/runtime/ModuleStore.js';
 export {WebPageTranscoder} from './WebPageTranscoder.js';
 import {addOptions, CommandOptions, Options} from './Options.js';
 
-// TODO(arv): Change this to .js after a npm push
-import {ModuleStore} from '@traceur/src/runtime/ModuleStore';
+import {ModuleStore} from '@traceur/src/runtime/ModuleStore.js';
 
 export function get(name) {
   return ModuleStore.get(ModuleStore.normalize('./' + name, __moduleName));

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -61,9 +61,9 @@ suite('Loader.js', function() {
       data: {}
     }
     load.normalizedName = '@abc/def';
-    assert.equal(loader.locate(load), 'http://example.org/a/@abc/def.js');
+    assert.equal(loader.locate(load), 'http://example.org/a/@abc/def');
     load.normalizedName = 'abc/def';
-    assert.equal(loader.locate(load), 'http://example.org/a/abc/def.js');
+    assert.equal(loader.locate(load), 'http://example.org/a/abc/def');
     load.normalizedName = 'abc/def.js';
     assert.equal(loader.locate(load), 'http://example.org/a/abc/def.js');
     load.normalizedName = './abc/def.js';
@@ -270,7 +270,7 @@ suite('Loader.js', function() {
   test('LoaderImport.Fail.deperror', function(done) {
     var reporter = new MutedErrorReporter();
     var metadata = {traceurOptions: {sourceMaps: 'memory'}};
-    getLoader(reporter).import('loads/main', {metadata: metadata}).then(
+    getLoader(reporter).import('loads/main.js', {metadata: metadata}).then(
       function(mod) {
         fail('should not have succeeded')
         done();

--- a/test/unit/runtime/loads/main.js
+++ b/test/unit/runtime/loads/main.js
@@ -1,1 +1,1 @@
-import "./deperror";
+import "./deperror.js";


### PR DESCRIPTION
The npm version has now been updated so that we no longer need this
spec violating hack.

This found a few cases where we loaded modules twice (once for .js
and once for no file extension on the name).