### PR TITLE
Warn when metadata.traceurOptions are misspelled.

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -342,6 +342,16 @@ export class Options {
     this.inputSourceMap = false;
     this.typeAssertionModule = null;
   }
+
+  static listUnknownOptions(obj) {
+    var unknowns = [];
+    Object.keys(obj).forEach((propName) => {
+      if (!(propName in optionsV01)) {
+        unknowns.push(propName);
+      }
+    });
+    return unknowns;
+  }
   /**
    * Sets the options based on an object.
    */

--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -228,7 +228,15 @@ export class InternalLoader {
   }
 
   defaultMetadata_(metadata = {}) {
-    metadata.traceurOptions = metadata.traceurOptions || new Options();
+    let incoming = metadata.traceurOptions;
+    if (incoming  && !(incoming instanceof Options)) {
+      var unknown = Options.listUnknownOptions(incoming);
+      if (unknown.length) {
+        console.warn('Unknown metadata.traceurOptions ignored: ' +
+            unknown.join(','));
+      }
+    }
+    metadata.traceurOptions = incoming || new Options();
     return metadata;
   }
 

--- a/test/unit/CompileOptions.js
+++ b/test/unit/CompileOptions.js
@@ -156,6 +156,14 @@ suite('options', function() {
 
     options.sourceRoot = true;
     assert.equal(options.sourceRoot, true);
+  });
 
+  test('listUnknownOptions', function() {
+    let unknown = Options.listUnknownOptions({});
+    assert.equal(unknown.length, 0);
+    unknown = Options.listUnknownOptions({junk: true});
+    assert.deepEqual(unknown, ['junk']);
+    unknown = Options.listUnknownOptions(new Options());
+    assert.equal(unknown.length, 0);
   });
 });

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -305,4 +305,21 @@ suite('Loader.js', function() {
     }).catch(done);
   });
 
+  test('import with metadata having junk', function(done) {
+    var loader = getTestLoader();
+    let consoleWarn = console.warn;
+    var actualWarning = '';
+    console.warn = function(msg) {
+      actualWarning = msg;
+    };
+    var metadata = {traceurOptions: {junk: true}};
+    getTestLoader().import('./resources/test_module.js', {metadata: metadata}).
+        then(function(mod) {
+          assert.equal(actualWarning,
+            'Unknown metadata.traceurOptions ignored: junk');
+          console.warn = consoleWarn;
+          done();
+      }).catch(done);
+  });
+
 });


### PR DESCRIPTION
Fixes #1767