### PR TITLE
Avoid unnecessary object literal transformations.

### DIFF
--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -54,7 +54,23 @@ class FindAdvancedProperty extends FindVisitor {
     if (isProtoName(tree.name))
       this.protoExpression = tree.value;
     else
-      super.visitPropertyNameAssignment(tree);
+      this.visitAny(tree.name);
+      // We do not want to visit object literals in the property's value.
+  }
+
+  visitPropertyMethodAssignment(tree) {
+    this.visitAny(tree.name);
+    // We do not want to visit object literals in the method's body.
+  }
+
+  visitGetAccessor(tree) {
+    this.visitAny(tree.name);
+    // We do not want to visit object literals in the accessor's body.
+  }
+
+  visitSetAccessor(tree) {
+     this.visitAny(tree.name);
+    // We do not want to visit object literals in the accessor's body.
   }
 
   visitComputedPropertyName(tree) {


### PR DESCRIPTION
Example:


```js
var outer = {
  inner: {
    [0]: 1
  },
  method() {
    return {[2]: 3};
  },
  set a(value) {
    return {[4]: 5};
  }
};
```

The outer literal should not be transformed.

Fixes #1728.