### PR TITLE
Revert "Remove unused module getopt"

### DIFF
--- a/src/node/getopt.js
+++ b/src/node/getopt.js
@@ -1,0 +1,147 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var format = require('util').format;
+
+function addAbbrev(o) {
+  var ks = [''].concat(Object.keys(o).sort()), k, kprev = '';
+  for (var i = ks.length - 1; i > 0; i--) {
+    var ka = k = ks[i], pre = 0;
+
+    // find length of common prefix, clamp to min of 1.
+    while (kprev[pre] === k[pre]) {
+      pre++;
+    }
+    pre = pre || 1;
+
+    // add all unique prefixes for k.
+    while (!o[ka = ka.slice(0, -1)] && ka.length > pre && ka > ks[i - 1]) {
+      o[ka] = o[k];
+    }
+    kprev = k;
+  }
+}
+
+function Getopt(opts) {
+  this.opt = null;
+  this.optarg = null;
+  this.optopt = null;
+  this.optdata = null;
+
+  this.optind = 2;
+  this.nextchar = 0;
+
+  this.opts_ = Object.create(null);
+  for (var i = 0; i < opts.length; i++) {
+    var opt = opts[i], data = null, m;
+    if (Array.isArray(opt)) {
+      data = opt[1] || null;
+      opt = opt[0];
+    }
+    if (!(m = opt.match(/^([\w\-]+)(:{0,2})$/))) {
+      throw new Error('invalid option initializer: ' + opt);
+    }
+    this.opts_[m[1]] = {name: m[1], arg: m[2], data: data};
+  }
+  addAbbrev(this.opts_);
+}
+
+Getopt.prototype = {
+  getopt: function(argv) {
+    var m, arg, optInf;
+    this.opt = this.optarg = this.optopt = this.optdata = null;
+    if (this.optind >= argv.length) {
+      return false;
+    }
+    arg = argv[this.optind];
+    if (!this.nextchar && /^-[^\-]/.test(arg)) {
+      this.nextchar = 1;
+    }
+    if (this.nextchar) {
+      // short opt
+      this.opt = arg[this.nextchar] || null;
+      this.optarg = arg.slice(++this.nextchar) || null;
+    } else if (m = arg.match(/^--([^=]+)(?:=(.*))?$|^--(.+)$/)) {
+      // long opt
+      this.opt = m[1] || m[3];
+      this.optarg = m[2] === undefined ? null : m[2];
+    } else {
+      // free arg
+      this.optind++;
+      this.opt = '=';
+      this.optarg = arg;
+      return true;
+    }
+
+    if (optInf = this.opts_[this.opt]) {
+      this.opt = optInf.name;
+      this.optdata = optInf.data;
+      switch (optInf.arg) {
+        case '':
+          // no arg
+          if (!this.nextchar && this.optarg) {
+            // unexpected arg
+            this.optopt = this.opt;
+            this.opt = '!';
+            break;
+          }
+          this.optarg = null;
+          break;
+        case ':':
+          // required arg
+          if (this.optarg === null) {
+            if (++this.optind >= argv.length) {
+              // missing arg
+              this.optopt = this.opt;
+              this.opt = ':';
+              break;
+            }
+            this.optarg = argv[this.optind];
+          }
+          // fall through
+        case '::':
+          // optional arg
+          this.nextchar = 0;
+          break;
+      }
+    } else {
+      // unknown opt
+      this.optopt = this.opt;
+      this.opt = '?';
+    }
+
+    this.optind += !(this.nextchar %= arg.length);
+
+    return true;
+  },
+  message: function() {
+    switch (this.opt) {
+      case ':':
+        return format('missing argument for \'%s\'.', this.optopt);
+      case '?':
+        return format('unknown option \'%s\'.', this.optopt);
+      case '!':
+        return format('\'%s\' does not take an argument.', this.optopt);
+      case '=':
+        return format('optarg \'%s\'.', this.optarg);
+      default:
+        if (this.optarg === null)
+          return format('opt \'%s\'.', this.opt);
+        else
+          return format('opt \'%s\', optarg \'%s\'.', this.opt, this.optarg);
+    }
+  }
+}
+
+exports.Getopt = Getopt;

--- a/test/unit/util/getopt.js
+++ b/test/unit/util/getopt.js
@@ -1,0 +1,42 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {suite, test, assert} from '../../unit/unitTestRunner.js';
+
+suite('getopt', function() {
+  var Getopt = require('../../../src/node/getopt.js').Getopt;
+
+  test('invalid long options', function() {
+    var g = new Getopt(['0', '1:', '2::', '0test', '1test:', '2test::']);
+    var optcur;
+    var argv = [
+      'a', 'cmd',
+      '--has.dots', '--has spaces', '--=', '--=24', '--^', '--...', '--invalid',
+      '--has.dots=42', '--has spaces=42', '--^=42', '--...=42', '--invalid=42'
+    ];
+    while (optcur = g.optind, g.getopt(argv)) {
+      assert.equal(g.opt, '?');
+      assert.equal(g.optarg, null);
+      assert.equal(g.optopt, argv[optcur].slice(2));
+      if (/42$/.test(argv[g.optind])) {
+        break;
+      }
+    }
+    while (optcur = g.optind, g.getopt(argv)) {
+      assert.equal(g.opt, '?');
+      assert.equal(g.optarg, '42');
+      assert.equal(g.optopt, argv[optcur].replace(/^--|=.*$/g, ''));
+    }
+  });
+});


### PR DESCRIPTION
This reverts commit bb7c8e3ee52245d5d401cda017f4d017263dca73.

getopt is being used by build/expand-js-template.js. We need to
replace that before this can be removed.