### PR TITLE
Avoid undocumented feature of commanderjs to

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/google/traceur-compiler"
   },
   "dependencies": {
-    "commander": "2.x",
+    "commander": "2.6",
     "glob": "4.3",
     "rsvp": "^3.0.13",
     "semver": "2.x",

--- a/src/node/command.js
+++ b/src/node/command.js
@@ -102,15 +102,13 @@ traceurAPI.util.addOptions(commandLine, commandOptions);
 
 commandLine.usage('[options] [files]');
 
-commandLine.command('*').action(function() {
-    // The callback seems to receive a "command" at the end of arguments
-    for (var i = 0; i < arguments.length - 1; i++) {
-      rootSources.push({name: arguments[i], type: 'module'});
-    }
-  });
-
 commandLine.sourceMaps = false;
 commandLine.parse(process.argv);
+
+// Any remaining arguments become module inputs to compile
+commandLine.args.forEach(function(arg) {
+  rootSources.push({name: arg, type: 'module'});
+});
 
 // commanderjs sets self[name]=defaultValue if the argument is null.
 // To support --source-maps a legacy boolean we need to transfer the


### PR DESCRIPTION
process -- arguments.
Fix commander version at 2.6 until we publish one time.

Fixes #1804