### PR TITLE
Pass IdentifierToken to BindingIdentifier in renaming code.

### DIFF
--- a/src/codegeneration/BlockBindingTransformer.js
+++ b/src/codegeneration/BlockBindingTransformer.js
@@ -42,6 +42,7 @@ import {
   VariableStatement,
   WhileStatement
 } from '../syntax/trees/ParseTrees.js';
+import {IdentifierToken} from '../syntax/IdentifierToken.js';
 import {ParseTreeTransformer} from './ParseTreeTransformer.js';
 import {VAR} from '../syntax/TokenType.js';
 import {
@@ -393,7 +394,8 @@ export class BlockBindingTransformer extends ParseTreeTransformer {
       if (origName === newName) {
         return tree;
       }
-      let bindingIdentifier = new BindingIdentifier(tree.location, newName);
+      var newToken = new IdentifierToken(tree.location, newName);
+      let bindingIdentifier = new BindingIdentifier(tree.location, newToken);
       this.scope_.renameBinding(origName, bindingIdentifier, VAR,
                                 this.reporter_);
       return bindingIdentifier;

--- a/test/feature/Scope/RenameFunctionBlock.js
+++ b/test/feature/Scope/RenameFunctionBlock.js
@@ -1,0 +1,11 @@
+// Options: --block-binding
+// Issue #1773
+function when() {
+	function* where() {
+	    var index = 0;
+	    for (let x of Object) {
+	        index++;
+	    }
+	}
+	var x = 5;
+}

--- a/test/feature/Scope/RenameFunctionBlock.js
+++ b/test/feature/Scope/RenameFunctionBlock.js
@@ -1,11 +1,11 @@
 // Options: --block-binding
 // Issue #1773
 function when() {
-	function* where() {
-	    var index = 0;
-	    for (let x of Object) {
-	        index++;
-	    }
-	}
-	var x = 5;
+  function* where() {
+      var index = 0;
+      for (let x of Object) {
+          index++;
+      }
+  }
+  var x = 5;
 }


### PR DESCRIPTION
Hoisting inside of function* on the var x causes the let x to be renamed;
the rename code passed a string where  an IdentifierToken was required.
Fixes #1733