### PR TITLE
Skip extraneous rending of the AST to transcoded source.

### DIFF
--- a/src/runtime/InlineLoaderCompiler.js
+++ b/src/runtime/InlineLoaderCompiler.js
@@ -22,6 +22,11 @@ export class InlineLoaderCompiler extends LoaderCompiler {
     this.elements = elements;
   }
 
+  write() {
+    // no-op. The tree will be concatentated by evaluate and
+    // written by the caller of toTree();
+  }
+
   evaluateCodeUnit(codeUnit) {
     // Don't eval. Instead append the trees to the output.
     var tree = codeUnit.metadata.transformedTree;


### PR DESCRIPTION
When bundling multiple modules we concatentate the tree then write
it all out to a file. Writing the individual modules from tree to transcoded source
is just wasted.