### PR TITLE
Support extended import syntax

### DIFF
--- a/src/codegeneration/ImportSimplifyingTransformer.js
+++ b/src/codegeneration/ImportSimplifyingTransformer.js
@@ -1,0 +1,126 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  AnonBlock,
+  ImportDeclaration,
+  ImportSpecifier,
+  ImportSpecifierSet,
+  Module,
+} from '../syntax/trees/ParseTrees.js';
+import {ParseTreeTransformer} from './ParseTreeTransformer.js';
+import {
+  ANON_BLOCK,
+  IMPORT_CLAUSE_PAIR,
+  IMPORT_DECLARATION,
+  IMPORT_SPECIFIER_SET,
+  IMPORTED_BINDING,
+  NAME_SPACE_IMPORT,
+} from '../syntax/trees/ParseTreeType.js';
+import {createIdentifierToken} from './ParseTreeFactory.js';
+
+/**
+ * Normalizes import declarations to a simpler form. This is so that the
+ * ModuleTransformer only has to handle the basic import declarations.
+ */
+export class ImportSimplifyingTransformer extends ParseTreeTransformer {
+  transformModule(tree) {
+    let statements = [];
+    for (let i = 0; i < tree.scriptItemList.length; i++) {
+      let item = tree.scriptItemList[i];
+      switch (item.type) {
+        case IMPORT_DECLARATION: {
+          let transformed = this.transformAny(item);
+          if (transformed.type === ANON_BLOCK) {
+            statements.push(...transformed.statements);
+          } else {
+            statements.push(transformed);
+          }
+          break;
+        }
+
+        default:
+          statements.push(item);
+      }
+    }
+    return new Module(tree.location, statements, tree.moduleName);
+  }
+
+  transformImportDeclaration(tree) {
+    let importClause = tree.importClause;
+    if (importClause === null) {
+      // import 'mod';
+      // =>
+      // import {} from 'mod';
+      let set = new ImportSpecifierSet(null, []);
+      return new ImportDeclaration(tree.location, set, tree.moduleSpecifier);
+    }
+
+    if (importClause.type === NAME_SPACE_IMPORT) {
+      return tree;
+    }
+
+    if (importClause.type === IMPORTED_BINDING) {
+      // import x from 'mod';
+      // =>
+      // import {default as x} from 'mod';
+      let specifier = this.transformAny(importClause);
+      let set = new ImportSpecifierSet(null, [specifier]);
+      return new ImportDeclaration(tree.location, set, tree.moduleSpecifier);
+    }
+
+    if (importClause.type === IMPORT_CLAUSE_PAIR) {
+      let {first, second} = importClause;
+      if (second.type === IMPORT_SPECIFIER_SET) {
+        // import x, {a as b} from 'mod';
+        // =>
+        // import {default as x, a as b} from 'mod';
+        let defaultSpecifier = this.transformAny(first);
+        let specifiers = [
+          defaultSpecifier,
+          ...second.specifiers
+        ];
+        let set = new ImportSpecifierSet(first.location, specifiers);
+        return new ImportDeclaration(tree.location, set, tree.moduleSpecifier);
+      }
+
+      // import x, * as m from 'mod';
+      // =>
+      // import {default as x} from 'mod';
+      // import * as m from 'mod';
+      let firstImport =
+          new ImportDeclaration(tree.location, first, tree.moduleSpecifier);
+      // Transform the default import again.
+      firstImport = this.transformAny(firstImport);
+      let secondImport =
+          new ImportDeclaration(tree.location, second, tree.moduleSpecifier);
+      return new AnonBlock(null, [firstImport, secondImport]);
+    }
+
+    return super.transformImportDeclaration(tree);
+  }
+
+  transformImportSpecifier(tree) {
+    // Keep shorthands since we want clean destructuring output.
+    return tree;
+  }
+
+  transformImportedBinding(tree) {
+    // x
+    // =>
+    // default as x
+    let name = createIdentifierToken('default');
+    return new ImportSpecifier(tree.location, tree, name);
+  }
+}

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -894,6 +894,16 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   }
 
   /**
+   * @param {ImportClausePair} tree
+   */
+  visitImportClausePair(tree) {
+    this.visitAny(tree.first);
+    this.write_(COMMA);
+    this.writeSpace_();
+    this.visitAny(tree.second);
+  }
+
+  /**
    * @param {ImportDeclaration} tree
    */
   visitImportDeclaration(tree) {

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -80,8 +80,9 @@ import {
   FUNCTION_DECLARATION,
   GET_ACCESSOR,
   IDENTIFIER_EXPRESSION,
-  IMPORTED_BINDING,
+  IMPORT_CLAUSE_PAIR,
   IMPORT_SPECIFIER_SET,
+  IMPORTED_BINDING,
   LITERAL_PROPERTY_NAME,
   MODULE_SPECIFIER,
   NAMED_EXPORT,
@@ -695,7 +696,8 @@ export class ParseTreeValidator extends ParseTreeVisitor {
     if (tree.importClause !== null) {
       this.check_(tree.importClause.type === NAME_SPACE_IMPORT ||
                   tree.importClause.type === IMPORTED_BINDING ||
-                  tree.importClause.type === IMPORT_SPECIFIER_SET,
+                  tree.importClause.type === IMPORT_SPECIFIER_SET ||
+                  tree.importClause.type === IMPORT_CLAUSE_PAIR,
                   tree.importClause,
                   'Invalid import clause');
     }
@@ -710,6 +712,14 @@ export class ParseTreeValidator extends ParseTreeVisitor {
   visitImportedBinding(tree) {
     this.checkType_(BINDING_IDENTIFIER, tree.binding,
                     'binding identifier expected');
+  }
+
+  visitImportClausePair(tree) {
+    this.checkType_(IMPORTED_BINDING, tree.first, 'ImportedBinding expected');
+    this.check_(tree.second.type === NAME_SPACE_IMPORT ||
+                tree.second.type === IMPORT_SPECIFIER_SET,
+                tree.second,
+                'Invalid import clause');
   }
 
   /**

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -654,6 +654,17 @@
       "ParseTree"
     ]
   },
+  "ImportClausePair": {
+    "location": [
+      "SourceRange"
+    ],
+    "first": [
+      "ParseTree"
+    ],
+    "second": [
+      "ParseTree"
+    ]
+  },
   "ImportDeclaration": {
     "location": [
       "SourceRange"

--- a/test/feature/Modules/ImportPair.module.js
+++ b/test/feature/Modules/ImportPair.module.js
@@ -1,0 +1,10 @@
+import def, * as m from './resources/default-and-named.js';
+import def2, {x} from './resources/default-and-named.js';
+import def3, {x as y} from './resources/default-and-named.js';
+
+assert.equal(def, 'default');
+assert.equal(def2, 'default');
+assert.equal(def3, 'default');
+
+assert.equal(x, 'x');
+assert.equal(y, 'x');

--- a/test/feature/Modules/resources/default-and-named.js
+++ b/test/feature/Modules/resources/default-and-named.js
@@ -1,0 +1,2 @@
+export default 'default';
+export var x = 'x';

--- a/test/unit/codegeneration/ImportSimplifyingTransformer.js
+++ b/test/unit/codegeneration/ImportSimplifyingTransformer.js
@@ -1,0 +1,65 @@
+// Copyright 2014 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {suite, test, assert} from '../../unit/unitTestRunner.js';
+
+import {ImportSimplifyingTransformer} from '../../../src/codegeneration/ImportSimplifyingTransformer.js';
+import {Parser} from '../../../src/syntax/Parser.js';
+import {SourceFile} from '../../../src/syntax/SourceFile.js';
+import {write} from '../../../src/outputgeneration/TreeWriter.js';
+
+suite('ImportSimplifyingTransformer.js', function() {
+
+  function parseModule(content) {
+    var file = new SourceFile('test', content);
+    var parser = new Parser(file);
+    return parser.parseModule();
+  }
+
+  function testNormalize(name, content, expected) {
+    test(name, function() {
+      var tree = parseModule(content);
+      var transformer = new ImportSimplifyingTransformer(null);
+      var transformed = transformer.transformAny(tree);
+      var expectedTree = parseModule(expected);
+      assert.equal(write(expectedTree), write(transformed));
+    });
+  }
+
+  testNormalize('import default',
+    'import a from "mod";',
+    'import {default as a} from "mod";');
+  testNormalize('import spec',
+    'import {a as b} from "mod";',
+    'import {a as b} from "mod";');
+  testNormalize('import spec with shorthand',
+    'import {a as b, c} from "mod";',
+    'import {a as b, c} from "mod";');
+  testNormalize('import namespace',
+    'import * as m from "mod";',
+    'import * as m from "mod";');
+  testNormalize('import empty',
+    'import "mod";',
+    'import {} from "mod";');
+  testNormalize('import pair',
+    'import a, {b as c} from "mod";',
+    'import {default as a, b as c} from "mod";');
+  testNormalize('import pair',
+    'import a, {} from "mod";',
+    'import {default as a} from "mod";');
+  testNormalize('import pair with name space',
+    'import a, * as b from "mod";',
+    'import {default as a} from "mod";' +
+     'import * as b from "mod";');
+});


### PR DESCRIPTION
This adds support for a import clause pair:

  import def, {a, b} from 'mod';
  import def2, * as m from 'mod';

The AST for this is using a ImportClausePair. To simplify the
transformer the above is first transformed into:

  import {default as def, a, b} from 'mod';
  import {default as def2} from 'mod';
  import * as m from 'mod';

then the existing transformer just works.

This preprocessing is done in the ModuleNormalizeTransformer.

Fixes #1509