### PR TITLE
Skip and fix tests for io.js

### DIFF
--- a/test/feature/Collections/Map.js
+++ b/test/feature/Collections/Map.js
@@ -41,7 +41,10 @@ assert.equal(t.get(null), 'value9');
 assert.equal(t.get(NaN), 'value10');
 assert.equal(t.get(0), 'value11');
 assert.equal(t.get(1 / Infinity), 'value11');
-assert.equal(t.get(-1 / Infinity), 'value11');
+
+// V8 is broken for -0
+// https://code.google.com/p/v8/issues/detail?id=3906
+// assert.equal(t.get(-1 / Infinity), 'value11');
 
 assert.isTrue(!t.has({}));
 
@@ -61,7 +64,10 @@ assert.isTrue(t.has(undefined));
 assert.isTrue(t.has(null));
 assert.isTrue(t.has(NaN));
 assert.isTrue(t.has(0));
-assert.isTrue(t.has(-0));
+
+// V8 is broken for -0
+// https://code.google.com/p/v8/issues/detail?id=3906
+// assert.isTrue(t.has(-0));
 
 
 // forEach

--- a/test/feature/Collections/Set.js
+++ b/test/feature/Collections/Set.js
@@ -40,7 +40,10 @@ assert.isTrue(t.has(undefined));
 assert.isTrue(t.has(null));
 assert.isTrue(t.has(NaN));
 assert.isTrue(t.has(0));
-assert.isTrue(t.has(-0));
+
+// V8 is broken for -0
+// https://code.google.com/p/v8/issues/detail?id=3906
+// assert.isTrue(t.has(-0));
 
 var expected = [
   undefinedKey,

--- a/test/feature/Modules/Error_InvalidModuleDeclaration.module.js
+++ b/test/feature/Modules/Error_InvalidModuleDeclaration.module.js
@@ -1,4 +1,4 @@
-// Error: File not found 'test/feature/Modules/resources/no_such_file.js'
+// Error: 'test/feature/Modules/resources/no_such_file.js'
 // Error: Specified as ./resources/no_such_file.js.
 // Error: Imported by test/feature/Modules/Error_InvalidModuleDeclaration.module.js.
 // Error: Normalizes to test/feature/Modules/resources/no_such_file.js

--- a/test/feature/PromiseAll.js
+++ b/test/feature/PromiseAll.js
@@ -1,4 +1,8 @@
+// Skip.
 // Async.
+
+// V8 does not yet support iterable argument to Promise.all.
+// https://code.google.com/p/v8/issues/detail?id=3705
 
 function* gen() {
   yield 1;


### PR DESCRIPTION
This skips and updates the tests for IO.js 1.2