### PR TITLE
Fix ParseTreeValidator for case clauses

### DIFF
--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -357,7 +357,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
         'expression expected');
     for (let i = 0; i < tree.statements.length; i++) {
       let statement = tree.statements[i];
-      this.checkVisit_(statement.isStatement(), statement,
+      this.checkVisit_(statement.isStatementListItem(), statement,
           'statement expected');
     }
   }
@@ -447,7 +447,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
   visitDefaultClause(tree) {
     for (let i = 0; i < tree.statements.length; i++) {
       let statement = tree.statements[i];
-      this.checkVisit_(statement.isStatement(), statement,
+      this.checkVisit_(statement.isStatementListItem(), statement,
           'statement expected');
     }
   }

--- a/test/feature/Syntax/CaseClauseShouldBeStatementListItem.js
+++ b/test/feature/Syntax/CaseClauseShouldBeStatementListItem.js
@@ -1,0 +1,14 @@
+switch (1) {
+  case 2:
+    let x;
+    break;
+  case 3:
+    const y = 4;
+    break;
+  case 5:
+    function f() {}
+    break;
+  default:
+    class C {}
+    break;
+}


### PR DESCRIPTION
In ES6 the case statements may contain Declarations. The parsing part
of that was already correct but the validator was using ES5 logic.