### PR TITLE
adds inline ability for es6 output

### DIFF
--- a/src/codegeneration/InlineES6ModuleTransformer.js
+++ b/src/codegeneration/InlineES6ModuleTransformer.js
@@ -1,0 +1,153 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {CONST} from '../syntax/TokenType.js';
+import {ModuleTransformer} from './ModuleTransformer.js';
+import {
+  createBindingIdentifier,
+  createFunctionBody,
+  createImmediatelyInvokedFunctionExpression,
+  createScopedExpression,
+  createVariableStatement,
+  createUseStrictDirective,
+  createExpressionStatement
+  } from './ParseTreeFactory.js';
+import globalThis from './globalThis.js';
+import scopeContainsThis from './scopeContainsThis.js';
+import {IMPORT_SPECIFIER_SET} from '../syntax/trees/ParseTreeType.js';
+import {AnonBlock} from '../syntax/trees/ParseTrees.js';
+
+let anonInlineModules = 0;
+
+/**
+ * Inline's ES6 module imports and outputs to a single ES6 formatted file.
+ * usage: traceur --modules=inline --outputLanguage=es6 --out ./out/some-lib.js -- ./src/root.js
+ *
+ * in:
+ *  // a.js
+ *  export function a() {
+ *    return 'A';
+ *  }
+ *
+ *  // root.js
+ *  import {a} from './a.js';
+ *  export function b() {
+ *    return a();
+ *  }
+ *
+ *  out:
+ *  // some-lib.js
+ *  const $__module__a__js = (function() {
+ *    "use strict";
+ *    function a() {
+ *      return 'A';
+ *    }
+ *    return {get a() {
+ *        return a;
+ *      }};
+ *  })();
+ *  "use strict";
+ *  const {a} = $__module__a__js;
+ *  export function b() {
+ *    return a();
+ *  }
+ */
+export class InlineES6ModuleTransformer extends ModuleTransformer {
+
+  constructor(identifierGenerator, reporter, options, metadata) {
+    super(identifierGenerator, reporter, options);
+    this.metadata_ = metadata;
+  }
+
+  /**
+   * Places "use strict" at the top of each generated module
+   * The default `var __moduleName = "../some/path/to/module.js";` is omitted
+   * @returns {Array} statements
+   */
+  moduleProlog() {
+    return [createUseStrictDirective()];
+  }
+
+  /**
+   * Wraps a module in to an IIFE closure and returns the module as a `const` unless it's a root module
+   * @param statements
+   * @returns {Array} statements
+   */
+  wrapModule(statements) {
+    let seed = this.moduleName || 'anon_' + ++anonInlineModules;
+    let idName = this.getTempVarNameForModuleName(seed);
+
+    if (this.isRootModule) {
+      // removes the return statement from the output
+      statements.pop();
+      return statements;
+    }
+
+    let body = createFunctionBody(statements);
+    let moduleExpression;
+    if (statements.some(scopeContainsThis)) {
+      moduleExpression = createScopedExpression(body, globalThis());
+    } else {
+      moduleExpression = createImmediatelyInvokedFunctionExpression(body);
+    }
+
+    return [createVariableStatement(CONST, idName, moduleExpression)];
+  }
+
+  /**
+   * Preserves the `export` statements for root modules
+   * @param tree
+   * @returns {Tree}
+   */
+  transformExportDeclaration(tree) {
+    if (this.isRootModule)
+      return tree;
+
+    this.exportVisitor_.visitAny(tree);
+    return this.transformAny(tree.declaration);
+  }
+
+  /**
+   * Transforms imports to use `const` statements
+   * @param tree
+   * @returns {VariableStatement}
+   */
+  transformImportDeclaration(tree) {
+    if (!tree.importClause ||
+      (tree.importClause.type === IMPORT_SPECIFIER_SET &&
+      tree.importClause.specifiers.length === 0)) {
+      return createExpressionStatement(this.transformAny(tree.moduleSpecifier));
+    }
+    let binding = this.transformAny(tree.importClause);
+    let initializer = this.transformAny(tree.moduleSpecifier);
+    return createVariableStatement(CONST, binding, initializer);
+  }
+
+  transformNamedExport(tree) {
+    return new AnonBlock(null, []);
+  }
+
+  /**
+   * Ensures each transformed module has a unique name
+   * @param tree
+   * @returns {BindingIdentifier}
+   */
+  transformModuleSpecifier(tree) {
+    return createBindingIdentifier(this.getTempVarNameForModuleSpecifier(tree));
+  }
+
+  get isRootModule() {
+    return this.moduleName === (this.metadata_ && this.metadata_.rootModule);
+  }
+}

--- a/src/codegeneration/PureES6Transformer.js
+++ b/src/codegeneration/PureES6Transformer.js
@@ -14,6 +14,7 @@
 
 import {AnnotationsTransformer} from './AnnotationsTransformer.js';
 import {MemberVariableTransformer} from './MemberVariableTransformer.js';
+import {InlineES6ModuleTransformer} from './InlineES6ModuleTransformer.js';
 import {MultiTransformer} from './MultiTransformer.js';
 import {TypeAssertionTransformer} from './TypeAssertionTransformer.js';
 import {TypeTransformer} from './TypeTransformer.js';
@@ -65,5 +66,9 @@ export class PureES6Transformer extends MultiTransformer {
     }
     append(AnnotationsTransformer);
     append(TypeTransformer);
+
+    if (options.modules === 'inline') {
+      append(InlineES6ModuleTransformer);
+    }
   }
 }

--- a/src/node/recursiveModuleCompile.js
+++ b/src/node/recursiveModuleCompile.js
@@ -36,6 +36,7 @@ function recursiveModuleCompileToSingleFile(outputFile, includes, options) {
   // Resolve includes before changing directory.
   var resolvedIncludes = includes.map(function(include) {
     include.name = path.resolve(include.name);
+    include.rootModule = true;
     return include;
   });
 
@@ -144,7 +145,10 @@ function recursiveModuleCompile(fileNamesAndTypes, options) {
 
     var loadOptions = {
       referrerName: referrerName,
-      metadata: {traceurOptions: optionsCopy}
+      metadata: {
+        traceurOptions: optionsCopy,
+        rootModule: input.rootModule && input.name
+      }
     };
 
     return loadFunction.call(loader, name, loadOptions).then(function() {

--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -390,6 +390,7 @@ export class InternalLoader {
       codeUnit.metadata = {
         traceurOptions: metadata.traceurOptions,
         outputName: metadata.outputName,
+        rootModule: metadata.rootModule
       };
       this.cache.set(key, codeUnit);
     }

--- a/test/unit/codegeneration/PureES6Transformer.js
+++ b/test/unit/codegeneration/PureES6Transformer.js
@@ -48,4 +48,46 @@ suite('PureES6Transformer.js', function() {
     var transformed = transformer.transform(tree);
     assert.equal(write(transformed), write(expectedTree));
   });
+
+  test('Inline', function() {
+    var options = new Options({
+      modules: 'inline'
+    });
+    var metadata = {
+      rootModule: null
+    };
+    var reporter = new ErrorReporter();
+
+    var code = [
+      `import {TestA} from ${"'./resources/test_a.js'"};`,
+      `import {TestB} from ${"'./resources/test_b.js'"};`,
+      'export class App {',
+      '  constructor() {',
+      '    this.name = "hello";',
+      '  }',
+      '}',
+      'export const test = {TestA, TestB};'
+    ].join('\n');
+
+    var expected = [
+      '"use strict";',
+      'const {TestA} = $__resources_47_test_95_a_46_js__;',
+      'const {TestB} = $__resources_47_test_95_b_46_js__;',
+      'export class App {',
+      '  constructor() {',
+      '    this.name = "hello";',
+      '  }',
+      '}',
+      'export const test = {',
+      '  TestA,',
+      '  TestB',
+      '};'
+    ].join('\n');
+
+    var tree = parse(code, reporter, options);
+    var expectedTree = parse(expected, reporter, options);
+    var transformer = new PureES6Transformer(reporter, options, metadata);
+    var transformed = transformer.transform(tree);
+    assert.equal(write(transformed), write(expectedTree));
+  });
 });

--- a/test/unit/node/generated-code-dependencies.js
+++ b/test/unit/node/generated-code-dependencies.js
@@ -342,6 +342,20 @@ suite('context test', function() {
         });
   });
 
+  test('compiled modules inline with outputLanguage=es6', function(done) {
+    tempFileName = resolve(uuid.v4() + '.js');
+    var executable = 'node ' + resolve('src/node/command.js');
+    var inputFilename = resolve('test/unit/node/resources/import-x.js');
+    exec(executable + ' --out ' + tempFileName + ' --modules=inline --outputLanguage=es6 -- ' + inputFilename,
+      function(error, stdout, stderr) {
+        assert.isNull(error);
+        executeFileWithRuntime(tempFileName).then(function() {
+          assert.equal(global.result, 'x');
+          done();
+        }).catch(done);
+      });
+  });
+
   test('working dir doesn\'t change when recursive compiling', function (done) {
     var recursiveCompile = require('../../../src/node/recursiveModuleCompile')
       .recursiveModuleCompileToSingleFile;


### PR DESCRIPTION
Adds a new transformer module called `InlineES6ModuleTransformer` for in-lining ES6 imports (as parts) with a root module.

usage: ```traceur --modules=inline --outputLanguage=es6 --out ./out/some-lib.js ./src/root.js```

transforms:

```js
 // a.js
 export function a() {
   return 'A';
 }

 // root.js
 import {a} from './a.js';
 export function b() {
   return a();
 }
```

into:

```js
 const $__module_a_js__ = (function() {
   "use strict";
   function a() {
     return 'A';
   }
   return {get a() {
       return a;
     }};
 })();
 "use strict";
 const {a} = $__module_a_js__;
 export function b() {
   return a();
 }
```