### PR TITLE
Move the sourceMaps=memory feature out of System module.

### DIFF
--- a/src/node/NodeLoaderCompiler.js
+++ b/src/node/NodeLoaderCompiler.js
@@ -53,16 +53,13 @@ export class NodeLoaderCompiler extends LoaderCompiler {
       return;
     }
     require('source-map-support').install({
-      retrieveSourceMap: function(filename) {
+      retrieveSourceMap: function(url) {
         try {
-          var map = System.getSourceMap(filename);
+          let map = System.getSourceMap(url);
           if (map) {
-            return {
-              url: filename,
-              map: map
-            };
+            return {url, map};
           }
-        } catch(ex) {
+        } catch (ex) {
           // Failure in this function results in no error output.
           console.error('retrieveSourceMap FAILED ', ex);
         }

--- a/src/node/NodeLoaderCompiler.js
+++ b/src/node/NodeLoaderCompiler.js
@@ -15,6 +15,11 @@
 import {LoaderCompiler} from '../runtime/LoaderCompiler.js';
 
 export class NodeLoaderCompiler extends LoaderCompiler {
+  constructor() {
+    super();
+    this.sourceMapsInMemory_ = false;
+  }
+
   evaluateCodeUnit(codeUnit) {
     // We cannot move these to file scope since this file is included in
     // bin/traceur.js which needs to work in a browser.
@@ -26,6 +31,9 @@ export class NodeLoaderCompiler extends LoaderCompiler {
     // Node eval does not support //# sourceURL yet.
     // In node we use a low level evaluator so that the
     // sourcemap=memory mechanism can help us debug.
+    if (codeUnit.metadata.traceurOptions.sourceMaps === 'memory') {
+      this.enableMemorySourceMaps_();
+    }
 
     // Node 0.10 uses a string as the filename.
     // Node 0.12 >= uses an option object
@@ -38,5 +46,28 @@ export class NodeLoaderCompiler extends LoaderCompiler {
     let result = runInThisContext(content, options);
     codeUnit.metadata.transformedTree = null;
     return result;
+  }
+
+  enableMemorySourceMaps_() {
+    if (this.sourceMapsInMemory_) {
+      return;
+    }
+    require('source-map-support').install({
+      retrieveSourceMap: function(filename) {
+        try {
+          var map = System.getSourceMap(filename);
+          if (map) {
+            return {
+              url: filename,
+              map: map
+            };
+          }
+        } catch(ex) {
+          // Failure in this function results in no error output.
+          console.error('retrieveSourceMap FAILED ', ex);
+        }
+      }
+    });
+    this.sourceMapsInMemory_ = true;
   }
 }

--- a/src/node/System.js
+++ b/src/node/System.js
@@ -21,23 +21,6 @@ var System = new traceur.runtime.NodeTraceurLoader();
 
 var traceurMap;
 
-require('source-map-support').install({
-  retrieveSourceMap: function(filename) {
-    try {
-      var map = System.getSourceMap(filename);
-      if (map) {
-        return {
-          url: filename,
-          map: map
-        };
-      }
-    } catch(ex) {
-      // Failure in this function results in no error output.
-      console.error('retrieveSourceMap FAILED ', ex);
-    }
-  }
-});
-
 Reflect.global.System = System;
 System.map = System.semverMap(System.version);
 

--- a/src/node/System.js
+++ b/src/node/System.js
@@ -23,18 +23,17 @@ var traceurMap;
 
 require('source-map-support').install({
   retrieveSourceMap: function(filename) {
-    var map = System.getSourceMap(filename);
-    if (!map && filename === traceur.selfCompiledFilename) {
-      if (!traceurMap) {
-        traceurMap = fs.readFileSync(traceur.selfCompiledFilename + '.map', 'utf8');
+    try {
+      var map = System.getSourceMap(filename);
+      if (map) {
+        return {
+          url: filename,
+          map: map
+        };
       }
-      map = traceurMap;
-    }
-    if (map) {
-      return {
-        url: filename,
-        map: map
-      };
+    } catch(ex) {
+      // Failure in this function results in no error output.
+      console.error('retrieveSourceMap FAILED ', ex);
     }
   }
 });

--- a/src/runtime/NodeTraceurLoader.js
+++ b/src/runtime/NodeTraceurLoader.js
@@ -1,0 +1,40 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+import {TraceurLoader} from './TraceurLoader.js';
+import {NodeLoaderCompiler} from '../node/NodeLoaderCompiler.js';
+
+let fs = require('fs');
+let path = require('path');
+let fileloader = require('../node/nodeLoader.js');
+
+export class NodeTraceurLoader extends TraceurLoader {
+  constructor() {
+    let url = (path.resolve('./') + '/').replace(/\\/g, '/');
+    super(fileloader, url, new NodeLoaderCompiler());
+    this.traceurMap_ = null;  // optional cache for sourcemap
+  }
+
+  getSourceMap(filename) {
+    var map = super.getSourceMap(filename);
+    if (!map && filename.replace(/\\/g, '/').endsWith('/bin/traceur.js')) {
+      if (!this.traceurMap_) {
+        this.traceurMap_ =
+            fs.readFileSync(filename + '.map', 'utf8');
+      }
+      map = this.traceurMap_;
+    }
+    return map;
+  }
+}

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -15,7 +15,6 @@
 import {isAbsolute, resolveUrl} from '../util/url.js';
 import {Loader} from './Loader.js';
 import {LoaderCompiler} from './LoaderCompiler.js';
-import {NodeLoaderCompiler} from '../node/NodeLoaderCompiler.js';
 import {systemjs} from './system-map.js';
 import {webLoader} from './webLoader.js';
 
@@ -310,14 +309,5 @@ export class TraceurLoader extends Loader {
 export class BrowserTraceurLoader extends TraceurLoader {
   constructor() {
     super(webLoader, window.location.href, new LoaderCompiler());
-  }
-}
-
-export class NodeTraceurLoader extends TraceurLoader {
-  constructor() {
-    let path = require('path');
-    let fileloader = require('../node/nodeLoader.js');
-    let url = (path.resolve('./') + '/').replace(/\\/g, '/');
-    super(fileloader, url, new NodeLoaderCompiler());
   }
 }

--- a/src/traceur.js
+++ b/src/traceur.js
@@ -95,7 +95,7 @@ import {LoaderCompiler} from './runtime/LoaderCompiler.js';
 import {BrowserTraceurLoader} from './runtime/TraceurLoader.js';
 import {NodeLoaderCompiler} from './node/NodeLoaderCompiler.js';
 import {InlineLoaderCompiler} from './runtime/InlineLoaderCompiler.js';
-import {NodeTraceurLoader} from './runtime/TraceurLoader.js';
+import {NodeTraceurLoader} from './runtime/NodeTraceurLoader.js';
 import {TraceurLoader} from './runtime/TraceurLoader.js';
 
 export let runtime = {

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -230,6 +230,10 @@ suite('Loader.js', function() {
   });
 
   test('LoaderImport.Fail.deperror', function(done) {
+    // This tests in-memory source maps which cause V8 to take an
+    // extraordinaril long time to produce e.stack values.  We have to
+    // give mocha more time on the Travis machines.
+    this.timeout(4000);
     var reporter = new MutedErrorReporter();
     var metadata = {traceurOptions: {sourceMaps: 'memory'}};
     getTestLoader(reporter).import('test/unit/runtime/loads/main.js', {metadata: metadata}).then(


### PR DESCRIPTION
Read the map in NodeTraceurLoader if bin/traceur.js is requested.
Enable the memory map in NodeLoaderCompiler, dynamically.
Move NodeTraceurLoader to its own file.