### PR TITLE
Call ToString for template literal placeholders

### DIFF
--- a/test/feature/TemplateLiterals/TaggedToStringSustitutionOrder.js
+++ b/test/feature/TemplateLiterals/TaggedToStringSustitutionOrder.js
@@ -1,0 +1,41 @@
+var subs = [];
+var log = [];
+var tagged = [];
+function getter(name, value) {
+  return {
+    get: function() {
+      log.push('get' + name);
+      return value;
+    },
+    set: function(v) {
+      log.push('set' + name);
+    }
+  };
+}
+Object.defineProperties(subs, {
+  0: getter(0, 1),
+  1: getter(1, 2),
+  2: getter(2, 3)
+});
+function tag(cs) {
+  var substitutions = arguments.length - 1;
+  var cooked = cs.length;
+  var e = cs[0];
+  var i = 0;
+  assert.equal(cooked, substitutions + 1);
+  while (i < substitutions) {
+    var sub = arguments[i++ + 1];
+    var tail = cs[i];
+    tagged.push(sub);
+    e = e.concat(sub, tail);
+  }
+  return e;
+}
+assert.equal('-1-2-3-', tag`-${subs[0]}-${subs[1]}-${subs[2]}-`);
+assert.deepEqual(['get0', 'get1', 'get2'], log);
+assert.deepEqual([1, 2, 3], tagged);
+tagged.length = 0;
+log.length = 0;
+assert.equal('-1-', tag`-${subs[0]}-`);
+assert.deepEqual(['get0'], log);
+assert.deepEqual([1], tagged);

--- a/test/feature/TemplateLiterals/ToStringSubstitutions.js
+++ b/test/feature/TemplateLiterals/ToStringSubstitutions.js
@@ -1,0 +1,16 @@
+var a = {
+  toString: function() { return 'a'; },
+  valueOf: function() { return '-a-'; }
+};
+var b = {
+  toString: function() { return 'b'; },
+  valueOf: function() { return '-b-'; }
+};
+assert.equal('a', `${a}`);
+assert.equal('ab', `${a}${b}`);
+assert.equal('-a--b-', `${a + b}`);
+assert.equal('-a-', `${a + ''}`);
+assert.equal('1a', `1${a}`);
+assert.equal('1a2', `1${a}2`);
+assert.equal('1a2b', `1${a}2${b}`);
+assert.equal('1a2b3', `1${a}2${b}3`);

--- a/test/feature/TemplateLiterals/ToStringSustitutionOrder.js
+++ b/test/feature/TemplateLiterals/ToStringSustitutionOrder.js
@@ -1,0 +1,20 @@
+var subs = [];
+var log = [];
+function getter(name, value) {
+  return {
+    get: function() {
+      log.push('get' + name);
+      return value;
+    },
+    set: function(v) {
+      log.push('set' + name);
+    }
+  };
+}
+Object.defineProperties(subs, {
+  0: getter(0, 'a'),
+  1: getter(1, 'b'),
+  2: getter(2, 'c')
+});
+assert.equal('-a-b-c-', `-${subs[0]}-${subs[1]}-${subs[2]}-`);
+assert.deepEqual(['get0', 'get1', 'get2'], log);


### PR DESCRIPTION
We were not calling ToString correctly for template literal
placeholder expressions. This lead to cases where we ended up with
calling valueOf instead as required by a + b.

Fixes #1836