### PR TITLE
Member variables in ES6

### DIFF
--- a/src/codegeneration/ArrowFunctionTransformer.js
+++ b/src/codegeneration/ArrowFunctionTransformer.js
@@ -65,8 +65,8 @@ export class ArrowFunctionTransformer extends TempVarTransformer {
     return this.transformUsingTempVar_(tree);
   }
 
-  // Transforms the arrow function using a comman expression to avoid needing to
-  // read this earlier in the funciton.
+  // Transforms the arrow function using a comma expression to avoid needing to
+  // read this earlier in the function.
   //
   //   ($tmp = this, function() {})
   transformUsingCommaExpression_(tree) {

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -29,14 +29,11 @@ import {
   createIdentifierToken
 } from '../codegeneration/ParseTreeFactory.js';
 import {
-  CALL_EXPRESSION,
   COMPUTED_PROPERTY_NAME,
-  EXPRESSION_STATEMENT,
   GET_ACCESSOR,
   PROPERTY_METHOD_ASSIGNMENT,
   PROPERTY_VARIABLE_DECLARATION,
   SET_ACCESSOR,
-  SUPER_EXPRESSION
 } from '../syntax/trees/ParseTreeType.js';
 import {SuperTransformer} from './SuperTransformer.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
@@ -65,6 +62,10 @@ import {
 } from './PlaceholderParser.js';
 import {propName} from '../staticsemantics/PropName.js';
 import {prependStatements} from './PrependStatements.js';
+import {
+  transformConstructor,
+  getInstanceInitExpression,
+} from './MemberVariableConstructorTransformer.js';
 
 // Interaction between ClassTransformer and SuperTransformer:
 // - The initial call to SuperTransformer will always be a transformBlock on
@@ -144,7 +145,6 @@ export class ClassTransformer extends TempVarTransformer {
    */
   constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator);
-    this.options_ = options;
     this.strictCount_ = 0;
     this.state_ = null;
     this.reporter_ = reporter;
@@ -198,7 +198,6 @@ export class ClassTransformer extends TempVarTransformer {
     this.state_ = {hasSuper: false};
     let superClass = this.transformAny(tree.superClass);
 
-    let hasConstructor = false;
     let protoElements = [], staticElements = [];
     let initInstanceVars = [], initStaticVars = [];
     let constructor;
@@ -226,7 +225,6 @@ export class ClassTransformer extends TempVarTransformer {
 
         case PROPERTY_METHOD_ASSIGNMENT:
           if (!tree.isStatic && propName(tree) === CONSTRUCTOR) {
-            hasConstructor = true;
             constructor = tree;
           } else {
             let transformed = this.transformPropertyMethodAssignment_(
@@ -236,7 +234,7 @@ export class ClassTransformer extends TempVarTransformer {
           break;
 
         case PROPERTY_VARIABLE_DECLARATION:
-          this.transformAny(tree);
+          tree = this.transformAny(tree);
           if (tree.initializer !== null) {
             initVars.push(tree);
           }
@@ -249,15 +247,15 @@ export class ClassTransformer extends TempVarTransformer {
 
     let object = createObjectLiteralExpression(protoElements);
     let staticObject = createObjectLiteralExpression(staticElements);
-    let initStatements = getInstanceInitStatements(initInstanceVars);
+    let initExpression = getInstanceInitExpression(initInstanceVars);
     let func;
 
-    if (!hasConstructor) {
-      func = this.getDefaultConstructor_(tree, internalName, initStatements);
+    if (!constructor) {
+      func = this.getDefaultConstructor_(tree, internalName, initExpression);
     } else {
-      if (this.options_.memberVariables) {
-        constructor = this.appendInstanceInitializers_(constructor,
-            initStatements, tree.superClass);
+      if (initInstanceVars.length > 0) {
+        constructor = transformConstructor(constructor, initExpression,
+            tree.superClass);
       }
       let homeObject = createMemberExpression(internalName, 'prototype');
       let transformedCtor = this.transformPropertyMethodAssignment_(
@@ -432,49 +430,32 @@ export class ClassTransformer extends TempVarTransformer {
     return transformedTree;
   }
 
-  getDefaultConstructor_(tree, internalName, initStatements) {
+  getDefaultConstructor_(tree, internalName, initExpression) {
     let constructorParams = createEmptyParameterList();
     let constructorBody;
+    let initStatement = createExpressionStatement(initExpression);
     if (tree.superClass) {
       let statement = parseStatement `$traceurRuntime.superConstructor(
           ${internalName}).apply(this, arguments)`;
-      constructorBody = createFunctionBody([statement, ...initStatements]);
+      constructorBody = createFunctionBody([statement, initStatement]);
       this.state_.hasSuper = true;
     } else {
-      constructorBody = createFunctionBody(initStatements);
+      constructorBody = createFunctionBody([initStatement]);
     }
 
     return new FunctionExpression(tree.location, tree.name, false,
                                   constructorParams, null, [], constructorBody);
   }
 
-  /**
-   *  Appends assignment to this for the member variables after the super call.
-   */
-  appendInstanceInitializers_(constructor, initStatements, superClass) {
-    if (initStatements.length === 0) return constructor;
+  transformConstructorWithInitializer_(constructor, initExpression, superClass) {
+    if (superClass) {
+      let transformer = new SuperExpressionTransformer(initExpression);
+      return transformer.transformAny(constructor);
+    }
 
     let statements = constructor.body.statements;
-
-    if (superClass) {
-      let superExpressionIndex = -1;
-
-      for (let i = 0; i < statements.length; i++) {
-        let statement = statements[i];
-        if (statement.isDirectivePrologue()) {
-          continue;
-        }
-        if (isSuper(statement)) {
-          superExpressionIndex = i;
-          break;
-        }
-      }
-
-      statements = statements.slice();
-      statements.splice(superExpressionIndex + 1, 0, ...initStatements);
-    } else {
-      statements = prependStatements(statements, ...initStatements);
-    }
+    let initStatement = createExpressionStatement(initExpression);
+    statements = prependStatements(statements, initStatement);
 
     return new PropertyMethodAssignment(constructor.location, false,
         constructor.functionKind, constructor.name, constructor.parameterList,
@@ -485,32 +466,11 @@ export class ClassTransformer extends TempVarTransformer {
 
 // TODO(vicb): Does not handle computed properties
 function appendStaticInitializers(staticObject, initStaticMemberVars) {
-  // Initializes static member variables
   if (initStaticMemberVars.length === 0) return staticObject;
 
-  let properties =[];
-  for (let i = 0; i < initStaticMemberVars.length; i++) {
-    let mv = initStaticMemberVars[i];
-    properties.push(createPropertyNameAssignment(mv.name, mv.initializer));
-  }
+  let properties = initStaticMemberVars.map(
+      (mv) => createPropertyNameAssignment(mv.name, mv.initializer));
+
   return createObjectLiteralExpression(
       staticObject.propertyNameAndValues.concat(properties));
-}
-
-// TODO(vicb): Does not handle computed properties
-function getInstanceInitStatements(initInstanceVars) {
-    // Compute instance member variable initialization statements
-    let initStatements = [];
-    for (let i = 0; i < initInstanceVars.length; i++) {
-      let mv = initInstanceVars[i];
-      let name = mv.name.literalToken;
-      initStatements.push(parseStatement `this.${name} = ${mv.initializer};`);
-    }
-  return initStatements;
-}
-
-function isSuper(statement) {
-  return statement.type === EXPRESSION_STATEMENT &&
-         statement.expression.type === CALL_EXPRESSION &&
-         statement.expression.operand.type === SUPER_EXPRESSION;
 }

--- a/src/codegeneration/ES6ClassTransformer.js
+++ b/src/codegeneration/ES6ClassTransformer.js
@@ -1,0 +1,203 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  CONSTRUCTOR
+} from '../syntax/PredefinedName.js';
+import {
+  AnonBlock,
+  ClassExpression,
+  ClassDeclaration,
+  FormalParameterList,
+  PropertyMethodAssignment,
+} from '../syntax/trees/ParseTrees.js';
+import {
+  GET_ACCESSOR,
+  PROPERTY_METHOD_ASSIGNMENT,
+  PROPERTY_VARIABLE_DECLARATION,
+  SET_ACCESSOR,
+} from '../syntax/trees/ParseTreeType.js';
+import {TempVarTransformer} from './TempVarTransformer.js';
+import {
+  createBindingIdentifier,
+  createFunctionBody,
+  createIdentifierToken,
+  createImmediatelyInvokedFunctionExpression,
+  createLiteralPropertyName,
+  createRestParameter,
+} from './ParseTreeFactory.js';
+import {
+  parsePropertyDefinition,
+  parseStatement,
+} from './PlaceholderParser.js';
+import {propName} from '../staticsemantics/PropName.js';
+import {prependStatements} from './PrependStatements.js';
+import {
+  transformConstructor,
+  getInstanceInitExpression,
+} from './MemberVariableConstructorTransformer.js';
+
+/**
+ * Transform member variable declarations to valid ES6 statements.
+ *
+ * - instance variables are initialized in the constructor,
+ * - static variables are initialized after the class definition,
+ *   through `Object.defineProperty(...)`
+ */
+export class ES6ClassTransformer extends TempVarTransformer {
+  transformClassElements_(tree) {
+    let elements = [];
+    let initInstanceVars = [], initStaticVars = [];
+    let constructor;
+    let constructorIndex = 0;
+
+    tree.elements.forEach((tree) => {
+      let initVars;
+      if (tree.isStatic) {
+        initVars = initStaticVars;
+      } else {
+        initVars = initInstanceVars;
+      }
+
+      switch (tree.type) {
+        case GET_ACCESSOR:
+        case SET_ACCESSOR:
+          elements.push(this.transformAny(tree));
+          break;
+
+        case PROPERTY_METHOD_ASSIGNMENT:
+          if (!tree.isStatic && propName(tree) === CONSTRUCTOR) {
+            constructor = tree;
+            constructorIndex = elements.length;
+          } else {
+            elements.push(this.transformAny(tree));
+          }
+          break;
+
+        case PROPERTY_VARIABLE_DECLARATION:
+          tree = this.transformAny(tree);
+          if (tree.initializer !== null) {
+            initVars.push(tree);
+          }
+          break;
+
+        default:
+          throw new Error(`Unexpected class element: ${tree.type}`);
+      }
+    });
+
+    if (initInstanceVars.length > 0) {
+      let initExpression = getInstanceInitExpression(initInstanceVars);
+
+      if (!constructor) {
+        constructor = this.getDefaultConstructor_(tree);
+      }
+
+      constructor = transformConstructor(constructor, initExpression,
+          tree.superClass);
+    }
+
+    if (constructor) {
+      elements.splice(constructorIndex, 0, constructor);
+    }
+
+    return {
+      elements,
+      initStaticVars,
+    };
+  }
+
+  /**
+   * Transforms a single class declaration
+   *
+   * @param {ClassDeclaration} tree
+   * @return {ParseTree}
+   */
+  transformClassDeclaration(tree) {
+    let {
+      elements,
+      initStaticVars,
+    } = this.transformClassElements_(tree);
+
+    let superClass = this.transformAny(tree.superClass);
+    let classDecl = new ClassDeclaration(tree.location, tree.name, superClass,
+        elements, tree.annotations, tree.typeParameters);
+
+    if (initStaticVars.length === 0) {
+      return classDecl;
+    }
+
+    let statements = createStaticInitializerStatements(tree.name, initStaticVars);
+    statements = prependStatements(statements, classDecl);
+
+    return new AnonBlock(null, statements);
+  }
+
+  /**
+   * Transforms a single class expression
+   *
+   * @param {ClassExpression} tree
+   * @return {ParseTree}
+   */
+  transformClassExpression(tree) {
+    let {
+      elements,
+      initStaticVars,
+    } = this.transformClassElements_(tree);
+
+    let superClass = this.transformAny(tree.superClass);
+    let classExpression = new ClassExpression(tree.location, tree.name,
+        superClass, elements, tree.annotations, tree.typeParameters);
+
+    if (initStaticVars.length === 0) {
+      return classExpression;
+    }
+
+    this.pushTempScope();
+    let id = this.getTempIdentifier();
+    let className = createBindingIdentifier(id);
+    let statements = [
+      parseStatement `let ${id} = ${classExpression}`,
+      ...createStaticInitializerStatements(className, initStaticVars),
+      parseStatement `return ${className}`
+    ];
+    let body = createFunctionBody(statements);
+    this.popTempScope();
+
+    return createImmediatelyInvokedFunctionExpression(body);
+  }
+
+  getDefaultConstructor_(tree) {
+    if (tree.superClass) {
+      let param = createRestParameter(createIdentifierToken('args'));
+      let paramList = new FormalParameterList(null, [param]);
+      let body = createFunctionBody([parseStatement `super(...args)`]);
+      let name = createLiteralPropertyName(CONSTRUCTOR);
+      return new PropertyMethodAssignment(tree.location, false, null, name,
+          paramList, null, [], body);
+    }
+
+    return parsePropertyDefinition `constructor() {}`;
+  }
+}
+
+// TODO(vicb): Does not handle computed properties
+function createStaticInitializerStatements(className, initStaticMemberVars) {
+  return initStaticMemberVars.map((mv) => {
+    let propName = mv.name.literalToken.value;
+    return parseStatement
+        `Object.defineProperty(${className}, ${propName}, {enumerable: true,
+        configurable: true, value: ${mv.initializer}, writable: true})`;
+  });
+}

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -112,7 +112,7 @@ export class FromOptionsTransformer extends MultiTransformer {
       append(AnnotationsTransformer);
 
     if (options.typeAssertions) {
-      // Transforming member variabless to getters/setters only make
+      // Transforming member variables to getters/setters only make
       // sense when the type assertions are enabled.
       if (transformOptions.memberVariables) append(MemberVariableTransformer);
       append(TypeAssertionTransformer);

--- a/src/codegeneration/MemberVariableConstructorTransformer.js
+++ b/src/codegeneration/MemberVariableConstructorTransformer.js
@@ -1,0 +1,88 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PropertyMethodAssignment} from '../syntax/trees/ParseTrees.js';
+import {SUPER_EXPRESSION} from '../syntax/trees/ParseTreeType.js';
+import {ParseTreeTransformer} from './ParseTreeTransformer.js';
+import {
+  createCommaExpression,
+  createExpressionStatement,
+  createFunctionBody,
+  createParenExpression,
+  createThisExpression,
+} from './ParseTreeFactory.js';
+import {prependStatements} from './PrependStatements.js';
+import {parseExpression} from './PlaceholderParser.js';
+
+/**
+ * Transforms class constructors when classes have initialized instance
+ * member variables.
+ *
+ * When there is a super class, transforms `super()` to
+ * `(super(), initExpression, this)`
+ *
+ * Otherwise (no super class), prepend the initExpression to the constructor
+ * body.
+ */
+export function transformConstructor(constructor, initExpression, superClass) {
+  if (superClass) {
+    let transformer = new SuperCallTransformer(initExpression);
+    return transformer.transformAny(constructor);
+  }
+
+  let statements = constructor.body.statements;
+  let initStatement = createExpressionStatement(initExpression);
+  statements = prependStatements(statements, initStatement);
+
+  return new PropertyMethodAssignment(constructor.location, false,
+      constructor.functionKind, constructor.name, constructor.parameterList,
+      constructor.typeAnnotation, constructor.annotations,
+      createFunctionBody(statements));
+}
+
+// TODO(vicb): Does not handle computed properties
+export function getInstanceInitExpression(initInstanceVars) {
+  let expressions = initInstanceVars.map((mv) => {
+    let name = mv.name.literalToken;
+    return parseExpression `this.${name} = ${mv.initializer}`;
+  });
+  return createCommaExpression(expressions);
+}
+
+class SuperCallTransformer extends ParseTreeTransformer {
+  constructor(expression) {
+    super();
+    this.expression = expression;
+  }
+
+  transformCallExpression(tree) {
+    if (tree.operand.type === SUPER_EXPRESSION) {
+      var thisExpression = createThisExpression();
+      return createParenExpression(
+          createCommaExpression([tree, this.expression, thisExpression]));
+    }
+
+    return super.transformCallExpression(tree);
+  }
+
+  transformClassDeclaration(tree) {
+    // Do not transform `super()`  in nested classes
+    return tree;
+  }
+
+  transformClassExpression(tree) {
+    // Do not transform `super()`  in nested classes
+    return tree;
+  }
+}

--- a/src/codegeneration/ParseTreeFactory.js
+++ b/src/codegeneration/ParseTreeFactory.js
@@ -671,7 +671,7 @@ export function createPropertyNameAssignment(identifier, value) {
  * @param {string} name
  * @return {LiteralPropertyName}
  */
-function createLiteralPropertyName(name) {
+export function createLiteralPropertyName(name) {
   return new LiteralPropertyName(null, createIdentifierToken(name));
 }
 
@@ -679,7 +679,7 @@ function createLiteralPropertyName(name) {
  * @param {string|IdentifierToken|BindingIdentifier} identifier
  * @return {RestParameter}
  */
-function createRestParameter(identifier) {
+export function createRestParameter(identifier) {
   return new RestParameter(null, createBindingIdentifier(identifier), null);
 }
 

--- a/src/codegeneration/PureES6Transformer.js
+++ b/src/codegeneration/PureES6Transformer.js
@@ -17,6 +17,7 @@ import {MemberVariableTransformer} from './MemberVariableTransformer.js';
 import {MultiTransformer} from './MultiTransformer.js';
 import {TypeAssertionTransformer} from './TypeAssertionTransformer.js';
 import {TypeTransformer} from './TypeTransformer.js';
+import {ES6ClassTransformer} from './ES6ClassTransformer.js';
 import {UniqueIdentifierGenerator} from './UniqueIdentifierGenerator.js';
 import {validate as validateFreeVariables} from
     '../semantics/FreeVariableChecker.js';
@@ -56,6 +57,9 @@ export class PureES6Transformer extends MultiTransformer {
       // sense when the type assertions are enabled.
       if (options.memberVariables) append(MemberVariableTransformer);
       append(TypeAssertionTransformer);
+    }
+    if (options.memberVariables) {
+      append(ES6ClassTransformer);
     }
     append(AnnotationsTransformer);
     append(TypeTransformer);

--- a/src/codegeneration/PureES6Transformer.js
+++ b/src/codegeneration/PureES6Transformer.js
@@ -52,7 +52,7 @@ export class PureES6Transformer extends MultiTransformer {
     }
 
     if (options.typeAssertions) {
-      // Transforming member variabless to getters/setters only make
+      // Transforming member variables to getters/setters only make
       // sense when the type assertions are enabled.
       if (options.memberVariables) append(MemberVariableTransformer);
       append(TypeAssertionTransformer);

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -416,7 +416,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
   visitCommaExpression(tree) {
     for (let i = 0; i < tree.expressions.length; i++) {
       let expression = tree.expressions[i];
-      this.checkVisit_(expression.isAssignmentExpression(), expression,
+      this.checkVisit_(expression.isExpression(), expression,
           'expression expected');
     }
   }

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -324,6 +324,10 @@ const FUNCTION_STATE_DERIVED_CONSTRUCTOR = 1 << 5;
 const FUNCTION_STATE_GENERATOR = 1 << 6;
 const FUNCTION_STATE_ASYNC = 1 << 7;
 
+const FUNCTION_STATE_LENIENT =
+    FUNCTION_STATE_METHOD | FUNCTION_STATE_GENERATOR |
+    FUNCTION_STATE_ASYNC | FUNCTION_STATE_DERIVED_CONSTRUCTOR;
+
 /**
  * This is used to track the functions as the parser descends. It allows
  * us to determine if we are in a function and what kind of function it is.
@@ -938,9 +942,7 @@ export class Parser {
    */
   parseStatement() {
     // Allow return, yield and await.
-    let fs = this.pushFunctionState_(
-        FUNCTION_STATE_FUNCTION | FUNCTION_STATE_GENERATOR |
-        FUNCTION_STATE_ASYNC);
+    let fs = this.pushFunctionState_(FUNCTION_STATE_LENIENT);
     let result = this.parseModuleItem_(this.peekType_());
     this.popFunctionState_(fs);
     return result;
@@ -954,9 +956,7 @@ export class Parser {
    */
   parseStatements() {
     // Allow return, yield and await.
-    let fs = this.pushFunctionState_(
-        FUNCTION_STATE_FUNCTION | FUNCTION_STATE_GENERATOR |
-        FUNCTION_STATE_ASYNC);
+    let fs = this.pushFunctionState_(FUNCTION_STATE_LENIENT);
     let result = this.parseModuleItemList_();
     this.popFunctionState_(fs);
     return result;
@@ -2621,8 +2621,7 @@ export class Parser {
   }
 
   parseExpression() {
-    let fs = this.pushFunctionState_(FUNCTION_STATE_FUNCTION |
-        FUNCTION_STATE_GENERATOR | FUNCTION_STATE_ASYNC);
+    let fs = this.pushFunctionState_(FUNCTION_STATE_LENIENT);
     let expression = this.parseExpression_();
     this.popFunctionState_(fs);
     return expression;

--- a/test/unit/codegeneration/ES6ClassTransformer.js
+++ b/test/unit/codegeneration/ES6ClassTransformer.js
@@ -1,0 +1,178 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {suite, test, assert} from '../../unit/unitTestRunner.js';
+
+import {Options} from '../../../src/Options.js';
+import {Parser} from '../../../src/syntax/Parser.js';
+import {ParseTreeValidator} from '../../../src/syntax/ParseTreeValidator.js';
+import {SourceFile} from '../../../src/syntax/SourceFile.js';
+import {ES6ClassTransformer} from '../../../src/codegeneration/ES6ClassTransformer.js';
+import {UniqueIdentifierGenerator} from '../../../src/codegeneration/UniqueIdentifierGenerator.js';
+import {write} from '../../../src/outputgeneration/TreeWriter.js';
+
+suite('ES6ClassTransformer.js', function() {
+  var transformer;
+
+  setup(function() {
+    transformer = new ES6ClassTransformer(new UniqueIdentifierGenerator());
+  });
+
+  function parseScript(content, memberVariables = true) {
+    var file = new SourceFile('test', content);
+    var options = new Options({
+      memberVariables: memberVariables,
+      annotations: true,
+      validate: true,
+    });
+    var parser = new Parser(file, null, options);
+    var tree = parser.parseScript();
+    ParseTreeValidator.validate(tree);
+    return tree;
+  }
+
+  function normalizeScript(content) {
+    var tree = parseScript(content, false);
+    return write(tree);
+  }
+
+  function testTransform(name, content, expected) {
+    test(name, function() {
+      var tree = parseScript(content);
+      var transformed = transformer.transformAny(tree);
+      assert.equal(normalizeScript(expected), write(transformed));
+    });
+  }
+
+  testTransform('ClassDeclaration no ctor',
+    `class C {
+      static c0 = 0;
+      c1 = 1;
+      c2 = 2;
+      c3;
+    }`,
+    `class C {
+      constructor() {
+        this.c1 = 1, this.c2 = 2;
+      }
+    }
+    Object.defineProperty(C, "c0", {
+      enumerable: true, configurable: true, value: 0, writable: true
+    });`
+  );
+
+  testTransform('ClassDeclaration with ctor',
+    `class C {
+      static c0 = 0;
+      c1 = 1;
+      c2 = 2;
+      c3;
+      constructor() {
+        fn();
+      }
+    }`,
+    `class C {
+      constructor() {
+        this.c1 = 1, this.c2 = 2;
+        fn();
+      }
+    }
+    Object.defineProperty(C, "c0", {
+      enumerable: true, configurable: true, value: 0, writable: true
+    });`
+  );
+
+  testTransform('derived ClassDeclaration no ctor',
+    `class C extends B {
+      static c0 = 0;
+      c1 = 1;
+      c2 = 2;
+      c3;
+    }`,
+    `class C extends B {
+      constructor(...args) {
+        (super(...args), this.c1 = 1, this.c2 = 2, this);
+      }
+    }
+    Object.defineProperty(C, "c0", {
+      enumerable: true, configurable: true, value: 0, writable: true
+    });`
+  );
+
+  testTransform('derived ClassDeclaration with ctor',
+    `class C extends B {
+      static c0 = 0;
+      c1 = 1;
+      c2 = 2;
+      c3;
+      constructor() {
+        super(null);
+        fn();
+      }
+    }`,
+    `class C extends B {
+      constructor() {
+        (super(null), this.c1 = 1, this.c2 = 2, this);
+        fn();
+      }
+    }
+    Object.defineProperty(C, "c0", {
+      enumerable: true, configurable: true, value: 0, writable: true
+    });`
+  );
+
+  testTransform('preserve annotations',
+    `@Annotation() class C {}`,
+    `@Annotation() class C {}`
+  );
+
+  testTransform('preserve setters, getters and methods',
+    `class C {
+      static get sa() {}
+      get a() {}
+      static set sa(v) {}
+      set a(v) {}
+      fn() {}
+      static fn() {}
+    }`,
+    `class C {
+      static get sa() {}
+      get a() {}
+      static set sa(v) {}
+      set a(v) {}
+      fn() {}
+      static fn() {}
+    }`
+  );
+
+  testTransform('ClassExpression',
+    `var c = class {
+      static c0 = 0;
+      c1 = 1;
+      c2 = 2;
+      c3;
+    }`,
+    `var c = (function() {
+      let $__0 = class {
+        constructor() {
+          this.c1 = 1, this.c2 = 2;
+        }
+      };
+      Object.defineProperty($__0, "c0", {
+        enumerable: true, configurable: true, value: 0, writable: true
+      });
+      return $__0;
+    })();`
+  );
+});


### PR DESCRIPTION
relates to #1708 

/cc @arv @caitp

TODO:
- [x] generated ctor if super class - currently ```parseStatement `super(...arguments)` ``` fails,
- [x] the coma expression (class expression) is not valid: `let` and ";",
- [x] add tests