### PR TITLE
Fix parsing of extends expression

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -855,6 +855,7 @@ export class Parser {
     let superClass = null;
     if (this.eatIf_(EXTENDS)) {
       superClass = this.parseLeftHandSideExpression_();
+      superClass = this.coverFormalsToParenExpression_(superClass);
     }
     this.eat_(OPEN_CURLY);
     let elements = this.parseClassElements_(superClass);

--- a/test/feature/Classes/ExtendCoverFormals.js
+++ b/test/feature/Classes/ExtendCoverFormals.js
@@ -1,0 +1,10 @@
+class C {}
+
+var x = 1;
+var y = C;
+class D extends (x, y) {
+
+}
+
+assert.instanceOf(new D(), C);
+assert.instanceOf(new D(), D);


### PR DESCRIPTION
If the extends expression was a cover formals then we ended up
generating invalid code.