### PR TITLE
Fix template object caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ INDIVIDUAL_RUNTIME_MODULES = \
   src/runtime/classes.js \
   src/runtime/generators.js \
   src/runtime/async.js \
+  src/runtime/template.js \
   src/runtime/type-assertions.js \
   #end runtime modules
 SRC = \

--- a/src/codegeneration/PlaceholderParser.js
+++ b/src/codegeneration/PlaceholderParser.js
@@ -20,7 +20,6 @@ import {
 } from '../syntax/trees/ParseTreeType.js';
 import {IdentifierToken} from '../syntax/IdentifierToken.js';
 import {LiteralToken} from '../syntax/LiteralToken.js';
-import {Map} from '../runtime/polyfills/Map.js';
 import {CollectingErrorReporter} from '../util/CollectingErrorReporter.js';
 import {Options} from '../Options.js';
 import {ParseTree} from '../syntax/trees/ParseTree.js';
@@ -76,14 +75,15 @@ import {
  */
 const NOT_FOUND = {};
 
-let cache = new Map();
-
 /**
  * @param {function(Parser) : ParseTree} doParse Function that calls the correct
  *     parse method on the parser.
  */
 function makeParseFunction(doParse) {
-  return (sourceLiterals, ...values) => parse(sourceLiterals, values, doParse);
+  let cache = new Map();
+  return (sourceLiterals, ...values) => {
+    return parse(sourceLiterals, values, doParse, cache);
+  };
 }
 
 /**
@@ -99,7 +99,7 @@ export let parseStatements = makeParseFunction((p) => p.parseStatements());
 export let parsePropertyDefinition =
     makeParseFunction((p) => p.parsePropertyDefinition());
 
-function parse(sourceLiterals, values, doParse) {
+function parse(sourceLiterals, values, doParse, cache) {
   let tree = cache.get(sourceLiterals);
   if (!tree) {
     let source = insertPlaceholderIdentifiers(sourceLiterals);

--- a/src/codegeneration/TemplateLiteralTransformer.js
+++ b/src/codegeneration/TemplateLiteralTransformer.js
@@ -25,7 +25,6 @@ import {
 } from '../syntax/trees/ParseTrees.js';
 import {LiteralToken} from '../syntax/LiteralToken.js';
 import {ParseTreeTransformer} from './ParseTreeTransformer.js';
-import {TempVarTransformer} from './TempVarTransformer.js';
 import {
   PERCENT,
   PLUS,
@@ -38,74 +37,84 @@ import {
   createArrayLiteralExpression,
   createBinaryExpression,
   createCallExpression,
-  createIdentifierExpression,
+  createMemberExpression,
   createOperatorToken,
-  createParenExpression,
-  createStringLiteral
+  createParenExpression
 } from './ParseTreeFactory.js';
-import {parseExpression} from './PlaceholderParser.js';
+
+function createStringLiteralExpression(loc, str) {
+  return new LiteralExpression(loc, new LiteralToken(STRING, str, loc));
+}
 
 /**
- * @param {ParseTree} tree
+ * Generetes the runtime call to create the template object.
+ * The tagged template literal
+ *
+ *   f `a${42}\n`
+ *
+ * gets compiled into:
+ *
+ *   f($traceurRuntime.getTemplateObject(['a', '\\n], ['a', '\n']), 42)
+ *
+ * Note that if the cooked and the raw strings are identical the runtime call
+ * only pass one array.
+ *
+ * @param {Array<ParseTree>} elements
  * @return {ParseTree}
  */
-function createCallSiteIdObject(tree) {
-  let elements = tree.elements;
-  let cooked = createCookedStringArray(elements);
-  let raw = createRawStringArray(elements);
-  return parseExpression `Object.freeze(Object.defineProperties(${cooked}, {
-    raw: {
-      value: Object.freeze(${raw})
+function createGetTemplateObject(elements) {
+  let cooked = [];
+  let raw = [];
+  let same = true;
+  for (let i = 0; i < elements.length; i += 2) {
+    let loc = elements[i].location;
+    let str = elements[i].value.value;
+    let cookedStr = toCookedString(str);
+    let rawStr = toRawString(str);
+    let cookedLiteral = createStringLiteralExpression(loc, cookedStr);
+    cooked.push(cookedLiteral);
+    if (cookedStr !== rawStr) {
+      same = false;
+      let rawLiteral = createStringLiteralExpression(loc, rawStr);
+      raw.push(rawLiteral);
+    } else {
+      raw.push(cookedLiteral);
     }
-  }))`;
+  }
+
+  maybeAddEmptyStringAtEnd(elements, cooked);
+  let cookedLiteral = createArrayLiteralExpression(cooked);
+  let args = [cookedLiteral];
+  if (!same) {
+    maybeAddEmptyStringAtEnd(elements, raw);
+    let rawLiteral = createArrayLiteralExpression(raw);
+    args.unshift(rawLiteral);
+  }
+
+  return createCallExpression(
+      createMemberExpression('$traceurRuntime', 'getTemplateObject'),
+      createArgumentList(args));
 }
 
 /**
  * Adds an empty string at the end if needed. This is needed in case the
  * template literal does not end with a literal portion.
- * @param {Array.<ParseTree>} elements
- * @param {Array.<ParseTree>} items This is the array that gets mutated.
+ * @param {Array<ParseTree>} elements
+ * @param {Array<ParseTree>} items This is the array that gets mutated.
  */
 function maybeAddEmptyStringAtEnd(elements, items) {
   let length = elements.length;
-  if (!length || elements[length - 1].type !== TEMPLATE_LITERAL_PORTION)
-    items.push(createStringLiteral(''));
-}
-
-function createRawStringArray(elements) {
-  let items = [];
-  for (let i = 0; i < elements.length; i += 2) {
-    let str = elements[i].value.value;
-    // Normalize line endings before using JSON for the rest.
-    str = str.replace(/\r\n?/g, '\n');
-    str = JSON.stringify(str);
-    // JSON does not handle Unicode line terminators \u2028 and \u2029.
-    str = replaceRaw(str);
-    let loc = elements[i].location;
-    let expr = new LiteralExpression(loc, new LiteralToken(STRING, str, loc));
-    items.push(expr);
+  if (!length || elements[length - 1].type !== TEMPLATE_LITERAL_PORTION) {
+    items.push(createStringLiteralExpression(null, '""'));
   }
-  maybeAddEmptyStringAtEnd(elements, items);
-  return createArrayLiteralExpression(items);
 }
 
-function createCookedStringLiteralExpression(tree) {
-  let str = cookString(tree.value.value);
-  let loc = tree.location;
-  return new LiteralExpression(loc, new LiteralToken(STRING, str, loc));
-}
-
-function createCookedStringArray(elements) {
-  let items = [];
-  for (let i = 0; i < elements.length; i += 2) {
-    items.push(createCookedStringLiteralExpression(elements[i]));
-  }
-  maybeAddEmptyStringAtEnd(elements, items);
-  return createArrayLiteralExpression(items);
-}
-
-function replaceRaw(s) {
-  return s.replace(/\u2028|\u2029/g, function(c) {
+function toRawString(str) {
+  // Normalize line endings before using JSON for the rest.
+  str = str.replace(/\r\n?/g, '\n');
+  str = JSON.stringify(str);
+  // JSON does not handle Unicode line terminators \u2028 and \u2029.
+  return str.replace(/\u2028|\u2029/g, function(c) {
     switch (c) {
       case '\u2028':
         return '\\u2028';
@@ -121,8 +130,10 @@ function replaceRaw(s) {
  * Takes a raw string and returns a string that is suitable for the cooked
  * value. This involves removing line continuations, escaping double quotes
  * and escaping whitespace.
+ * @param {string} s
+ * @return {string}
  */
-function cookString(s) {
+function toCookedString(s) {
   let sb = ['"'];
   let i = 0, k = 1, c, c2;
   while (i < s.length) {
@@ -190,24 +201,18 @@ function cookString(s) {
   return sb.join('');
 }
 
-export class TemplateLiteralTransformer extends TempVarTransformer {
-
-  /**
-   * Override to not use functions scope for temporary variables since we
-   * only want to scope these to modules or global.
-   */
-  transformFunctionBody(tree) {
-    return ParseTreeTransformer.prototype.transformFunctionBody.call(this, tree);
-  }
-
+export class TemplateLiteralTransformer extends ParseTreeTransformer {
   transformNewExpression(tree) {
     if (tree.operand) {
       let operand = tree.operand;
       do {
         // If operand contains a tagged TemplateLiteral, parenthesize the entire
         // operand.
-        if (operand.type === TEMPLATE_LITERAL_EXPRESSION && operand.operand !== null) {
-          tree = new NewExpression(tree.location, createParenExpression(tree.operand), tree.args);
+        if (operand.type === TEMPLATE_LITERAL_EXPRESSION &&
+            operand.operand !== null) {
+          tree = new NewExpression(tree.location,
+                                   createParenExpression(tree.operand),
+                                   tree.args);
           break;
         }
       } while (operand = operand.operand);
@@ -216,17 +221,14 @@ export class TemplateLiteralTransformer extends TempVarTransformer {
   }
 
   transformTemplateLiteralExpression(tree) {
-    if (!tree.operand)
+    if (!tree.operand) {
       return this.createDefaultTemplateLiteral(tree);
+    }
 
     let operand = this.transformAny(tree.operand);
     let elements = tree.elements;
 
-    let callsiteIdObject = createCallSiteIdObject(tree);
-    let idName = this.addTempVar(callsiteIdObject);
-
-    let args = [createIdentifierExpression(idName)];
-
+    let args = [createGetTemplateObject(tree.elements)];
     for (let i = 1; i < elements.length; i += 2) {
       args.push(this.transformAny(elements[i]));
     }
@@ -257,34 +259,37 @@ export class TemplateLiteralTransformer extends TempVarTransformer {
   }
 
   transformTemplateLiteralPortion(tree) {
-    return createCookedStringLiteralExpression(tree);
+    let str = toCookedString(tree.value.value);
+    return createStringLiteralExpression(tree.location, str);
   }
 
   createDefaultTemplateLiteral(tree) {
     // convert to ("a" + b + "c" + d + "")
-    let length = tree.elements.length;
+    let elements = tree.elements;
+    let length = elements.length;
     if (length === 0) {
-      let loc = tree.location;
-      return new LiteralExpression(loc, new LiteralToken(STRING, '""', loc));
+      return createStringLiteralExpression(tree.location, '""');
     }
 
-    let firstNonEmpty = tree.elements[0].value.value === '' ? -1 : 0;
-    let binaryExpression = this.transformAny(tree.elements[0]);
+    let firstNonEmpty = elements[0].value.value === '';
+    let binaryExpression = this.transformAny(elements[0]);
     if (length === 1)
       return binaryExpression;
 
     let plusToken = createOperatorToken(PLUS);
     for (let i = 1; i < length; i++) {
-      let element = tree.elements[i];
+      let element = elements[i];
       if (element.type === TEMPLATE_LITERAL_PORTION) {
-        if (element.value.value === '')
+        if (element.value.value === '') {
           continue;
-        else if (firstNonEmpty < 0 && i === 2)
+        }
+        if (firstNonEmpty && i === 2) {
           binaryExpression = binaryExpression.right;
+        }
       }
-      let transformedTree = this.transformAny(tree.elements[i]);
+      let transformedTree = this.transformAny(elements[i]);
       binaryExpression = createBinaryExpression(binaryExpression, plusToken,
-                                              transformedTree);
+                                                transformedTree);
     }
 
     return new createParenExpression(binaryExpression);

--- a/src/runtime/template.js
+++ b/src/runtime/template.js
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** @fileoverview import all runtime modules, eg for Traceur self-build. */
+let {defineProperty, freeze} = Object;
+let {slice} = Array.prototype;
+let map = Object.create(null);
 
-import './relativeRequire.js';
-import './spread.js';
-import './destructuring.js';
-import './classes.js';
-import './async.js';
-import './generators.js';
-import './template.js';
-import './type-assertions.js';
+function getTemplateObject(raw, cooked = undefined) {
+  var key = raw.join('${}');
+  var templateObject = map[key];
+  if (templateObject) return templateObject;
+  if (!cooked) {
+    cooked = slice.call(raw);
+  }
+  return map[key] = freeze(defineProperty(cooked, 'raw', {value: freeze(raw)}));
+}
+
+$traceurRuntime.getTemplateObject = getTemplateObject;

--- a/test/feature/TemplateLiterals/TemplateObjectCaching.module.js
+++ b/test/feature/TemplateLiterals/TemplateObjectCaching.module.js
@@ -1,0 +1,17 @@
+import {cooked, raw} from './resources/template-objects.js';
+
+function assertCooked(obj) {
+  assert.equal(obj, cooked);
+  assert.notEqual(obj, raw);
+}
+
+function assertRaw(obj) {
+  assert.equal(obj, raw);
+  assert.notEqual(obj, cooked);
+}
+
+assertCooked `a${1}b`;
+assertCooked `a${2}b`;
+
+assertRaw `c${3}d\n`;
+assertRaw `c${4}d\n`;

--- a/test/feature/TemplateLiterals/resources/template-objects.js
+++ b/test/feature/TemplateLiterals/resources/template-objects.js
@@ -1,0 +1,13 @@
+export let cooked;
+export let raw;
+
+function setCooked(obj) {
+  cooked = obj;
+}
+
+function setRaw(obj) {
+  raw = obj;
+}
+
+setCooked `a${1}b`;
+setRaw `c${3}d\n`;


### PR DESCRIPTION
This updates the template object caching to match the spec.

2 identical templates should use the same template object. Previously
only the location was used to determine the hashing.

Fixes #1845