### PR TITLE
Add System.dirname() and replace __dirname

### DIFF
--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -293,11 +293,10 @@ export class TraceurLoader extends Loader {
    */
   dirname(filename) {
     var lastSlash = filename.lastIndexOf('/');
-    if (lastSlash === -1) {
+    if (lastSlash === -1)
       return '.';
-    } else if (lastSlash === 0) {
+    if (lastSlash === 0)
       return '/';
-    }
     return filename.slice(0, lastSlash);
   }
 

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -287,4 +287,18 @@ export class TraceurLoader extends Loader {
       factoryFunction);
   }
 
+  /**
+   * @return {string} The directory part of a file name.
+   * Emulates node path.dirname.
+   */
+  dirname(filename) {
+    var lastSlash = filename.lastIndexOf('/');
+    if (lastSlash === -1) {
+      return '.';
+    } else if (lastSlash === 0) {
+      return '/';
+    }
+    return filename.slice(0, lastSlash);
+  }
+
 }

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -22,6 +22,7 @@ suite('context test', function() {
   var uuid = require('node-uuid');
   var exec = require('child_process').exec;
   var nodeLoader = require('../../../src/node/nodeLoader.js');
+  var theDirName = System.dirname(__moduleName);
 
   var tempFileName;
   var tempMapName;
@@ -39,7 +40,7 @@ suite('context test', function() {
   }
 
   function resolve(name) {
-    return forwardSlash(path.resolve(__dirname, '../../../' + name));
+    return forwardSlash(path.resolve(theDirName, '../../../' + name));
   }
 
   function executeFileWithRuntime(fileName, options, debug) {
@@ -76,7 +77,7 @@ suite('context test', function() {
   }
 
   test('class', function(done) {
-    var fileName = path.resolve(__dirname, 'resources/class.js');
+    var fileName = path.resolve(theDirName, 'resources/class.js');
     executeFileWithRuntime(fileName).then(function(value) {
       assert.equal(value, 2);
       done();
@@ -84,7 +85,7 @@ suite('context test', function() {
   });
 
   test('generator', function(done) {
-    var fileName = path.resolve(__dirname, 'resources/generator.js');
+    var fileName = path.resolve(theDirName, 'resources/generator.js');
     var options = {
       generatorComprehension: true
     };
@@ -95,7 +96,7 @@ suite('context test', function() {
   });
 
   test('generator (symbols)', function(done) {
-    var fileName = path.resolve(__dirname, 'resources/generator.js');
+    var fileName = path.resolve(theDirName, 'resources/generator.js');
     var options = {
       generatorComprehension: true,
       symbols: true

--- a/test/unit/node/require.js
+++ b/test/unit/node/require.js
@@ -21,14 +21,14 @@ suite('require.js', function() {
 
   test('traceurRequire', function() {
     // TODO(arv): The path below is sucky...
-    var x = traceurRequire(path.join(__dirname, './resources/x.js')).x;
+    var x = traceurRequire(path.join(System.dirname(__moduleName), './resources/x.js')).x;
     assert.equal(x, 'x');
   });
 
   test('traceurRequire errors', function() {
     try {
       var filename = 'resources/syntax-error.js';
-      traceurRequire(path.join(__dirname, './' + filename));
+      traceurRequire(path.join(System.dirname(__moduleName), './' + filename));
       assert.notOk(true);
     } catch (ex) {
       assert.equal(ex.length, 1, 'One error is reported');
@@ -39,7 +39,7 @@ suite('require.js', function() {
 
   test('traceurRequire.makeDefault options', function() {
     // TODO(arv): The path below is sucky...
-    var fixturePath = path.join(__dirname, './resources/async-function.js');
+    var fixturePath = path.join(System.dirname(__moduleName), './resources/async-function.js');
     var experimentalOption = {asyncFunctions: true};
     // traceur.require must throw without the experimentalOption
     try {
@@ -76,7 +76,7 @@ suite('require.js', function() {
     // As above, use node's original require, not the local Tracuer
     // supplied one.
     var Q = traceurRequire.nodeRequire(
-      path.join(__dirname, './resources/import-export.js')).Q;
+      path.join(System.dirname(__moduleName), './resources/import-export.js')).Q;
     var q = new Q();
     assert.equal(q.name, 'Q');
   });

--- a/test/unit/node/tree-writer.js
+++ b/test/unit/node/tree-writer.js
@@ -27,7 +27,7 @@ suite('tree writer', function() {
 
   function testWriteModule(resouceName) {
     test(resouceName, function() {
-      var fileName = path.resolve(__dirname, resouceName);
+      var fileName = path.resolve(System.dirname(__moduleName), resouceName);
       var source = fs.readFileSync(fileName, 'utf-8');
       var file = new traceur.syntax.SourceFile(fileName, source);
       var result = parseFileAsModule(file);

--- a/test/unit/runtime/System.js
+++ b/test/unit/runtime/System.js
@@ -177,4 +177,12 @@ suite('System.js', function() {
     }).catch(done);
   });
 
+
+  test('System.dirname', function(){
+    assert.equal(System.dirname(''), '.');
+    assert.equal(System.dirname('a.js'), '.');
+    assert.equal(System.dirname('/a.js'), '/');
+    assert.equal(System.dirname('a/b.js'), 'a');
+    assert.equal(System.dirname('/a/b.js'), '/a');
+  });
 });


### PR DESCRIPTION
with System.dirname(__moduleName).

We use `__dirname` in some tests but this value is not part of the standard module environment. 
Of course we don't know that `__moduleName` will be standard either, but it seems more likely.

Maybe importing path.dirname would be cleaner, but System.dirname(__moduleName) is
somewhat closer to the convenience of __dirname we replace.