### PR TITLE
Fix issue with async arrow function

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -2516,7 +2516,7 @@ export class Parser {
         left.identifierToken.value === ASYNC && type === IDENTIFIER) {
       if (this.peekTokenNoLineTerminator_() !== null) {
         var bindingIdentifier = this.parseBindingIdentifier_();
-        var asyncToken = left.IdentifierToken;
+        var asyncToken = left.identifierToken;
         return this.parseArrowFunction_(start, bindingIdentifier,
             asyncToken);
       }

--- a/test/feature/AsyncFunctions/AsyncArrow2.js
+++ b/test/feature/AsyncFunctions/AsyncArrow2.js
@@ -1,0 +1,9 @@
+// Options: --async-functions
+// Async.
+
+var f = async x => x;
+
+f(1).then((result) => {
+  assert.equal(result, 1);
+  done();
+}).catch(done);


### PR DESCRIPTION
A typo caused the async token to be undefined.

Fixes #1723