### PR TITLE
Cleanup code gen for classes.

### DIFF
--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AlphaRenamer} from './AlphaRenamer.js';
 import {
   CONSTRUCTOR
 } from '../syntax/PredefinedName.js';
 import {
   AnonBlock,
+  ClassExpression,
   ExportDeclaration,
+  FunctionDeclaration,
   FunctionExpression,
   GetAccessor,
   PropertyMethodAssignment,
@@ -38,6 +39,8 @@ import {
 import {SuperTransformer} from './SuperTransformer.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
 import {
+  CONST,
+  LET,
   VAR,
   STRING
 } from '../syntax/TokenType.js';
@@ -57,8 +60,7 @@ import {
 import {hasUseStrict} from '../semantics/util.js';
 import {
   parseExpression,
-  parseStatement,
-  parseStatements
+  parseStatement
 } from './PlaceholderParser.js';
 import {propName} from '../staticsemantics/PropName.js';
 import {prependStatements} from './PrependStatements.js';
@@ -137,6 +139,16 @@ function classMethodDebugName(className, methodName, isStatic) {
   return createBindingIdentifier('$__' + className + '_prototype_' + methodName);
 }
 
+function functionExpressionToDeclaration(tree, name) {
+  if (tree.name === null) {
+    name = createBindingIdentifier(name);
+  } else {
+    name = tree.name;
+  }
+  return new FunctionDeclaration(tree.location, name, tree.functionKind,
+      tree.parameterList, tree.typeAnnotation, tree.annotations, tree.body);
+}
+
 export class ClassTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
@@ -148,7 +160,7 @@ export class ClassTransformer extends TempVarTransformer {
     this.strictCount_ = 0;
     this.state_ = null;
     this.reporter_ = reporter;
-    this.showDebugNames_ = options.debugNames;
+    this.options_ = options;
   }
 
   // Override to handle AnonBlock
@@ -193,7 +205,34 @@ export class ClassTransformer extends TempVarTransformer {
     return MakeStrictTransformer.transformTree(tree);
   }
 
-  transformClassElements_(tree, internalName, originalName) {
+  /**
+   * Transforms a single class declaration
+   *
+   * @param {ClassDeclaration} tree
+   * @return {ParseTree}
+   */
+  transformClassDeclaration(tree) {
+    // `class C {}` is equivalent to `let C = class C {};`
+    // Convert to class expression and transform that instead.
+    let classExpression = new ClassExpression(tree.location, tree.name,
+        tree.superClass, tree.elements, tree.annotations, tree.typeParameters);
+    let transformed = this.transformClassExpression(classExpression);
+    let useLet = !this.options_.transformOptions.blockBinding &&
+                 this.options_.parseOptions.blockBinding;
+    return createVariableStatement(useLet ? LET : VAR, tree.name, transformed);
+  }
+
+  transformClassExpression(tree) {
+    this.pushTempScope();
+
+    let name;
+    if (tree.name)
+      name = tree.name.identifierToken;
+    else
+      name = createIdentifierToken(this.getTempIdentifier());
+
+    let internalName = id(`${name}`);
+
     let oldState = this.state_;
     this.state_ = {hasSuper: false};
     let superClass = this.transformAny(tree.superClass);
@@ -228,7 +267,7 @@ export class ClassTransformer extends TempVarTransformer {
             constructor = tree;
           } else {
             let transformed = this.transformPropertyMethodAssignment_(
-                tree, homeObject, internalName, originalName);
+                tree, homeObject, internalName, name);
             elements.push(transformed);
           }
           break;
@@ -267,79 +306,7 @@ export class ClassTransformer extends TempVarTransformer {
     let state = this.state_;
     this.state_ = oldState;
 
-    return {
-      func,
-      superClass,
-      object,
-      staticObject,
-      hasSuper: state.hasSuper,
-      initStaticVars,
-    };
-  }
-
-  /**
-   * Transforms a single class declaration
-   *
-   * @param {ClassDeclaration} tree
-   * @return {ParseTree}
-   */
-  transformClassDeclaration(tree) {
-    let name = tree.name.identifierToken;
-    let internalName = id(`$${name}`);
-
-    let renamed = AlphaRenamer.rename(tree, name.value, internalName.identifierToken.value);
-    let referencesClassName = renamed !== tree
-    tree = renamed;
-
-    let {
-      func,
-      hasSuper,
-      object,
-      staticObject,
-      superClass,
-      initStaticVars,
-    } = this.transformClassElements_(tree, internalName, name);
-
-    // TODO(arv): Use let.
-    let statements = parseStatements `var ${name} = ${func}`;
-
-    staticObject = appendStaticInitializers(staticObject, initStaticVars);
-
-    let expr = classCall(name, object, staticObject, superClass);
-
-    if (hasSuper || referencesClassName) {
-      // The internal name is so that super lookups continue to work even in
-      // case someone overrides the class binding name.
-      // Also, ClassExpression binds the class name in the class body.
-      // TODO(arv): Use const for the internal name.
-      statements.push(parseStatement `var ${internalName} = ${name}`);
-    }
-    statements.push(createExpressionStatement(expr));
-
-    let anonBlock = new AnonBlock(null, statements);
-    return this.makeStrict_(anonBlock);
-  }
-
-  transformClassExpression(tree) {
-    this.pushTempScope();
-
-    let name;
-    if (tree.name)
-      name = tree.name.identifierToken;
-    else
-      name = createIdentifierToken(this.getTempIdentifier());
-
-    let internalName = id(`${name}`);
-
-    let {
-      func,
-      hasSuper,
-      object,
-      staticObject,
-      superClass,
-      initStaticVars,
-    } = this.transformClassElements_(tree, internalName, name);
-
+    let hasSuper = state.hasSuper;
     let expression;
 
     staticObject = appendStaticInitializers(staticObject, initStaticVars);
@@ -347,16 +314,25 @@ export class ClassTransformer extends TempVarTransformer {
     if (hasSuper || tree.name) {
       // We need a binding name that can be referenced in the super calls and
       // we hide this name in an IIFE.
-      // TODO(arv): Use const.
+
+      let functionStatement;
+      if (tree.name &&
+          !this.options_.transformOptions.blockBinding &&
+          this.options_.parseOptions.blockBinding) {
+        functionStatement = createVariableStatement(CONST, tree.name, func);
+      } else {
+        functionStatement = functionExpressionToDeclaration(func, name);
+      }
+
       if (superClass) {
         expression = parseExpression `function($__super) {
-          var ${internalName} = ${func};
+          ${functionStatement};
           return ($traceurRuntime.createClass)(${internalName}, ${object},
                                                ${staticObject}, $__super);
         }(${superClass})`;
       } else {
         expression = parseExpression `function() {
-          var ${internalName} = ${func};
+          ${functionStatement};
           return ($traceurRuntime.createClass)(${internalName}, ${object},
                                                ${staticObject});
         }()`;
@@ -375,7 +351,7 @@ export class ClassTransformer extends TempVarTransformer {
     let body = this.transformSuperInFunctionBody_(
         tree.body, homeObject, internalName);
 
-    if (this.showDebugNames_) {
+    if (this.options_.showDebugNames_) {
       tree.debugName = classMethodDebugName(originalName, methodNameFromTree(tree.name), isStatic);
     }
 

--- a/src/codegeneration/PlaceholderParser.js
+++ b/src/codegeneration/PlaceholderParser.js
@@ -260,7 +260,7 @@ export class PlaceholderTransformer extends ParseTreeTransformer {
           this.transformIdentifierExpression(tree.expression);
       if (transformedExpression === tree.expression)
         return tree;
-      if (transformedExpression.isStatement())
+      if (transformedExpression.isStatementListItem())
         return transformedExpression;
       return createExpressionStatement(transformedExpression);
     }


### PR DESCRIPTION
By first transforming a ClassDeclaration

```js
class C {}
```

to a let and ClassExpression

```js
let C = class C {};
```

We can simplify the code slightly.

Now we always end up using an IIFE which is better because using
a FunctionDeclaration has the wrong semantics.