### PR TITLE
[strong] Disallow assigning to undefined and binding

### DIFF
--- a/src/staticsemantics/StrictParams.js
+++ b/src/staticsemantics/StrictParams.js
@@ -39,7 +39,7 @@ export class StrictParams extends ParseTreeVisitor {
   }
 
   static visit(tree, errorReporter) {
-    new StrictParams(errorReporter).visitAny(tree);
+    new this(errorReporter).visitAny(tree);
   }
 }
 

--- a/src/staticsemantics/StrongParams.js
+++ b/src/staticsemantics/StrongParams.js
@@ -1,0 +1,34 @@
+// Copyright 2013 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strong';
+
+import {StrictParams} from './StrictParams.js';
+import {UNDEFINED} from '../syntax/PredefinedName.js';
+
+/**
+ * Strong functions may not have a binding named undefined
+ */
+export class StrongParams extends StrictParams {
+  visitBindingIdentifier(tree) {
+    if (tree.identifierToken.value === UNDEFINED) {
+      this.errorReporter.reportError(
+          tree.identifierToken.location.start,
+          'In strong mode, binding or assigning to undefined is deprecated');
+    } else {
+      super.visitBindingIdentifier(tree);
+    }
+  }
+}
+

--- a/test/feature/StrongMode/AssignToUndefined.js
+++ b/test/feature/StrongMode/AssignToUndefined.js
@@ -1,0 +1,20 @@
+// Options: --strong-mode
+// Error: :13:1: In strong mode, binding or assigning to undefined is deprecated
+// Error: :14:1: In strong mode, binding or assigning to undefined is deprecated
+// Error: :15:2: In strong mode, binding or assigning to undefined is deprecated
+// Error: :16:5: In strong mode, binding or assigning to undefined is deprecated
+// Error: :17:6: In strong mode, binding or assigning to undefined is deprecated
+// Error: :18:3: In strong mode, binding or assigning to undefined is deprecated
+// Error: :19:3: In strong mode, binding or assigning to undefined is deprecated
+// Error: :20:1: In strong mode, binding or assigning to undefined is deprecated
+
+'use strong';
+
+undefined = 1;
+undefined += 2;
+[undefined] = [3];
+[...undefined] = [3];
+({x: undefined} = {x: 4});
+({undefined} = {undefined: 5});
+--undefined;
+undefined++;

--- a/test/feature/StrongMode/BindingNameUndefined.js
+++ b/test/feature/StrongMode/BindingNameUndefined.js
@@ -1,0 +1,32 @@
+// Options: --strong-mode
+// Error: :16:5: In strong mode, binding or assigning to undefined is deprecated
+// Error: :17:7: In strong mode, binding or assigning to undefined is deprecated
+// Error: :19:12: In strong mode, binding or assigning to undefined is deprecated
+// Error: :20:10: In strong mode, binding or assigning to undefined is deprecated
+// Error: :21:7: In strong mode, binding or assigning to undefined is deprecated
+// Error: :22:11: In strong mode, binding or assigning to undefined is deprecated
+// Error: :24:1: In strong mode, binding or assigning to undefined is deprecated
+// Error: :25:2: In strong mode, binding or assigning to undefined is deprecated
+// Error: :26:3: In strong mode, binding or assigning to undefined is deprecated
+// Error: :27:6: In strong mode, binding or assigning to undefined is deprecated
+// Error: :28:3: In strong mode, binding or assigning to undefined is deprecated
+
+'use strong';
+
+let undefined;
+const undefined = 42;
+
+function f(undefined) {}
+function undefined() {}
+class undefined {}
+(function undefined() {});
+
+undefined => 42;
+(undefined) => 42;
+([undefined]) => 42;
+([...undefined]) => 42;
+({undefined}) => 42;
+
+let {undefined: x} = {undefined: 2};
+const {undefined: x} = {undefined: 2};
+

--- a/test/feature/StrongMode/StrictParamNameUndefined.js
+++ b/test/feature/StrongMode/StrictParamNameUndefined.js
@@ -1,0 +1,21 @@
+// Options: --strong-mode
+// Error: :12:12: In strong mode, binding or assigning to undefined is deprecated
+// Error: :13:13: In strong mode, binding or assigning to undefined is deprecated
+// Error: :14:16: In strong mode, binding or assigning to undefined is deprecated
+// Error: :15:13: In strong mode, binding or assigning to undefined is deprecated
+// Error: :17:1: In strong mode, binding or assigning to undefined is deprecated
+// Error: :18:2: In strong mode, binding or assigning to undefined is deprecated
+// Error: :19:3: In strong mode, binding or assigning to undefined is deprecated
+// Error: :20:6: In strong mode, binding or assigning to undefined is deprecated
+// Error: :21:3: In strong mode, binding or assigning to undefined is deprecated
+
+function f(undefined) { 'use strong'; }
+function f([undefined]) { 'use strong'; }
+function f([...undefined]) { 'use strong'; }
+function f({undefined}) { 'use strong'; }
+
+undefined => { 'use strong'; };
+(undefined) => { 'use strong'; };
+([undefined]) => { 'use strong'; };
+([...undefined]) => { 'use strong'; };
+({undefined}) => { 'use strong'; };


### PR DESCRIPTION
In strong mode it is not allowed to create a new binding with the
name undefined. It is also not allowed to assign to the existing
undefined.