### PR TITLE
Finalize support for extended export from

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -37,6 +37,7 @@ export const optionsV01 = enumerableOnlyObject({
   defaultParameters: true,
   destructuring: true,
   exponentiation: false,
+  exportFromExtended: false,
   forOf: true,
   forOn: false,
   freeVariableChecker: false,
@@ -147,6 +148,7 @@ addFeatureOption('arrayComprehension', EXPERIMENTAL); // 11.4.1.2
 addFeatureOption('asyncFunctions', EXPERIMENTAL);
 addFeatureOption('asyncGenerators', EXPERIMENTAL);
 addFeatureOption('exponentiation', EXPERIMENTAL);
+addFeatureOption('exportFromExtended', EXPERIMENTAL);
 addFeatureOption('forOn', EXPERIMENTAL);
 addFeatureOption('generatorComprehension', EXPERIMENTAL);
 addFeatureOption('memberVariables', EXPERIMENTAL);

--- a/test/feature/Modules/ExportForwardDefault.module.js
+++ b/test/feature/Modules/ExportForwardDefault.module.js
@@ -1,4 +1,7 @@
-import {a, b} from './resources/export-forward-default-as-a.js';
+// Options: --export-from-extended
+
+import {a, b, default as C} from './resources/export-forward-default-as.js';
 
 assert.equal(42, a);
 assert.equal(123, b());
+assert.equal('m', new C().m());

--- a/test/feature/Modules/resources/export-forward-default-as.js
+++ b/test/feature/Modules/resources/export-forward-default-as.js
@@ -1,2 +1,3 @@
 export a from './default.js';
 export b from './default-function.js';
+export default from './default-class.js';

--- a/test/instantiate/export-forward-default.js
+++ b/test/instantiate/export-forward-default.js
@@ -1,1 +1,3 @@
+// Options: --export-from-extended
+
 export a from './export-default.js';


### PR DESCRIPTION
This adds the lookahead on from so that

  export default from 'mod'

works as expected.

This is now guarded by the option export-from-extended.

Fixes #1841