### PR TITLE
Implement proper tail calls.

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -49,6 +49,7 @@ export var optionsV01 = enumerableOnlyObject({
   modules: 'register',
   numericLiterals: true,
   outputLanguage: 'es5',
+  properTailCalls: false,
   propertyMethods: true,
   propertyNameShorthand: true,
   referrer: '',
@@ -136,6 +137,10 @@ addFeatureOption('templateLiterals', ON_BY_DEFAULT);   // 7.6.8
 addFeatureOption('unicodeEscapeSequences', ON_BY_DEFAULT);  // 11.8.4
 addFeatureOption('unicodeExpressions', ON_BY_DEFAULT);
 
+// EXPERIMENTAL due to performance impact although properly part of ES6
+addFeatureOption('properTailCalls', EXPERIMENTAL);
+addFeatureOption('symbols', EXPERIMENTAL);
+
 // EXPERIMENTAL
 addFeatureOption('annotations', EXPERIMENTAL);
 addFeatureOption('arrayComprehension', EXPERIMENTAL); // 11.4.1.2
@@ -146,7 +151,6 @@ addFeatureOption('forOn', EXPERIMENTAL);
 addFeatureOption('generatorComprehension', EXPERIMENTAL);
 addFeatureOption('memberVariables', EXPERIMENTAL);
 addFeatureOption('require', EXPERIMENTAL);
-addFeatureOption('symbols', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
 
 var transformOptionsPrototype = {};

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -41,6 +41,7 @@ import {ObjectLiteralTransformer} from './ObjectLiteralTransformer.js';
 import {PropertyNameShorthandTransformer} from
     './PropertyNameShorthandTransformer.js';
 import {InstantiateModuleTransformer} from './InstantiateModuleTransformer.js';
+import {ProperTailCallTransformer} from './ProperTailCallTransformer.js';
 import {RegularExpressionTransformer} from './RegularExpressionTransformer.js';
 import {RestParameterTransformer} from './RestParameterTransformer.js';
 import {SpreadTransformer} from './SpreadTransformer.js';
@@ -158,7 +159,8 @@ export class FromOptionsTransformer extends MultiTransformer {
       append(ClassTransformer);
 
     if (transformOptions.propertyMethods ||
-              transformOptions.computedPropertyNames) {
+        transformOptions.computedPropertyNames ||
+        transformOptions.properTailCalls) {
       append(ObjectLiteralTransformer);
     }
 
@@ -217,5 +219,9 @@ export class FromOptionsTransformer extends MultiTransformer {
 
     if (transformOptions.symbols)
       append(SymbolTransformer);
+
+    if (transformOptions.properTailCalls) {
+      append(ProperTailCallTransformer);
+    }
   }
 }

--- a/src/codegeneration/ProperTailCallTransformer.js
+++ b/src/codegeneration/ProperTailCallTransformer.js
@@ -1,0 +1,133 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {TempVarTransformer} from './TempVarTransformer.js';
+import {RewriteTailCallsTransformer} from './RewriteTailCallsTransformer.js';
+import {
+  createFunctionBody,
+  createFunctionExpression,
+  createIdentifierExpression as id
+} from './ParseTreeFactory.js';
+import {
+  parseExpression,
+  parseStatement,
+  parseStatements
+} from './PlaceholderParser.js';
+import {
+  AnonBlock,
+  FunctionDeclaration,
+  FunctionExpression,
+} from '../syntax/trees/ParseTrees.js';
+
+//
+// Example:
+//
+// function f(a) {
+//   var b = g(a);
+//   f;
+//   return h(b);
+// }
+//
+// Becomes:
+//
+// $traceurRuntime.initTailRecursiveFunction(function f(a) {
+//   return $traceurRuntime.call(function(a) {
+//     var b = g(a);
+//     f;
+//     return $traceurRuntime.continuation(h, null, [b]);
+//   }, this, arguments);
+// })
+
+export class ProperTailCallTransformer extends TempVarTransformer {
+  // TODO(mnieper): This transformer currently expects that classes and template
+  // literals have already been desugared. Otherwise they are not guaranteed
+  // to have proper tail calls.
+
+  constructor(identifierGenerator) {
+    super(identifierGenerator);
+    this.inBlock_ = false;
+  }
+
+  transformFunctionDeclaration(tree) {
+    var tree = super.transformFunctionDeclaration(tree);
+    if (tree.functionKind !== null) {
+      // do not transform async/generator functions
+      return tree;
+    }
+
+    var nameIdExpression = id(tree.name.identifierToken);
+
+    var setupFlagExpression = parseExpression
+        `$traceurRuntime.initTailRecursiveFunction(${nameIdExpression})`;
+
+    var funcDecl = this.transformFunction_(tree, FunctionDeclaration);
+    if (funcDecl === tree) {
+      return tree;
+    }
+
+    // Function declarations in blocks do not hoist. In that case we add the
+    // variable declaration after the function declaration.
+
+    var tmpVar = id(this.inBlock_ ?
+        this.getTempIdentifier() : this.addTempVar(setupFlagExpression));
+
+    if (!this.inBlock_) {
+      return funcDecl;
+    }
+
+    return new AnonBlock(null, [
+      funcDecl,
+      parseStatement `var ${tmpVar} = ${setupFlagExpression};`
+    ]);
+  }
+
+  transformFunctionExpression(tree) {
+    var tree = super.transformFunctionExpression(tree);
+    if (tree.functionKind) {
+      // do not transform async/generator functions
+      return tree;
+    }
+
+    var functionExpression =
+        this.transformFunction_(tree, FunctionExpression);
+
+    if (functionExpression === tree) {
+      return tree;
+    }
+
+    return parseExpression `
+        $traceurRuntime.initTailRecursiveFunction(${functionExpression})`;
+  }
+
+  transformFunction_(tree, constructor) {
+    var body = RewriteTailCallsTransformer.transform(this, tree.body);
+    if (body === tree.body) {
+      return tree;
+    }
+    var func = id(this.getTempIdentifier());
+    var innerFunction = createFunctionExpression(tree.parameterList, body);
+    var outerBody = createFunctionBody(parseStatements `
+        return $traceurRuntime.call(${innerFunction}, this, arguments);`);
+    return new constructor(tree.location, tree.name, tree.functionKind,
+        tree.parameterList, tree.typeAnnotation, tree.annotations, outerBody);
+  }
+
+  transformBlock(tree) {
+    var inBlock = this.inBlock_;
+    this.inBlock_ = true;
+    var rv = super.transformBlock(tree);
+    this.inBlock_ = inBlock;
+    return rv;
+  }
+}

--- a/src/codegeneration/RewriteTailCallsTransformer.js
+++ b/src/codegeneration/RewriteTailCallsTransformer.js
@@ -1,0 +1,76 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ParseTreeTransformer} from './ParseTreeTransformer.js';
+import {RewriteTailExpressionsTransformer} from
+    './RewriteTailExpressionsTransformer.js';
+import {
+  ReturnStatement,
+  TryStatement
+} from '../syntax/trees/ParseTrees.js';
+
+export class RewriteTailCallsTransformer extends ParseTreeTransformer {
+  constructor(bodyTransformer) {
+    this.bodyTransformer_ = bodyTransformer;
+  }
+
+  transformReturnStatement(tree) {
+    var expression = tree.expression;
+    if (expression !== null) {
+      expression = RewriteTailExpressionsTransformer.transform(
+          this.bodyTransformer_, expression);
+      if (expression !== tree.expression) {
+        return new ReturnStatement(tree.location, expression);
+      }
+    }
+    return tree;
+  }
+
+  transformTryStatement(tree) {
+    var block;
+    if (tree.finallyBlock !== null) {
+      block = this.transformAny(tree.finallyBlock);
+      if (block !== tree.finallyBlock) {
+        return new TryStatement(tree.location, tree.body, tree.catchBlock,
+            block);
+      }
+    } else {
+      block = this.transformAny(tree.catchBlock);
+      if (block !== tree.catchBlock) {
+        return new TryStatement(tree.location, tree.body, block,
+            tree.finallyBlock);
+      }
+    }
+    return tree;
+  }
+
+  transformForInStatement(tree) {return tree;}
+  transformForOfStatement(tree) {return tree;}
+  transformForOnStatement(tree) {return tree;}
+  transformClassDeclaration(tree) {return tree;}
+  transformClassExpression(tree) {return tree;}
+  transformExpressionStatement(tree) {return tree;}
+  transformFunctionDeclaration(tree) {return tree;}
+  transformFunctionExpression(tree) {return tree;}
+  transformGetAccessor(tree) {return tree;}
+  transformSetAccessor(tree) {return tree;}
+  transformPropertyMethodAssignment(tree) {return tree;}
+  transformArrowFunctionExpression(tree) {return tree;}
+  transformComprehensionFor(tree) {return tree;}
+  transformVariableStatement(tree) {return tree;}
+
+  static transform(bodyTransformer, tree) {
+    return new RewriteTailCallsTransformer(bodyTransformer).transformAny(tree);
+  }
+}

--- a/src/codegeneration/RewriteTailExpressionsTransformer.js
+++ b/src/codegeneration/RewriteTailExpressionsTransformer.js
@@ -1,0 +1,165 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ParseTreeTransformer} from './ParseTreeTransformer.js';
+import {
+  ArgumentList,
+  BinaryExpression,
+  CallExpression,
+  ConditionalExpression,
+  MemberExpression,
+  MemberLookupExpression
+} from '../syntax/trees/ParseTrees.js';
+import {
+  createArrayLiteralExpression,
+  createAssignmentExpression,
+  createCommaExpression,
+  createMemberExpression,
+  createIdentifierExpression as id,
+  createNullLiteral,
+  createParenExpression,
+} from './ParseTreeFactory.js';
+import {
+  COMMA_EXPRESSION,
+  MEMBER_EXPRESSION,
+  MEMBER_LOOKUP_EXPRESSION,
+  IDENTIFIER_EXPRESSION,
+  PAREN_EXPRESSION,
+  THIS_EXPRESSION
+} from '../syntax/trees/ParseTreeType.js';
+import {
+  AND,
+  OR
+} from '../syntax/TokenType.js';
+
+function createCall(tree, operand, thisArg) {
+  var argList = tree.args; // can be null
+  var argArray = argList ? argList.args : [];
+  argArray = argArray.map(arg => {
+    if (arg.type === COMMA_EXPRESSION) {
+      return createParenExpression(arg.type);
+    }
+    return arg;
+  });
+  return new CallExpression(tree.location,
+      createMemberExpression('$traceurRuntime', 'continuation'),
+      new ArgumentList(argList ? argList.location : null, [operand, thisArg,
+          createArrayLiteralExpression(argArray)]));
+}
+
+export class RewriteTailExpressionsTransformer extends ParseTreeTransformer {
+  // TODO(mnieper): template literals in tail position
+
+  constructor(bodyTransformer) {
+    this.bodyTransformer_ = bodyTransformer;
+  }
+
+  transformBinaryExpression(tree) {
+    var operator = tree.operator;
+    if (operator.type !== AND && operator.type !== OR) {
+      return tree;
+    }
+    var right = this.transformAny(tree.right);
+    if (right !== tree.right) {
+      return new BinaryExpression(tree.location, tree.left, operator, right);
+    }
+    return tree;
+  }
+
+  transformCallExpression(tree) {
+    var operand = tree.operand;
+    while (operand.type === PAREN_EXPRESSION) {
+      operand = operand.expression;
+      // TODO(mnieper): Readd parens to the resulting call.
+    }
+    switch (operand.type) {
+      case IDENTIFIER_EXPRESSION:
+        return createCall(tree, operand, createNullLiteral());
+      case MEMBER_EXPRESSION:
+      case MEMBER_LOOKUP_EXPRESSION:
+        return this.transformMemberExpressionCall_(tree, operand)
+    }
+    return tree;
+  }
+
+  transformMemberExpressionCall_(tree, operand) {
+    var object = operand.operand;
+    var thisArg;
+    var assignment;
+    if (object.type === IDENTIFIER_EXPRESSION ||
+        object.type === THIS_EXPRESSION) {
+        // If we wanted to be strict, we would have to leave out identifier
+        // expressions here. When referring to getters on the global object,
+        // they could have side effects.
+      thisArg = object;
+    } else {
+      thisArg = id(this.bodyTransformer_.addTempVar());
+      assignment = createAssignmentExpression(thisArg, operand.operand);
+    }
+    if (operand.type === MEMBER_EXPRESSION) {
+      operand = new MemberExpression(operand.location, thisArg, operand.memberName);
+    } else {
+      operand = new MemberLookupExpression(operand.location, thisArg, operand.memberExpression);
+    }
+    if (assignment) {
+      return createParenExpression(createCommaExpression([assignment,
+          createCall(tree, operand, thisArg)]));
+    } else {
+      return createCall(tree, operand, thisArg);
+    }
+  }
+
+  transformCommaExpression(tree) {
+    var expressions = tree.expressions;
+    var expression = expressions[expressions.length - 1];
+    var transformedExpression = this.transformAny(expression);
+    if (expression !== transformedExpression) {
+      expressions = expressions.slice(0, -1);
+      expressions.push(transformedExpression);
+      return new CommaExpression(tree.location, expressions);
+    }
+    return tree;
+  }
+
+  transformConditionalExpression(tree) {
+    var left = this.transformAny(tree.left);
+    var right = this.transformAny(tree.right);
+    if (left !== tree.left || right !== tree.right) {
+      return new ConditionalExpression(tree.location, tree.condition,
+          left, right);
+    }
+    return tree;
+  }
+
+  transformNewExpression(tree) {
+    return createCall(tree, createMemberExpression('$traceurRuntime', 'construct'),
+        tree.operand);
+  }
+
+  transformArrayLiteralExpression(tree) {return tree;}
+  transformArrowFunctionExpression(tree) {return tree;}
+  transformFunctionExpression(tree) {return tree;}
+  transformIdentifierExpression(tree) {return tree;}
+  transformLiteralExpression(tree) {return tree;}
+  transformMemberExpression(tree) {return tree;}
+  transformMemberLookupExpression(tree) {return tree;}
+  transformPostfixExpression(tree) {return tree;}
+  transformObjectLiteralExpression(tree) {return tree;}
+  transformUnaryExpression(tree) {return tree;}
+
+  static transform(bodyTransformer,  tree) {
+    return new RewriteTailExpressionsTransformer(bodyTransformer).
+        transformAny(tree);
+  }
+}

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -25,8 +25,8 @@
 
   var $Object = Object;
   var $TypeError = TypeError;
-  var $defineProperties = $Object.defineProperties;
   var $create = $Object.create;
+  var $defineProperties = $Object.defineProperties;
   var $defineProperty = $Object.defineProperty;
   var $freeze = $Object.freeze;
   var $getOwnPropertyDescriptor = $Object.getOwnPropertyDescriptor;

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -25,8 +25,8 @@
 
   var $Object = Object;
   var $TypeError = TypeError;
-  var $create = $Object.create;
   var $defineProperties = $Object.defineProperties;
+  var $create = $Object.create;
   var $defineProperty = $Object.defineProperty;
   var $freeze = $Object.freeze;
   var $getOwnPropertyDescriptor = $Object.getOwnPropertyDescriptor;
@@ -37,29 +37,27 @@
   var $preventExtensions = Object.preventExtensions;
   var $seal = Object.seal;
   var $isExtensible = Object.isExtensible;
+  var $apply = Function.prototype.call.bind(Function.prototype.apply)
 
-  function nonEnum(value) {
-    return {
-      configurable: true,
-      enumerable: false,
-      value: value,
-      writable: true
-    };
+  function $bind(operand, thisArg, args) {
+    // args may be an arguments-like object
+    var argArray = [thisArg];
+    for (var i = 0; i < args.length; i++) {
+      argArray[i + 1] = args[i];
+    }
+    var func = $apply(Function.prototype.bind, operand, argArray);
+    return func; // prevent tail call
   }
 
-  var method = nonEnum;
+  function $construct(func, argArray) {
+    var object = new ($bind(func, null, argArray));
+    return object; // prevent tail call
+  }
 
-  // ### Symbols
+  // ### Support for proper tail recursion
   //
-  // Symbols are emulated using an object which is an instance of SymbolValue.
-  // Calling Symbol as a function returns a symbol value object.
-  //
-  // If options.symbols is enabled then all property accesses are transformed
-  // into runtime calls which uses the internal string as the real property
-  // name.
-  //
-  // If options.symbols is disabled symbols just toString as their internal
-  // representation, making them work but leak as enumerable properties.
+  // This has to come before any function below that uses tail recursion.
+  // Every call is the following functions is deliberately not in tail position.
 
   var counter = 0;
 
@@ -70,17 +68,6 @@
   function newUniqueString() {
     return '__$' + Math.floor(Math.random() * 1e9) + '$' + ++counter + '$__';
   }
-
-  // The string used for the real property.
-  var symbolInternalProperty = newUniqueString();
-  var symbolDescriptionProperty = newUniqueString();
-
-  // Used for the Symbol wrapper
-  var symbolDataProperty = newUniqueString();
-
-  // All symbol values are kept in this map. This is so that we can get back to
-  // the symbol object if all we have is the string key representing the symbol.
-  var symbolValues = $create(null);
 
   // Private names are a bit simpler than Symbol since it is not supposed to be
   // exposed to user code.
@@ -96,291 +83,427 @@
     return s;
   }
 
-  /**
-   * Whether symbol is an emulated symbol.
-   */
-  function isShimSymbol(symbol) {
-    return typeof symbol === 'object' && symbol instanceof SymbolValue;
+  var CONTINUATION_TYPE = Object.create(null);
+
+  function createContinuation(operand, thisArg, argsArray) {
+    return [CONTINUATION_TYPE, operand, thisArg, argsArray];
   }
 
-  function typeOf(v) {
-    if (isShimSymbol(v))
-      return 'symbol';
-    return typeof v;
+  function isContinuation(object) {
+    return object && object[0] === CONTINUATION_TYPE;
   }
 
-  /**
-   * Creates a new unique symbol object.
-   * @param {string=} string Optional string used for toString.
-   * @constructor
-   */
-  function Symbol(description) {
-    var value = new SymbolValue(description);
-    if (!(this instanceof Symbol))
-      return value;
+  var isTailRecursiveName = null;
 
-    // new Symbol should throw.
+  function setupProperTailCalls() {
+    isTailRecursiveName = createPrivateName();
+
+    // By 19.2.3.1 and 19.2.3.3, Function.prototype.call and
+    // Function.prototype.apply do proper tail calls.
+
+    Function.prototype.call = initTailRecursiveFunction(
+        function call(thisArg) {
+          var result = tailCall(function (thisArg) {
+            var argArray = [];
+            for (var i = 1; i < arguments.length; ++i) {
+              argArray[i - 1] = arguments[i];
+            }
+            var continuation = createContinuation(this, thisArg, argArray);
+            return continuation; // prevent tail call
+          }, this, arguments);
+          return result; // prevent tail call
+        });
+
+    Function.prototype.apply = initTailRecursiveFunction(
+        function apply(thisArg, argArray) {
+          var result = tailCall(function (thisArg, argArray) {
+            var continuation = createContinuation(this, thisArg, argArray);
+            return continuation; // prevent tail call
+          }, this, arguments);
+          return result; // prevent tail call
+        });
+  }
+
+  function initTailRecursiveFunction(func) {
+    if (isTailRecursiveName === null) {
+      setupProperTailCalls();
+    }
+    func[isTailRecursiveName] = true;
+    return func;
+  }
+
+  function isTailRecursive(func) {
+    return !!func[isTailRecursiveName];
+  }
+
+  function tailCall(func, thisArg, argArray) {
+    var continuation = argArray[0];
+    if (isContinuation(continuation)) {
+      continuation = $apply(func, thisArg, continuation[3]);
+      return continuation; // prevent tail call
+    }
+    continuation = createContinuation(func, thisArg, argArray);
+    while (true) {
+      if (isTailRecursive(func)) {
+        continuation = $apply(func, continuation[2], [continuation]);
+      } else {
+        continuation = $apply(func, continuation[2], continuation[3]);
+      }
+      if (!isContinuation(continuation)) {
+        return continuation;
+      }
+      func = continuation[1];
+    }
+  }
+
+  function construct() {
+    var object;
+    if (isTailRecursive(this)) {
+      object = $construct(this, [createContinuation(null, null, arguments)]);
+    } else  {
+      object = $construct(this, arguments);
+    }
+    return object; // prevent tail call
+  }
+
+  // This definition that follows is the last setup to support proper tail
+  // calls in subsequent code. At the end, the global $traceurRuntime object
+  // will be set up.
+
+  var $traceurRuntime = {
+    initTailRecursiveFunction: initTailRecursiveFunction,
+    call: tailCall,
+    continuation: createContinuation,
+    construct: construct
+  };
+
+  (function () {
+    // This has to be an IIFE as calls to initTailRecursiveFunction are hoisted
+    // and should not appear before it is set above.
+
+    function nonEnum(value) {
+      return {
+        configurable: true,
+        enumerable: false,
+        value: value,
+        writable: true
+      };
+    }
+
+    var method = nonEnum;
+
+    // ### Symbols
     //
-    // There are two ways to get a wrapper to a symbol. Either by doing
-    // Object(symbol) or call a non strict function using a symbol value as
-    // this. To correctly handle these two would require a lot of work for very
-    // little gain so we are not doing those at the moment.
-    throw new TypeError('Symbol cannot be new\'ed');
-  }
+    // Symbols are emulated using an object which is an instance of SymbolValue.
+    // Calling Symbol as a function returns a symbol value object.
+    //
+    // If options.symbols is enabled then all property accesses are transformed
+    // into runtime calls which uses the internal string as the real property
+    // name.
+    //
+    // If options.symbols is disabled symbols just toString as their internal
+    // representation, making them work but leak as enumerable properties.
 
-  $defineProperty(Symbol.prototype, 'constructor', nonEnum(Symbol));
-  $defineProperty(Symbol.prototype, 'toString', method(function() {
-    var symbolValue = this[symbolDataProperty];
-    return symbolValue[symbolInternalProperty];
-    /* The implementation of toString below matches the spec, but prevents
-    use of Symbols in eg generators unless --symbol is set. To simplify our
-    code we deliberately go against the spec here.
-    if (!symbolValue)
-      throw TypeError('Conversion from symbol to string');
-    var desc = symbolValue[symbolDescriptionProperty];
-    if (desc === undefined)
-      desc = '';
-    return 'Symbol(' + desc + ')';
-    */
-  }));
-  $defineProperty(Symbol.prototype, 'valueOf', method(function() {
-    var symbolValue = this[symbolDataProperty];
-    if (!symbolValue)
-      throw TypeError('Conversion from symbol to string');
-    if (!getOption('symbols'))
+    // The string used for the real property.
+    var symbolInternalProperty = newUniqueString();
+    var symbolDescriptionProperty = newUniqueString();
+
+    // Used for the Symbol wrapper
+    var symbolDataProperty = newUniqueString();
+
+    // All symbol values are kept in this map. This is so that we can get back to
+    // the symbol object if all we have is the string key representing the symbol.
+    var symbolValues = $create(null);
+
+    /**
+     * Whether symbol is an emulated symbol.
+     */
+    function isShimSymbol(symbol) {
+      return typeof symbol === 'object' && symbol instanceof SymbolValue;
+    }
+
+    function typeOf(v) {
+      if (isShimSymbol(v))
+        return 'symbol';
+      return typeof v;
+    }
+
+    /**
+     * Creates a new unique symbol object.
+     * @param {string=} string Optional string used for toString.
+     * @constructor
+     */
+    function Symbol(description) {
+      var value = new SymbolValue(description);
+      if (!(this instanceof Symbol))
+        return value;
+
+      // new Symbol should throw.
+      //
+      // There are two ways to get a wrapper to a symbol. Either by doing
+      // Object(symbol) or call a non strict function using a symbol value as
+      // this. To correctly handle these two would require a lot of work for very
+      // little gain so we are not doing those at the moment.
+      throw new TypeError('Symbol cannot be new\'ed');
+    }
+
+    $defineProperty(Symbol.prototype, 'constructor', nonEnum(Symbol));
+    $defineProperty(Symbol.prototype, 'toString', method(function() {
+      var symbolValue = this[symbolDataProperty];
       return symbolValue[symbolInternalProperty];
-    return symbolValue;
-  }));
+      /* The implementation of toString below matches the spec, but prevents
+      use of Symbols in eg generators unless --symbol is set. To simplify our
+      code we deliberately go against the spec here.
+      if (!symbolValue)
+        throw TypeError('Conversion from symbol to string');
+      var desc = symbolValue[symbolDescriptionProperty];
+      if (desc === undefined)
+        desc = '';
+      return 'Symbol(' + desc + ')';
+      */
+    }));
+    $defineProperty(Symbol.prototype, 'valueOf', method(function() {
+      var symbolValue = this[symbolDataProperty];
+      if (!symbolValue)
+        throw TypeError('Conversion from symbol to string');
+      if (!getOption('symbols'))
+        return symbolValue[symbolInternalProperty];
+      return symbolValue;
+    }));
 
-  function SymbolValue(description) {
-    var key = newUniqueString();
-    $defineProperty(this, symbolDataProperty, {value: this});
-    $defineProperty(this, symbolInternalProperty, {value: key});
-    $defineProperty(this, symbolDescriptionProperty, {value: description});
-    freeze(this);
-    symbolValues[key] = this;
-  }
-  $defineProperty(SymbolValue.prototype, 'constructor', nonEnum(Symbol));
-  $defineProperty(SymbolValue.prototype, 'toString', {
-    value: Symbol.prototype.toString,
-    enumerable: false
-  });
-  $defineProperty(SymbolValue.prototype, 'valueOf', {
-    value: Symbol.prototype.valueOf,
-    enumerable: false
-  });
+    function SymbolValue(description) {
+      var key = newUniqueString();
+      $defineProperty(this, symbolDataProperty, {value: this});
+      $defineProperty(this, symbolInternalProperty, {value: key});
+      $defineProperty(this, symbolDescriptionProperty, {value: description});
+      freeze(this);
+      symbolValues[key] = this;
+    }
+    $defineProperty(SymbolValue.prototype, 'constructor', nonEnum(Symbol));
+    $defineProperty(SymbolValue.prototype, 'toString', {
+      value: Symbol.prototype.toString,
+      enumerable: false
+    });
+    $defineProperty(SymbolValue.prototype, 'valueOf', {
+      value: Symbol.prototype.valueOf,
+      enumerable: false
+    });
 
-  var hashProperty = createPrivateName();
+    var hashProperty = createPrivateName();
 
-  // cached objects to avoid allocation of new object in defineHashObject
-  var hashPropertyDescriptor = {
-    value: undefined
-  };
-  var hashObjectProperties = {
-    hash: {
+    // cached objects to avoid allocation of new object in defineHashObject
+    var hashPropertyDescriptor = {
       value: undefined
-    },
-    self: {
-      value: undefined
+    };
+    var hashObjectProperties = {
+      hash: {
+        value: undefined
+      },
+      self: {
+        value: undefined
+      }
+    };
+
+    var hashCounter = 0;
+    function getOwnHashObject(object) {
+      var hashObject = object[hashProperty];
+      // Make sure we got the own property
+      if (hashObject && hashObject.self === object)
+        return hashObject;
+
+      if ($isExtensible(object)) {
+        hashObjectProperties.hash.value = hashCounter++;
+        hashObjectProperties.self.value = object;
+
+        hashPropertyDescriptor.value = $create(null, hashObjectProperties);
+
+        $defineProperty(object, hashProperty, hashPropertyDescriptor);
+        return hashPropertyDescriptor.value;
+      }
+
+      return undefined;
     }
-  };
 
-  var hashCounter = 0;
-  function getOwnHashObject(object) {
-    var hashObject = object[hashProperty];
-    // Make sure we got the own property
-    if (hashObject && hashObject.self === object)
-      return hashObject;
-
-    if ($isExtensible(object)) {
-      hashObjectProperties.hash.value = hashCounter++;
-      hashObjectProperties.self.value = object;
-
-      hashPropertyDescriptor.value = $create(null, hashObjectProperties);
-
-      $defineProperty(object, hashProperty, hashPropertyDescriptor);
-      return hashPropertyDescriptor.value;
+    function freeze(object) {
+      getOwnHashObject(object);
+      return $freeze.apply(this, arguments);
     }
 
-    return undefined;
-  }
+    function preventExtensions(object) {
+      getOwnHashObject(object);
+      return $preventExtensions.apply(this, arguments);
+    }
 
-  function freeze(object) {
-    getOwnHashObject(object);
-    return $freeze.apply(this, arguments);
-  }
+    function seal(object) {
+      getOwnHashObject(object);
+      return $seal.apply(this, arguments);
+    }
 
-  function preventExtensions(object) {
-    getOwnHashObject(object);
-    return $preventExtensions.apply(this, arguments);
-  }
+    freeze(SymbolValue.prototype);
 
-  function seal(object) {
-    getOwnHashObject(object);
-    return $seal.apply(this, arguments);
-  }
+    /**
+     * Checks if the string is a string that is used to represent an emulated
+     * symbol. This is used to filter out symbols in Object.keys,
+     * getOwnPropertyKeys and for-in loops.
+     */
+    function isSymbolString(s) {
+      return symbolValues[s] || privateNames[s];
+    }
 
-  freeze(SymbolValue.prototype);
+    function toProperty(name) {
+      if (isShimSymbol(name))
+        return name[symbolInternalProperty];
+      return name;
+    }
 
-  /**
-   * Checks if the string is a string that is used to represent an emulated
-   * symbol. This is used to filter out symbols in Object.keys,
-   * getOwnPropertyKeys and for-in loops.
-   */
-  function isSymbolString(s) {
-    return symbolValues[s] || privateNames[s];
-  }
+    // Override getOwnPropertyNames to filter out symbols keys.
+    function removeSymbolKeys(array) {
+      var rv = [];
+      for (var i = 0; i < array.length; i++) {
+        if (!isSymbolString(array[i])) {
+          rv.push(array[i]);
+        }
+      }
+      return rv;
+    }
 
-  function toProperty(name) {
-    if (isShimSymbol(name))
-      return name[symbolInternalProperty];
-    return name;
-  }
+    function getOwnPropertyNames(object) {
+      return removeSymbolKeys($getOwnPropertyNames(object));
+    }
 
-  // Override getOwnPropertyNames to filter out symbols keys.
-  function removeSymbolKeys(array) {
-    var rv = [];
-    for (var i = 0; i < array.length; i++) {
-      if (!isSymbolString(array[i])) {
-        rv.push(array[i]);
+    function keys(object) {
+      return removeSymbolKeys($keys(object));
+    }
+
+    function getOwnPropertySymbols(object) {
+      var rv = [];
+      var names = $getOwnPropertyNames(object);
+      for (var i = 0; i < names.length; i++) {
+        var symbol = symbolValues[names[i]];
+        if (symbol) {
+          rv.push(symbol);
+        }
+      }
+      return rv;
+    }
+
+    function getOwnPropertyDescriptor(object, name) {
+      return $getOwnPropertyDescriptor(object, toProperty(name));
+    }
+
+    // Override Object.prototpe.hasOwnProperty to always return false for
+    // private names.
+    function hasOwnProperty(name) {
+      return $hasOwnProperty.call(this, toProperty(name));
+    }
+
+    function getOption(name) {
+      return global.$traceurRuntime.options[name];
+    }
+
+    function defineProperty(object, name, descriptor) {
+      if (isShimSymbol(name)) {
+        name = name[symbolInternalProperty];
+      }
+      $defineProperty(object, name, descriptor);
+      return object;
+    }
+
+    function polyfillObject(Object) {
+      $defineProperty(Object, 'defineProperty', {value: defineProperty});
+      $defineProperty(Object, 'getOwnPropertyNames',
+                      {value: getOwnPropertyNames});
+      $defineProperty(Object, 'getOwnPropertyDescriptor',
+                      {value: getOwnPropertyDescriptor});
+      $defineProperty(Object.prototype, 'hasOwnProperty',
+                      {value: hasOwnProperty});
+      $defineProperty(Object, 'freeze', {value: freeze});
+      $defineProperty(Object, 'preventExtensions', {value: preventExtensions});
+      $defineProperty(Object, 'seal', {value: seal});
+      $defineProperty(Object, 'keys', {value: keys});
+      // getOwnPropertySymbols is added in polyfillSymbol.
+    }
+
+    function exportStar(object) {
+      for (var i = 1; i < arguments.length; i++) {
+        var names = $getOwnPropertyNames(arguments[i]);
+        for (var j = 0; j < names.length; j++) {
+          var name = names[j];
+          if (isSymbolString(name)) continue;
+          (function(mod, name) {
+            $defineProperty(object, name, {
+              get: function() { return mod[name]; },
+              enumerable: true
+            });
+          })(arguments[i], names[j]);
+        }
+      }
+      return object;
+    }
+
+    function isObject(x) {
+      return x != null && (typeof x === 'object' || typeof x === 'function');
+    }
+
+    function toObject(x) {
+      if (x == null)
+        throw $TypeError();
+      return $Object(x);
+    }
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-checkobjectcoercible
+    function checkObjectCoercible(argument) {
+      if (argument == null) {
+        throw new TypeError('Value cannot be converted to an Object');
+      }
+      return argument;
+    }
+
+    function polyfillSymbol(global, Symbol) {
+      if (!global.Symbol) {
+        global.Symbol = Symbol;
+        Object.getOwnPropertySymbols = getOwnPropertySymbols;
+      }
+      if (!global.Symbol.iterator) {
+        global.Symbol.iterator = Symbol('Symbol.iterator');
+      }
+      if (!global.Symbol.observer) {
+        global.Symbol.observer = Symbol('Symbol.observer');
       }
     }
-    return rv;
-  }
 
-  function getOwnPropertyNames(object) {
-    return removeSymbolKeys($getOwnPropertyNames(object));
-  }
+    function setupGlobals(global) {
+      polyfillSymbol(global, Symbol)
+      global.Reflect = global.Reflect || {};
+      global.Reflect.global = global.Reflect.global || global;
 
-  function keys(object) {
-    return removeSymbolKeys($keys(object));
-  }
-
-  function getOwnPropertySymbols(object) {
-    var rv = [];
-    var names = $getOwnPropertyNames(object);
-    for (var i = 0; i < names.length; i++) {
-      var symbol = symbolValues[names[i]];
-      if (symbol) {
-        rv.push(symbol);
-      }
+      polyfillObject(global.Object);
     }
-    return rv;
-  }
 
-  function getOwnPropertyDescriptor(object, name) {
-    return $getOwnPropertyDescriptor(object, toProperty(name));
-  }
+    setupGlobals(global);
 
-  // Override Object.prototpe.hasOwnProperty to always return false for
-  // private names.
-  function hasOwnProperty(name) {
-    return $hasOwnProperty.call(this, toProperty(name));
-  }
-
-  function getOption(name) {
-    return global.$traceurRuntime.options[name];
-  }
-
-  function defineProperty(object, name, descriptor) {
-    if (isShimSymbol(name)) {
-      name = name[symbolInternalProperty];
-    }
-    $defineProperty(object, name, descriptor);
-    return object;
-  }
-
-  function polyfillObject(Object) {
-    $defineProperty(Object, 'defineProperty', {value: defineProperty});
-    $defineProperty(Object, 'getOwnPropertyNames',
-                    {value: getOwnPropertyNames});
-    $defineProperty(Object, 'getOwnPropertyDescriptor',
-                    {value: getOwnPropertyDescriptor});
-    $defineProperty(Object.prototype, 'hasOwnProperty',
-                    {value: hasOwnProperty});
-    $defineProperty(Object, 'freeze', {value: freeze});
-    $defineProperty(Object, 'preventExtensions', {value: preventExtensions});
-    $defineProperty(Object, 'seal', {value: seal});
-    $defineProperty(Object, 'keys', {value: keys});
-    // getOwnPropertySymbols is added in polyfillSymbol.
-  }
-
-  function exportStar(object) {
-    for (var i = 1; i < arguments.length; i++) {
-      var names = $getOwnPropertyNames(arguments[i]);
-      for (var j = 0; j < names.length; j++) {
-        var name = names[j];
-        if (isSymbolString(name)) continue;
-        (function(mod, name) {
-          $defineProperty(object, name, {
-            get: function() { return mod[name]; },
-            enumerable: true
-          });
-        })(arguments[i], names[j]);
-      }
-    }
-    return object;
-  }
-
-  function isObject(x) {
-    return x != null && (typeof x === 'object' || typeof x === 'function');
-  }
-
-  function toObject(x) {
-    if (x == null)
-      throw $TypeError();
-    return $Object(x);
-  }
-
-  // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-checkobjectcoercible
-  function checkObjectCoercible(argument) {
-    if (argument == null) {
-      throw new TypeError('Value cannot be converted to an Object');
-    }
-    return argument;
-  }
-
-  function polyfillSymbol(global, Symbol) {
-    if (!global.Symbol) {
-      global.Symbol = Symbol;
-      Object.getOwnPropertySymbols = getOwnPropertySymbols;
-    }
-    if (!global.Symbol.iterator) {
-      global.Symbol.iterator = Symbol('Symbol.iterator');
-    }
-    if (!global.Symbol.observer) {
-      global.Symbol.observer = Symbol('Symbol.observer');
-    }
-  }
-
-  function setupGlobals(global) {
-    polyfillSymbol(global, Symbol)
-    global.Reflect = global.Reflect || {};
-    global.Reflect.global = global.Reflect.global || global;
-
-    polyfillObject(global.Object);
-  }
-
-  setupGlobals(global);
-
-  global.$traceurRuntime = {
-    checkObjectCoercible: checkObjectCoercible,
-    createPrivateName: createPrivateName,
-    defineProperties: $defineProperties,
-    defineProperty: $defineProperty,
-    exportStar: exportStar,
-    getOwnHashObject: getOwnHashObject,
-    getOwnPropertyDescriptor: $getOwnPropertyDescriptor,
-    getOwnPropertyNames: $getOwnPropertyNames,
-    isObject: isObject,
-    isPrivateName: isPrivateName,
-    isSymbolString: isSymbolString,
-    keys: $keys,
-    options: {},
-    setupGlobals: setupGlobals,
-    toObject: toObject,
-    toProperty: toProperty,
-    typeof: typeOf,
-  };
-
+    global.$traceurRuntime = {
+      call: tailCall,
+      checkObjectCoercible: checkObjectCoercible,
+      construct: construct,
+      continuation: createContinuation,
+      createPrivateName: createPrivateName,
+      defineProperties: $defineProperties,
+      defineProperty: $defineProperty,
+      exportStar: exportStar,
+      getOwnHashObject: getOwnHashObject,
+      getOwnPropertyDescriptor: $getOwnPropertyDescriptor,
+      getOwnPropertyNames: $getOwnPropertyNames,
+      initTailRecursiveFunction: initTailRecursiveFunction,
+      isObject: isObject,
+      isPrivateName: isPrivateName,
+      isSymbolString: isSymbolString,
+      keys: $keys,
+      options: {},
+      setupGlobals: setupGlobals,
+      toObject: toObject,
+      toProperty: toProperty,
+      typeof: typeOf,
+    };
+  })();
 })(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : this);

--- a/test/feature/ProperTailCalls/Call.js
+++ b/test/feature/ProperTailCalls/Call.js
@@ -1,0 +1,37 @@
+// Options: --proper-tail-calls
+
+Error.stackTraceLimit = Infinity;
+
+var stackSize;
+function recordStackSize() {
+  try {
+    Error.prepareStackTrace = function(error, structuredStackTrace) {
+      return structuredStackTrace.length;
+    }
+    stackSize = new Error().stack;
+  } finally {
+    delete Error.prepareStackTrace;
+  }
+}
+
+function assertProperTailCalls(limit = 30) {
+  assert.isTrue(stackSize < limit);
+}
+
+function g(n, m) {
+  if (n === 0) {
+    recordStackSize();
+  }
+  return n === 0 ? m : g.call(null, n - 1, n + m);
+}
+
+function f(n) {
+  return g(n, 0);
+}
+
+function sum(n) {
+  return n * (n + 1) / 2;
+}
+
+assert.equal(f(50), sum(50));
+assertProperTailCalls();

--- a/test/feature/ProperTailCalls/Coroutine.js
+++ b/test/feature/ProperTailCalls/Coroutine.js
@@ -1,0 +1,44 @@
+// Options: --proper-tail-calls
+
+Error.stackTraceLimit = Infinity;
+
+var stackSize;
+function recordStackSize() {
+  try {
+    Error.prepareStackTrace = function(error, structuredStackTrace) {
+      return structuredStackTrace.length;
+    }
+    stackSize = new Error().stack;
+  } finally {
+    delete Error.prepareStackTrace;
+  }
+}
+
+function assertProperTailCalls(limit = 30) {
+  assert.isTrue(stackSize < limit);
+}
+
+function g1(n, m) {
+  if (n === 0) {
+    recordStackSize();
+  }
+  return n === 0 ? m : g2(n - 1, n + m);
+}
+
+function g2(n, m) {
+  if (n === 0) {
+    recordStackSize();
+  }
+  return n === 0 ? m : g1(n - 1, n + m);
+}
+
+function f(n) {
+  return g1(n, 0);
+}
+
+function sum(n) {
+  return n * (n + 1) / 2;
+}
+
+assert.equal(f(50), sum(50));
+assertProperTailCalls();

--- a/test/feature/ProperTailCalls/Method.js
+++ b/test/feature/ProperTailCalls/Method.js
@@ -1,0 +1,52 @@
+// Options: --proper-tail-calls
+
+Error.stackTraceLimit = Infinity;
+
+var stackSize;
+function recordStackSize() {
+  try {
+    Error.prepareStackTrace = function(error, structuredStackTrace) {
+      return structuredStackTrace.length;
+    }
+    stackSize = new Error().stack;
+  } finally {
+    delete Error.prepareStackTrace;
+  }
+}
+
+function assertProperTailCalls(limit = 30) {
+  assert.isTrue(stackSize < limit);
+}
+
+var g1, g2;
+
+var obj = {
+  g1(n, m) {
+    if (n === 0) {
+      recordStackSize();
+    }
+    return n === 0 ? m : g2(n - 1, n + m);
+  },
+  get g2() {
+    var n = arguments[0];
+    var m = arguments[1];
+    if (n === 0) {
+      recordStackSize();
+    }
+    return n === 0 ? m : g1(n - 1, n + m);
+  }
+}
+
+var g1 = obj.g1;
+var g2 = Object.getOwnPropertyDescriptor(obj, 'g2').get;
+
+function f(n) {
+  return g1(n, 0);
+}
+
+function sum(n) {
+  return n * (n + 1) / 2;
+}
+
+assert.equal(f(50), sum(50));
+assertProperTailCalls();

--- a/test/feature/ProperTailCalls/Native.js
+++ b/test/feature/ProperTailCalls/Native.js
@@ -1,0 +1,10 @@
+// Options: --proper-tail-calls
+
+var count = 0;
+
+[1, 2, 3].forEach(function (n) {
+  count += n;
+});
+
+assert.equal(count, 6);
+

--- a/test/feature/ProperTailCalls/New.js
+++ b/test/feature/ProperTailCalls/New.js
@@ -1,0 +1,52 @@
+// Options: --proper-tail-calls
+
+Error.stackTraceLimit = Infinity;
+
+var stackSize;
+function recordStackSize() {
+  try {
+    Error.prepareStackTrace = function(error, structuredStackTrace) {
+      return structuredStackTrace.length;
+    }
+    stackSize = new Error().stack;
+  } finally {
+    delete Error.prepareStackTrace;
+  }
+}
+
+function assertProperTailCalls(limit = 30) {
+  assert.isTrue(stackSize < limit);
+}
+
+function Value(n, m) {
+  assert.instanceOf(this, Value);
+  if (n === 0) {
+    recordStackSize();
+    this.m = m;
+  } else {
+    return new Value(n - 1, n + m);
+  }
+}
+
+function f(n) {
+  return new Value(n, 0);
+}
+
+function sum(n) {
+  return n * (n + 1) / 2;
+}
+
+assert.equal(f(50).m, sum(50));
+assertProperTailCalls();
+
+class C {
+  constructor(n) {
+    this.x = n;
+  }
+}
+
+function g(n) {
+  return new C(n);
+}
+
+assert.equal(g(42).x, 42);

--- a/test/feature/ProperTailCalls/Sum.js
+++ b/test/feature/ProperTailCalls/Sum.js
@@ -1,0 +1,38 @@
+// Options: --proper-tail-calls
+
+Error.stackTraceLimit = Infinity;
+
+var stackSize;
+function recordStackSize() {
+  try {
+    Error.prepareStackTrace = function(error, structuredStackTrace) {
+      return structuredStackTrace.length;
+    }
+    stackSize = new Error().stack;
+  } finally {
+    delete Error.prepareStackTrace;
+  }
+}
+
+function assertProperTailCalls(limit = 30) {
+  assert.isTrue(stackSize < limit);
+}
+
+function g(n, m) {
+  if (n === 0) {
+    recordStackSize();
+  }
+  return n === 0 ? m : g(n - 1, n + m);
+}
+
+function f(n) {
+  return g(n, 0);
+}
+
+function sum(n) {
+  return n * (n + 1) / 2;
+}
+
+assert.equal(f(50), sum(50));
+assertProperTailCalls();
+

--- a/test/feature/ProperTailCalls/This.js
+++ b/test/feature/ProperTailCalls/This.js
@@ -1,0 +1,15 @@
+// Options: --proper-tail-calls
+
+class C {
+  constructor(x) {
+    this.x = x;
+  }
+  getX() {
+    return this.x;
+  }
+}
+
+var o = new C(42);
+
+assert.equal(o.getX(), 42);
+

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -406,6 +406,9 @@ suite('context test', function() {
       assert.isNull(error);
       cmd = 'node ' + tempFileName;
       exec(cmd, function(error, stdout, stderr) {
+        // FIXME: This test fails if traceur is compiled with proper tail calls
+        // as the code that shall display this message depends on the proper
+        // tail calls part of the runtime.
         assert.notEqual(error.toString().indexOf('traceur runtime not found'),
             -1, 'The runtime error message should be found');
         done();


### PR DESCRIPTION
The following PR implements proper tail calls as demanded by ES6. The are behind the new experimental flag `--proper-tail-calls`. (Experimental because it necessarily reduces performance of the generated code.)

This probably makes Traceur the first transpiler properly supporting tail calls!

Each function that contains calls in tail position is rewritten. All tests pass with proper tail calls enabled by default. Traceur itself compiled with `--proper-tail-calls true` also works as expected.

At the moment, the transformer does not touch arrow functions, class declarations and class expressions (so they should be transpiled if their are supposed to be properly tail recursive). Likewise, template literals in tail position are currently not touched, so the corresponding transpilation should be enabled as well.

The changes to `runtime.js` are far less worse than what the diff shows. I had to wrap most of that code into an extra IIFE and the additional two spaces at the beginning of each line cause the diffs.

It is left as a TODO to check all other transformers that they do not convert tail calls in non tail calls.

Please review this PR; it's hopefully ready to merge.