### PR TITLE
Exit with non-zero error if unit-test fails.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test: test/test-list.js bin/traceur.js \
 	node_modules/.bin/mocha $(MOCHA_OPTIONS) $(TESTS)
 	$(MAKE) test-interpret-throw
 
-test/unit/util/: bin/traceur.js
+test/unit/util/: bin/traceur.js bin/traceur-runtime.js
 	./traceur test/modular/tests.js
 
 test/unit: bin/traceur.js bin/traceur-runtime.js $(UNIT_TESTS)

--- a/test/modular/Mocha6.js
+++ b/test/modular/Mocha6.js
@@ -68,7 +68,7 @@ export class Mocha6 extends Mocha {
   run(fn) {
     return this.importFiles().then(() => {
       // The base mocha.run will not load files, see loadFiles() override.
-      super.run(fn);
+      return super.run(fn);
     });
   }
 }

--- a/test/modular/tests.js
+++ b/test/modular/tests.js
@@ -34,6 +34,12 @@ patterns.forEach((pattern) => {
   files.forEach((file) => testRunner.addFile(file));
 });
 
-testRunner.run().catch((ex) => {
-  console.error('testRunner run FAILED', ex.stack || ex);
+testRunner.run().then((runner) => {
+  var failed = 0; 
+  runner.on('fail', (err) => {
+    failed++;
+  });
+  runner.on('end', () => {
+    process.exit(failed);
+  });
 });


### PR DESCRIPTION
Build bin/traceur-runtime.js before unit-test
Fixes #1719