### PR TITLE
Fix ASI with multiline comments

### DIFF
--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -522,22 +522,15 @@ function nextToken() {
  *     line terminator.
  */
 function peekTokenNoLineTerminator() {
+  // Search the text between lastToken and next token.
   let t = peekToken();
   let start = lastToken.location.end.offset;
   let end = t.location.start.offset;
   for (let i = start; i < end; i++) {
-    let code = input.charCodeAt(i);
-    if (isLineTerminator(code))
+    // Any newline counts; a new line inside a block comment, the new line
+    // at the end of a line comment as well as a new line as a whitespace.
+    if (isLineTerminator(input.charCodeAt(i))) {
       return null;
-
-    // If we have a block comment we need to skip it since new lines inside
-    // the comment are not significant.
-    if (code === 47) {  // '/'
-      code = input.charCodeAt(++i);
-      // End of line comments always mean a new line is present.
-      if (code === 47)  // '/'
-        return null;
-      i = input.indexOf('*/', i) + 2;
     }
   }
   return t;

--- a/test/feature/Syntax/MultlineCommentIsNewLine.js
+++ b/test/feature/Syntax/MultlineCommentIsNewLine.js
@@ -1,0 +1,28 @@
+function f() {
+  return /*
+      */ 1;
+}
+assert.equal(undefined, f());
+
+function g() {
+  return /* */ 1;
+}
+assert.equal(1, g());
+
+function h() {
+  return /* */ /*
+      */ 1;
+}
+assert.equal(undefined, h());
+
+function i() {
+  return /* */ //
+      1;
+}
+assert.equal(undefined, i());
+
+function j() {
+  return //
+      1;
+}
+assert.equal(undefined, j());

--- a/test/feature/Syntax/NoNewLineHereEndOfFile.js
+++ b/test/feature/Syntax/NoNewLineHereEndOfFile.js
@@ -1,0 +1,3 @@
+// Comment not closed.
+var f = (x) /*
+    => {}


### PR DESCRIPTION
A multiline comment is treated as a new line for ASI when it
contains a new line.

Fixes #1803, #1809