### PR TITLE
Split NodeLoaderCompiler from System.

### DIFF
--- a/src/node/NodeLoaderCompiler.js
+++ b/src/node/NodeLoaderCompiler.js
@@ -18,11 +18,11 @@ import {LoaderCompiler} from '../runtime/LoaderCompiler.js';
 export class NodeLoaderCompiler extends LoaderCompiler {
   evaluateCodeUnit(codeUnit) {
     // Node eval does not support //# sourceURL yet.
-  	// In node we use a low level evaluator so that the
-  	// sourcemap=memory mechanism can help us debug.
-		let runInThisContext = require('vm').runInThisContext;
-  	let content = codeUnit.metadata.transcoded;
-  	let filename = codeUnit.address || codeUnit.normalizedName;
+    // In node we use a low level evaluator so that the
+    // sourcemap=memory mechanism can help us debug.
+    let runInThisContext = require('vm').runInThisContext;
+    let content = codeUnit.metadata.transcoded;
+    let filename = codeUnit.address || codeUnit.normalizedName;
     let result = runInThisContext(content, filename);
     codeUnit.metadata.transformedTree = null;
   }

--- a/src/node/NodeLoaderCompiler.js
+++ b/src/node/NodeLoaderCompiler.js
@@ -1,0 +1,29 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {LoaderCompiler} from '../runtime/LoaderCompiler.js';
+
+
+export class NodeLoaderCompiler extends LoaderCompiler {
+  evaluateCodeUnit(codeUnit) {
+    // Node eval does not support //# sourceURL yet.
+  	// In node we use a low level evaluator so that the
+  	// sourcemap=memory mechanism can help us debug.
+		let runInThisContext = require('vm').runInThisContext;
+  	let content = codeUnit.metadata.transcoded;
+  	let filename = codeUnit.address || codeUnit.normalizedName;
+    let result = runInThisContext(content, filename);
+    codeUnit.metadata.transformedTree = null;
+  }
+}

--- a/src/node/NodeLoaderCompiler.js
+++ b/src/node/NodeLoaderCompiler.js
@@ -14,15 +14,15 @@
 
 import {LoaderCompiler} from '../runtime/LoaderCompiler.js';
 
-
 export class NodeLoaderCompiler extends LoaderCompiler {
   evaluateCodeUnit(codeUnit) {
-    // Node eval does not support //# sourceURL yet.
-    // In node we use a low level evaluator so that the
-    // sourcemap=memory mechanism can help us debug.
+    // TODO(jjb): can we move this to file scope?
     let runInThisContext = require('vm').runInThisContext;
     let content = codeUnit.metadata.transcoded;
     let filename = codeUnit.address || codeUnit.normalizedName;
+    // Node eval does not support //# sourceURL yet.
+    // In node we use a low level evaluator so that the
+    // sourcemap=memory mechanism can help us debug.
     let result = runInThisContext(content, filename);
     codeUnit.metadata.transformedTree = null;
   }

--- a/src/node/System.js
+++ b/src/node/System.js
@@ -21,21 +21,7 @@ var path = require('path');
 var nodeLoader = require('./nodeLoader.js');
 var url = (path.resolve('./') + '/').replace(/\\/g, '/');
 
-
-var LoaderCompiler = traceur.runtime.LoaderCompiler;
-var NodeLoaderCompiler = function() {
-  LoaderCompiler.call(this);
-};
-
-NodeLoaderCompiler.prototype = {
-  __proto__: LoaderCompiler.prototype,
-  evaluateCodeUnit: function(codeUnit) {
-    var result = module._compile(codeUnit.metadata.transcoded,
-        codeUnit.address || codeUnit.normalizedName);
-    codeUnit.metadata.transformedTree = null;
-    return result;
-  }
-};
+var NodeLoaderCompiler = traceur.runtime.NodeLoaderCompiler;
 
 var System = new traceur.runtime.TraceurLoader(nodeLoader, url,
     new NodeLoaderCompiler());

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -94,6 +94,7 @@ export let codegeneration = {
 
 import {Loader} from './runtime/Loader.js';
 import {LoaderCompiler} from './runtime/LoaderCompiler.js';
+import {NodeLoaderCompiler} from './node/NodeLoaderCompiler.js';
 import {InlineLoaderCompiler} from './runtime/InlineLoaderCompiler.js';
 import {TraceurLoader} from './runtime/TraceurLoader.js';
 
@@ -101,5 +102,6 @@ export let runtime = {
   InlineLoaderCompiler,
   Loader,
   LoaderCompiler,
+  NodeLoaderCompiler,
   TraceurLoader
 };

--- a/test/modular/getTestLoader.js
+++ b/test/modular/getTestLoader.js
@@ -20,7 +20,7 @@ var resolveUrl = get('src/util/url.js').resolveUrl;
 
 var url;
 var fileLoader;
-if (typeof __filename !== 'undefined') {  // Node
+if (typeof window === 'undefined') {  // Node
   // TOD(arv): Make the system work better with file paths, especially
   // Windows file paths.
   url = process.cwd().replace(/\\/g, '/') + '/test/unit/runtime/';


### PR DESCRIPTION
Use vm.runInThisContext() rather than _compile().
This way we evaluate without the node wrapper that
introduces exports, module, `__filename` and `__dirname`.