### PR TITLE
readme: AtScript no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Traceur is a JavaScript.next-to-JavaScript-of-today compiler that allows you to
 use features from the future **today**. Traceur supports ES6, some ES7 features as 
-well as some AtScript features.
+well as some TypeScript features.
 
 Traceur's goal is to inform the design
 of new JavaScript features which are only valuable if they allow you to write


### PR DESCRIPTION
Rename "AtScript" to "TypeScript", as the AtScript name is now retired. All AtScript functionality is being moved to TypeScript.

Signed-off-by: David Li <jiawei.davidli@gmail.com>