### PR TITLE
Always wrap the body of a for-on-loop in a block.

### DIFF
--- a/src/codegeneration/InnerForOnTransformer.js
+++ b/src/codegeneration/InnerForOnTransformer.js
@@ -41,7 +41,10 @@ import {
 } from './ParseTreeFactory.js';
 import {ARGUMENTS} from '../syntax/PredefinedName.js';
 import {VAR} from '../syntax/TokenType.js';
-import {VARIABLE_DECLARATION_LIST} from '../syntax/trees/ParseTreeType.js';
+import {
+  VARIABLE_DECLARATION_LIST,
+  BLOCK
+} from '../syntax/trees/ParseTreeType.js';
 
 export class InnerForOnTransformer extends ParseTreeTransformer {
   // TODO: This class has considerable overlap with
@@ -78,8 +81,13 @@ export class InnerForOnTransformer extends ParseTreeTransformer {
           ${tree.initializer} = ${value};`;
     }
 
-    let body = new Block(tree.body.location,
-        [assignment, ...tree.body.statements]);
+    let body;
+    if (tree.body.type === BLOCK) {
+      body = new Block(tree.body.location,
+          [assignment, ...tree.body.statements]);
+    } else {
+      body = new Block(null, [assignment, tree.body]);
+    }
     body = this.transformAny(body);
     body = alphaRenameThisAndArguments(this, body);
 

--- a/test/feature/AsyncGenerators/ForOnBody.js
+++ b/test/feature/AsyncGenerators/ForOnBody.js
@@ -1,0 +1,14 @@
+// Options: --async-generators --for-on --async-functions
+// Async.
+
+async function* x() {
+}
+
+async function y() {
+  for (let a on x())
+    break;
+}
+
+y()
+
+done();


### PR DESCRIPTION

Fixes #1827.