### PR TITLE
Ensure "use strict" is within System.register closure for instantiate

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -222,7 +222,16 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
     return tree.moduleName;
   }
 
+  // module prolog is moved inside System.register
+  moduleProlog() {
+    return [];
+  }
+
   wrapModule(statements) {
+    let prolog = super.moduleProlog();
+
+    statements = prolog.concat(statements);
+
     if (this.moduleName) {
       return parseStatements
         `System.register(${this.moduleName}, ${this.dependencies}, function($__export) {

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -563,6 +563,21 @@ suite('context test', function() {
     });
   });
 
+  test('Instantiate output has "use strict" within System.register', function(done) {
+    tempFileName = resolve(uuid.v4() + '.js');
+    var inputFilename = './test/unit/node/resources/class.js';
+    var executable = 'node ' + resolve('src/node/command.js');
+
+    exec(executable + ' --out ' + tempFileName + ' --modules=instantiate ' + inputFilename,
+        function (error, stdout, stderr) {
+      if (error) return done(error);
+      var fileContents = fs.readFileSync(tempFileName).toString();
+      assert.isNull(fileContents.match(/^\s*"use strict"/));
+      assert.notEqual(fileContents.indexOf('"use strict"'), -1);
+      done();
+    });
+  });
+
   test('tval uses argv', function(done) {
     var cmd = './tval test/unit/node/resources/test_tval.js --arg1 --arg2 arg3';
     exec(cmd, function(error, stdout, stderr) {


### PR DESCRIPTION
This outputs:

```javascript
System.register(..., function() {
  "use strict";
});
```

instead of:

```javascript
"use strict";
System.register(..., function() {
});
```

The `__moduleName` variable is also moved in here as well.