### PR TITLE
Implement let and const in generators.

### DIFF
--- a/src/codegeneration/BlockBindingTransformer.js
+++ b/src/codegeneration/BlockBindingTransformer.js
@@ -141,6 +141,11 @@ import {prependStatements} from './PrependStatements.js';
  *
  * The block binding rewrite pass assumes that deconstructing assignments
  * and variable declarations have already been desugared. See getVariableName_.
+ *
+ * Note:
+ *
+ * If the transformation happens inside a generator, the inner function
+ * becomes an inner generator.
  */
 
 function varNeedsInitializer(tree, loopTree) {
@@ -613,9 +618,10 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
 
       var iifeInfo = FnExtractAbruptCompletions.createIIFE(
           this.idGenerator_, tree.body, iifeParameterList, iifeArgumentList,
-          () => loopLabel = loopLabel ||
-              this.idGenerator_.generateUniqueIdentifier()
-      );
+          () => {
+            return loopLabel = loopLabel ||
+                this.idGenerator_.generateUniqueIdentifier()
+          }, this.scope_.inGenerator);
 
       tree = loopFactory(initializer, renames, iifeInfo.loopBody);
 

--- a/src/semantics/Scope.js
+++ b/src/semantics/Scope.js
@@ -42,6 +42,7 @@ export class Scope {
     // Let and const as well as block scoped functions.
     this.lexicalDeclarations = Object.create(null);
     this.strictMode = parent && parent.strictMode || isTreeStrict(tree);
+    this.inGenerator = parent ? parent.inGenerator || false : false;
   }
 
   addBinding(tree, type, reporter) {

--- a/src/semantics/ScopeChainBuilder.js
+++ b/src/semantics/ScopeChainBuilder.js
@@ -62,6 +62,7 @@ export class ScopeChainBuilder extends ScopeVisitor {
       this.visitAny(tree.name);
     }
     this.visitAny(tree.parameterList);
+    scope.inGenerator = tree.isGenerator();
     this.visitAny(tree.body);
     this.popScope(scope);
   }

--- a/src/semantics/ScopeVisitor.js
+++ b/src/semantics/ScopeVisitor.js
@@ -88,6 +88,7 @@ export class ScopeVisitor extends ParseTreeVisitor {
   visitFunctionBodyForScope(tree, parameterList = tree.parameterList) {
     var scope = this.pushScope(tree);
     this.visitAny(parameterList);
+    scope.inGenerator = tree.functionKind && tree.isGenerator();
     this.visitAny(tree.body);
     this.popScope(scope);
   }

--- a/test/feature/Scope/LetInGenerators.js
+++ b/test/feature/Scope/LetInGenerators.js
@@ -1,0 +1,15 @@
+function h(t) {
+  return t();
+}
+
+function* f() {
+  for (let i = 0; i < 3; ++i) {
+    yield h(() => i);
+  }
+}
+
+var g = f();
+assert.deepEqual(g.next(), {value: 0, done: false});
+assert.deepEqual(g.next(), {value: 1, done: false});
+assert.deepEqual(g.next(), {value: 2, done: false});
+


### PR DESCRIPTION
At the moment, the block binding transformer wraps loop bodies into functions. This is a problem if loop bodies do contain `yield` expressions.

Following an idea of @arv, this patch turns those generated functions into generator functions if needed and lets the outer code yield from them.

Fixes #1379.
