### PR TITLE
Move error logging from Mocha6 to TraceurTestRunner.

### DIFF
--- a/test/modular/Mocha6.js
+++ b/test/modular/Mocha6.js
@@ -49,10 +49,6 @@ export class Mocha6 extends Mocha {
           then(() => {
             this.suite.emit('require', global, file, this);
             this.suite.emit('post-require', global, file, this);
-          }, (ex) => {
-            console.error('Mocha6.importFiles FAILED for ' + file);
-            console.error(ex.stack || ex);
-            return ex;
           });
     });
     return Promise.all(promiseImports);
@@ -66,8 +62,8 @@ export class Mocha6 extends Mocha {
    */
 
   run(fn) {
+    // The base mocha.run will not load files, see loadFiles() override.
     return this.importFiles().then(() => {
-      // The base mocha.run will not load files, see loadFiles() override.
       return super.run(fn);
     });
   }

--- a/test/modular/TraceurTestRunner.js
+++ b/test/modular/TraceurTestRunner.js
@@ -26,7 +26,7 @@ export class TraceurTestRunner extends Mocha6 {
       importMetadata: {
         traceurOptions: {
           sourceMaps: 'memory',
-          require: true
+          require: true // Some unit tests use require()
         }
       }
     });
@@ -94,6 +94,9 @@ export class TraceurTestRunner extends Mocha6 {
       runner.on('end', () => {
         process.exit(failed);
       });
+    }, (ex) => {
+      console.log('Test setup FAILED ', ex.stack || ex);
+      process.exit(failed);
     });
   }
 


### PR DESCRIPTION
If the test setup fails in one file, the Promise.all rejects other promises,
causing us to see repeats of the same error message. Move the error message
outside of the loop so we only see one