### PR TITLE
Fixup repl: define System with new BrowserTraceurLoader.

### DIFF
--- a/demo/repl.html
+++ b/demo/repl.html
@@ -46,6 +46,10 @@ if (location.host === 'traceur-compiler.googlecode.com') {
 <script src="../third_party/CodeMirror-4.0.3/keymap/sublime.js"></script>
 
 <script src="../bin/traceur.js"></script>
+<script>
+window.System = new traceur.runtime.BrowserTraceurLoader();
+System.map = System.semverMap(System.version);
+</script>
 
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans+Mono|Droid+Sans">
 

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -237,6 +237,9 @@ export class TraceurLoader extends Loader {
    */
   semverMap(normalizedName) {
     var slash = normalizedName.indexOf('/');
+    if (slash < 0) {
+      slash = normalizedName.length;
+    }
     var version = normalizedName.slice(0, slash);
     var at = version.indexOf('@');
     if (at !== -1) {

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -92,12 +92,14 @@ export let codegeneration = {
 
 import {Loader} from './runtime/Loader.js';
 import {LoaderCompiler} from './runtime/LoaderCompiler.js';
+import {BrowserTraceurLoader} from './runtime/TraceurLoader.js';
 import {NodeLoaderCompiler} from './node/NodeLoaderCompiler.js';
 import {InlineLoaderCompiler} from './runtime/InlineLoaderCompiler.js';
 import {NodeTraceurLoader} from './runtime/TraceurLoader.js';
 import {TraceurLoader} from './runtime/TraceurLoader.js';
 
 export let runtime = {
+  BrowserTraceurLoader,
   InlineLoaderCompiler,
   Loader,
   LoaderCompiler,

--- a/test/unit/browser/System.js
+++ b/test/unit/browser/System.js
@@ -135,6 +135,8 @@ suite('System.js', function() {
     var remapped = System.normalize('traceur@0.0/src/runtime/System.js');
     var versionSegment = remapped.split('/')[0];
     assert.equal(version, versionSegment);
+    var alsoByVersion = System.semverMap('traceur@0.0.13');
+    assertEqual(alsoByVersion['traceur'], System.map['traceur']);
   });
 
   test('System.applyMap', function() {


### PR DESCRIPTION
To load the `repl-module.js`, we use dynamic loading, `System.import()`.
The `bin/traceur.js` image contains a `System` only useful for bootloading. 
After loading the image on any platform we need to create a loader for 
that platform out of the image modules. 

To do this for the repl,  we need a reference to `BrowserTraceurLoader`. 
This reference has to be via a global. We can use a global `traceur` or
we can use `System.get(<secret path>')`. I picked the first one here.

Extend System.semverMap to compute map from just the version string