### PR TITLE
Implement fround in JS without depending on Float32Array

### DIFF
--- a/src/runtime/polyfills/Math.js
+++ b/src/runtime/polyfills/Math.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {fround as jsFround} from './fround.js';
 import {
   maybeAddFunctions,
   registerPolyfill,
@@ -205,13 +206,19 @@ export function trunc(x) {
   return x;
 }
 
-var f32 = new Float32Array(1);
+var fround, f32;
 
-export function fround(x) {
-  // From MDN
-  f32[0] = +x;
-  return f32[0];
+if (typeof Float32Array === 'function') {
+  f32 = new Float32Array(1);
+  fround = function(x) {
+    f32[0] = Number(x);
+    return f32[0];
+  };
+} else {
+  fround = jsFround;
 }
+
+export {fround};
 
 export function cbrt(x) {
   // From MDN

--- a/src/runtime/polyfills/fround.js
+++ b/src/runtime/polyfills/fround.js
@@ -1,0 +1,147 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based on code from:
+// https://github.com/inexorabletash/polyfill/blob/master/typedarray.js
+// Used with permission:
+// https://github.com/google/traceur-compiler/issues/1703
+
+var $isFinite = isFinite;
+var $isNaN = isNaN;
+
+var {
+  LN2,
+  abs,
+  floor,
+  log,
+  min,
+  pow,
+} = Math;
+
+function packIEEE754(v, ebits, fbits) {
+
+  var bias = (1 << (ebits - 1)) - 1,
+      s, e, f, ln,
+      i, bits, str, bytes;
+
+  function roundToEven(n) {
+    var w = floor(n), f = n - w;
+    if (f < 0.5)
+      return w;
+    if (f > 0.5)
+      return w + 1;
+    return w % 2 ? w + 1 : w;
+  }
+
+  // Compute sign, exponent, fraction
+  if (v !== v) {
+    // NaN
+    // http://dev.w3.org/2006/webapi/WebIDL/#es-type-mapping
+    e = (1 << ebits) - 1; f = pow(2, fbits - 1); s = 0;
+  } else if (v === Infinity || v === -Infinity) {
+    e = (1 << ebits) - 1; f = 0; s = (v < 0) ? 1 : 0;
+  } else if (v === 0) {
+    e = 0; f = 0; s = (1 / v === -Infinity) ? 1 : 0;
+  } else {
+    s = v < 0;
+    v = abs(v);
+
+    if (v >= pow(2, 1 - bias)) {
+      e = min(floor(log(v) / LN2), 1023);
+      f = roundToEven(v / pow(2, e) * pow(2, fbits));
+      if (f / pow(2, fbits) >= 2) {
+        e = e + 1;
+        f = 1;
+      }
+      if (e > bias) {
+        // Overflow
+        e = (1 << ebits) - 1;
+        f = 0;
+      } else {
+        // Normalized
+        e = e + bias;
+        f = f - pow(2, fbits);
+      }
+    } else {
+      // Denormalized
+      e = 0;
+      f = roundToEven(v / pow(2, 1 - bias - fbits));
+    }
+  }
+
+  // Pack sign, exponent, fraction
+  bits = [];
+  for (i = fbits; i; i -= 1) { bits.push(f % 2 ? 1 : 0); f = floor(f / 2); }
+  for (i = ebits; i; i -= 1) { bits.push(e % 2 ? 1 : 0); e = floor(e / 2); }
+  bits.push(s ? 1 : 0);
+  bits.reverse();
+  str = bits.join('');
+
+  // Bits to bytes
+  bytes = [];
+  while (str.length) {
+    bytes.push(parseInt(str.substring(0, 8), 2));
+    str = str.substring(8);
+  }
+  return bytes;
+}
+
+function unpackIEEE754(bytes, ebits, fbits) {
+  // Bytes to bits
+  var bits = [], i, j, b, str,
+      bias, s, e, f;
+
+  for (i = bytes.length; i; i -= 1) {
+    b = bytes[i - 1];
+    for (j = 8; j; j -= 1) {
+      bits.push(b % 2 ? 1 : 0); b = b >> 1;
+    }
+  }
+  bits.reverse();
+  str = bits.join('');
+
+  // Unpack sign, exponent, fraction
+  bias = (1 << (ebits - 1)) - 1;
+  s = parseInt(str.substring(0, 1), 2) ? -1 : 1;
+  e = parseInt(str.substring(1, 1 + ebits), 2);
+  f = parseInt(str.substring(1 + ebits), 2);
+
+  // Produce number
+  if (e === (1 << ebits) - 1) {
+    return f !== 0 ? NaN : s * Infinity;
+  } else if (e > 0) {
+    // Normalized
+    return s * pow(2, e - bias) * (1 + f / pow(2, fbits));
+  } else if (f !== 0) {
+    // Denormalized
+    return s * pow(2, -(bias - 1)) * (f / pow(2, fbits));
+  } else {
+    return s < 0 ? -0 : 0;
+  }
+}
+
+function unpackF32(b) {
+  return unpackIEEE754(b, 8, 23);
+}
+
+function packF32(v) {
+  return packIEEE754(v, 8, 23);
+}
+
+export function fround(x) {
+  if (x === 0 || !$isFinite(x) || $isNaN(x)) {
+    return x;
+  }
+  return unpackF32(packF32(Number(x)));
+}

--- a/test/feature/Math/fround.module.js
+++ b/test/feature/Math/fround.module.js
@@ -1,8 +1,22 @@
 import {fround} from '../../../src/runtime/polyfills/Math.js';
+import {fround as jsFround} from '../../../src/runtime/polyfills/fround.js';
 
-function testFround(fround) {
-  assert.equal(0, fround(0));
+function testFround(x, expected) {
+  assert.strictEqual(expected, Math.fround(x));
+  assert.strictEqual(expected, fround(x));
+  assert.strictEqual(expected, jsFround(x));
 }
 
-testFround(fround);
-testFround(Math.fround);
+testFround(0, 0);
+testFround(-0, -0);
+testFround(Infinity, Infinity);
+testFround(-Infinity, -Infinity);
+
+assert.isTrue(isNaN(Math.fround(NaN)));
+assert.isTrue(isNaN(fround(NaN)));
+assert.isTrue(isNaN(jsFround(NaN)));
+
+testFround(1, 1);
+testFround(1.5, 1.5);
+testFround(1.6, 1.600000023841858);
+testFround(1.337, 1.3370000123977661);


### PR DESCRIPTION
In case Float32Array is not available, use a pure JS
implementation.

This is based on Joshua Bell's code from
https://github.com/inexorabletash/polyfill/blob/master/typedarray.js

Fixes #1703