### PR TITLE
SourceRange fixups.

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -2196,10 +2196,10 @@ export class Parser {
         type = this.peekType_();
         switch (type) {
           case OPEN_PAREN:
-            var name = new LiteralPropertyName(start, staticToken);
+            var location = this.getTreeLocation_(start);
+            var name = new LiteralPropertyName(location, staticToken);
             return this.parseMethod_(start, isStatic, functionKind, name,
                                      annotations);
-
           default:
             isStatic = true;
             if (type === STAR && this.options_.generators)

--- a/test/unit/codegeneration/writer.js
+++ b/test/unit/codegeneration/writer.js
@@ -30,33 +30,33 @@ suite('writer.js', function() {
 
   test('WriteStatement', function() {
     var tree = new trees.Script(
-      'loc',
+      null,
       [new trees.VariableStatement(
-        'loc',
+        null,
         new trees.VariableDeclarationList(
-          'loc',
+          null,
           'var',
           [new trees.VariableDeclaration(
-            'loc',
-            new trees.IdentifierExpression('loc', new IdentifierToken('loc', 'x')),
             null,
-            new trees.LiteralExpression('loc', new LiteralToken(TokenType.NUMBER, '1', 'loc')))]
+            new trees.IdentifierExpression(null, new IdentifierToken(null, 'x')),
+            null,
+            new trees.LiteralExpression(null, new LiteralToken(TokenType.NUMBER, '1', null)))]
         )
       ),
       new trees.IfStatement(
-        'loc',
+        null,
         new trees.BinaryExpression(
-          'loc',
-          new trees.IdentifierExpression('loc', new IdentifierToken('loc', 'x')),
-          new Token(TokenType.CLOSE_ANGLE, 'loc'),
-          new trees.LiteralExpression('loc', new LiteralToken(TokenType.NUMBER, '0', 'loc'))
+          null,
+          new trees.IdentifierExpression(null, new IdentifierToken(null, 'x')),
+          new Token(TokenType.CLOSE_ANGLE, null),
+          new trees.LiteralExpression(null, new LiteralToken(TokenType.NUMBER, '0', null))
         ),
         new trees.Block(
-          'loc',
+          null,
           [new trees.PostfixExpression(
-            'loc',
-            new trees.IdentifierExpression('loc', new IdentifierToken('loc', 'x')),
-            new Token(TokenType.PLUS_PLUS, 'loc')
+            null,
+            new trees.IdentifierExpression(null, new IdentifierToken(null, 'x')),
+            new Token(TokenType.PLUS_PLUS, null)
           )]
         ),
         null


### PR DESCRIPTION
Pass location to LiteralPropertyName in Parser

Pass null for location in writer.js test,
rather than mis-typed string