### PR TITLE
Set require option in tval to improve compat

### DIFF
--- a/test/unit/node/resources/test_tval.js
+++ b/test/unit/node/resources/test_tval.js
@@ -1,3 +1,5 @@
 // Verify process.argv in a file of es6 code.
 let theArgs = process.argv.slice(2);
 console.log(['args', ...theArgs].join(''));
+
+var checkRequire = require('./iAmScript.js');

--- a/tval
+++ b/tval
@@ -43,7 +43,7 @@ var moduleName = path.resolve(filename.replace(/\\/g, '/'));
 process.argv = [process.mainModule.filename].concat(process.argv.slice(2));
 
 var metadata = {
-	traceurOptions: {require: true}
+  traceurOptions: {require: true}
 };
 
 // The module will evaluate and have process.argv ['node', filename, ...]

--- a/tval
+++ b/tval
@@ -42,8 +42,12 @@ var moduleName = path.resolve(filename.replace(/\\/g, '/'));
 // Simulate a future where it looks like node is executing our program
 process.argv = [process.mainModule.filename].concat(process.argv.slice(2));
 
+var metadata = {
+	traceurOptions: {require: true}
+};
+
 // The module will evaluate and have process.argv ['node', filename, ...]
-System.import(moduleName).catch(function(err) {
+System.import(moduleName, {metadata: metadata}).catch(function(err) {
   console.error(err.stack || err + '');
   process.exit(1);
 });


### PR DESCRIPTION

require() calls in tval-loaded modules will have the correct path.
