### PR TITLE
Strict mode arrow functions must validate the params

### DIFF
--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -55,7 +55,8 @@ import {
   STAR_STAR_EQUAL,
   STRING,
   UNSIGNED_RIGHT_SHIFT,
-  UNSIGNED_RIGHT_SHIFT_EQUAL
+  UNSIGNED_RIGHT_SHIFT_EQUAL,
+  YIELD
 } from './TokenType.js';
 import {
   ARRAY_PATTERN,
@@ -894,8 +895,11 @@ export class ParseTreeValidator extends ParseTreeVisitor {
    * @param {PropertyNameShorthand} tree
    */
   visitPropertyNameShorthand(tree) {
-    this.check_(tree.name.type === IDENTIFIER, tree,
-        'identifier token expected');
+    this.check_(tree.name.type === IDENTIFIER ||
+                tree.name.type === YIELD ||
+                tree.name.isStrictKeyword(),
+                tree,
+                'identifier token expected');
   }
 
   /**

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -1254,7 +1254,7 @@ export class Parser {
 
     let result = this.parseStatementList_(!strictMode);
 
-    if (!strictMode && this.strictMode_ && params)
+    if (!strictMode && this.strictMode_)
       StrictParams.visit(params, this.errorReporter_);
 
     this.strictMode_ = strictMode;
@@ -3265,7 +3265,7 @@ export class Parser {
     }
 
     this.eat_(ARROW);
-    let body = this.parseConciseBody_();
+    let body = this.parseConciseBody_(formals);
     this.popFunctionState_(fs);
     return new ArrowFunctionExpression(this.getTreeLocation_(start),
         asyncToken, formals, body);
@@ -3383,13 +3383,14 @@ export class Parser {
    *   [lookahead not {] AssignmentExpression
    *   { FunctionBody }
    *
+   * @param {ParseTree} params
    * @return {ParseTree}
    */
-  parseConciseBody_() {
+  parseConciseBody_(params) {
     // The body can be a block or an expression. A '{' is always treated as
     // the beginning of a block.
     if (this.peek_(OPEN_CURLY))
-      return this.parseFunctionBody_(null);
+      return this.parseFunctionBody_(params);
 
     return this.parseAssignmentExpression_(ALLOW_IN);
   }

--- a/test/feature/ArrayComprehension/Error_Disabled.js
+++ b/test/feature/ArrayComprehension/Error_Disabled.js
@@ -1,4 +1,4 @@
 // Options: --array-comprehension=false
-// Error: :4:14: Unexpected token for
+// Error: :4:14: Unexpected reserved word for
 
 var array = [for (x of [0, 1, 2, 3, 4]) x];

--- a/test/feature/ArrowFunctions/SloppyArguments.js
+++ b/test/feature/ArrowFunctions/SloppyArguments.js
@@ -1,0 +1,15 @@
+
+var f1 = implements => implements;
+var f2 = implements => { return implements; };
+var f3 = (implements) => { return implements; };
+assert.equal(1, f1(1));
+assert.equal(2, f2(2));
+assert.equal(3, f1(3));
+
+var g = ({static}) => static;
+assert.equal(4, g({static: 4}));
+
+var h1 = ([protected]) => protected;
+var h2 = ([...protected]) => protected[0];
+assert.equal(5, h1([5]));
+assert.equal(6, h2([6]));

--- a/test/feature/ObjectInitializerShorthand/Error_StrictKeyword.js
+++ b/test/feature/ObjectInitializerShorthand/Error_StrictKeyword.js
@@ -1,0 +1,12 @@
+// Error: :6:11: implements is a reserved identifier,
+// Error: :11:11: yield is a reserved identifier,
+
+function f() {
+  'use strict';
+  return {implements};
+}
+
+function g() {
+  'use strict';
+  return {yield};
+}

--- a/test/feature/ObjectInitializerShorthand/StrictKeyword.js
+++ b/test/feature/ObjectInitializerShorthand/StrictKeyword.js
@@ -1,0 +1,14 @@
+// This only tests the parsing.
+
+function f() {
+  return {implements};
+}
+
+function f2() {
+  return {yield};
+}
+
+function* g() {
+  'use strict';
+  return {yield};
+}

--- a/test/feature/Syntax/Error_StrictKeywordsInArguments.js
+++ b/test/feature/Syntax/Error_StrictKeywordsInArguments.js
@@ -1,6 +1,14 @@
-// Error: :3:25: implements is a reserved identifier
+// Error: :8:25: implements is a reserved identifier,
+// Error :8:25: implements is a reserved identifier
+// Error :10:1: implements is a reserved identifier
+// Error :11:2: implements is a reserved identifier
+// Error :12:3: implements is a reserved identifier
+// Error :13:6: implements is a reserved identifier
 
-function testImplements(implements) {
-  'use strict';
-  return 42;
-}
+function testImplements(implements) { 'use strict'; }
+
+implements => { 'use strict'; };
+(implements) => { 'use strict'; };
+([implements]) => { 'use strict'; };
+([...implements]) => { 'use strict'; };
+({implements}) => { 'use strict'; };


### PR DESCRIPTION
In case the outer scope of an arrow function is sloppy and the arrow
has a use strict directive we need to validate the parameters.