### PR TITLE
Use dynamic require in NodeTraceurLoader.

### DIFF
--- a/src/runtime/NodeTraceurLoader.js
+++ b/src/runtime/NodeTraceurLoader.js
@@ -15,21 +15,21 @@
 import {TraceurLoader} from './TraceurLoader.js';
 import {NodeLoaderCompiler} from '../node/NodeLoaderCompiler.js';
 
-let fs = require('fs');
-let path = require('path');
-let fileloader = require('../node/nodeLoader.js');
-
 export class NodeTraceurLoader extends TraceurLoader {
   constructor() {
+    let path = require('path');
+    let fileloader = require('../node/nodeLoader.js');
+
     let url = (path.resolve('./') + '/').replace(/\\/g, '/');
     super(fileloader, url, new NodeLoaderCompiler());
     this.traceurMap_ = null;  // optional cache for sourcemap
   }
 
   getSourceMap(filename) {
-    var map = super.getSourceMap(filename);
+    let map = super.getSourceMap(filename);
     if (!map && filename.replace(/\\/g, '/').endsWith('/bin/traceur.js')) {
       if (!this.traceurMap_) {
+        let fs = require('fs');
         this.traceurMap_ =
             fs.readFileSync(filename + '.map', 'utf8');
       }


### PR DESCRIPTION
This file is used to boot the node runtime so it needs to be compoiled into traceur object.
Since we have only one traceur object for both node and browser, module-file level
operations must not include require() calls.