### PR TITLE
Fix issue with CommonJS and export star

### DIFF
--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -429,7 +429,7 @@
         var names = $getOwnPropertyNames(arguments[i]);
         for (var j = 0; j < names.length; j++) {
           var name = names[j];
-          if (isSymbolString(name)) continue;
+          if (name === '__esModule' || isSymbolString(name)) continue;
           (function(mod, name) {
             $defineProperty(object, name, {
               get: function() { return mod[name]; },

--- a/test/commonjs/ExportStar.js
+++ b/test/commonjs/ExportStar.js
@@ -1,0 +1,4 @@
+import {Foo} from './deps/export-star.js';
+
+assert.equal('Foo from foo.js', Foo);
+assert(typeof Bar === 'undefined');

--- a/test/commonjs/deps/export-star.js
+++ b/test/commonjs/deps/export-star.js
@@ -1,0 +1,1 @@
+export * from './foo.js';

--- a/test/unit/node/resources/golden-cjs/dep.js
+++ b/test/unit/node/resources/golden-cjs/dep.js
@@ -1,8 +1,8 @@
 "use strict";
+var q = 'q';
 Object.defineProperties(module.exports, {
   q: {get: function() {
       return q;
     }},
   __esModule: {value: true}
 });
-var q = 'q';

--- a/test/unit/node/resources/golden-cjs/file.js
+++ b/test/unit/node/resources/golden-cjs/file.js
@@ -1,10 +1,10 @@
 "use strict";
+var $__dep_46_js__;
+var q = ($__dep_46_js__ = require("./dep.js"), $__dep_46_js__ && $__dep_46_js__.__esModule && $__dep_46_js__ || {default: $__dep_46_js__}).q;
+var p = 'module';
 Object.defineProperties(module.exports, {
   p: {get: function() {
       return p;
     }},
   __esModule: {value: true}
 });
-var $__dep_46_js__;
-var q = ($__dep_46_js__ = require("./dep.js"), $__dep_46_js__ && $__dep_46_js__.__esModule && $__dep_46_js__ || {default: $__dep_46_js__}).q;
-var p = 'module';


### PR DESCRIPTION
When there is an export star then the last statement was not a return
object literal but a return call expression that adds the default
exports so we need to extract the object literals from the call
expression and get the properties from that.

Fixes #1042