### PR TITLE
Make TempVarTransformer use let where possible

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -169,6 +169,7 @@ export class Compiler {
   /**
    * @param {string} content to be compiled.
    * @param {string} sourceName inserted into sourceMaps
+   * @return {ParseTree}
    */
   parse(content, sourceName = '<compiler-parse-input>') {
     sourceName = this.normalize(sourceName);

--- a/src/codegeneration/ArrowFunctionTransformer.js
+++ b/src/codegeneration/ArrowFunctionTransformer.js
@@ -48,12 +48,11 @@ function convertConciseBody(tree) {
  * @see <a href="http://wiki.ecmascript.org/doku.php?id=strawman:arrow_function_syntax">strawman:arrow_function_syntax</a>
  */
 export class ArrowFunctionTransformer extends TempVarTransformer {
-  constructor(identifierGenerator) {
-    super(identifierGenerator);
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator, reporter, options);
     this.inDerivedClass_ = false;
     this.inConstructor_ = false;
   }
-
 
   /**
    * Transforms an arrow function expression into a function declaration.

--- a/src/codegeneration/AsyncGeneratorTransformPass.js
+++ b/src/codegeneration/AsyncGeneratorTransformPass.js
@@ -38,7 +38,7 @@ export class AsyncGeneratorTransformPass extends TempVarTransformer {
   // itself produces async functions so GeneratorTransformPass may then
   // have to run twice.
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
+    super(identifierGenerator, reporter, options);
     this.transformOptions_ = options.transformOptions;
     this.inBlock_ = false;
   }
@@ -76,7 +76,7 @@ export class AsyncGeneratorTransformPass extends TempVarTransformer {
     if (!this.needsTransform_(tree)) {
       return super.transformFunctionExpression(tree);
     }
-    
+
     let name;
     if (!tree.name) {
       // We need a name to be able to reference the function object.
@@ -98,7 +98,8 @@ export class AsyncGeneratorTransformPass extends TempVarTransformer {
   transformFunction_(tree, constructor, nameExpression) {
     let body = super.transformAny(tree.body);
     body = AsyncGeneratorTransformer.transformAsyncGeneratorBody(
-          this.identifierGenerator, this.reporter_, body, nameExpression);
+        this.identifierGenerator, this.reporter, this.options, body,
+        nameExpression);
 
     // The async generator has been transformed away.
     let functionKind = null;

--- a/src/codegeneration/AsyncGeneratorTransformer.js
+++ b/src/codegeneration/AsyncGeneratorTransformer.js
@@ -38,8 +38,8 @@ import {ARGUMENTS} from '../syntax/PredefinedName.js';
 import {VAR} from '../syntax/TokenType.js';
 
 export class AsyncGeneratorTransformer extends TempVarTransformer {
-  constructor(identifierGenerator) {
-    super(identifierGenerator);
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator, reporter, options);
     this.variableDeclarations_ = [];
     this.ctx_ = id(this.getTempIdentifier());
   }
@@ -113,12 +113,15 @@ export class AsyncGeneratorTransformer extends TempVarTransformer {
    /**
     * @param {UniqueIdentifierGenerator} identifierGenerator
     * @param {ErrorReporter} reporter
+    * @param {Options} options
     * @param {Block} body
     * @param {IdentifierExpression} name
     * @return {Block}
     */
-  static transformAsyncGeneratorBody(identifierGenerator, reporter, body, name) {
-    return new AsyncGeneratorTransformer(identifierGenerator, reporter).
+  static transformAsyncGeneratorBody(identifierGenerator, reporter, options,
+                                     body, name) {
+    return new AsyncGeneratorTransformer(identifierGenerator, reporter,
+                                         options).
         transformAsyncGeneratorBody_(body, name);
   }
 }

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -158,11 +158,9 @@ export class ClassTransformer extends TempVarTransformer {
    * @param {Options} options
    */
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
+    super(identifierGenerator, reporter, options);
     this.strictCount_ = 0;
     this.state_ = null;
-    this.reporter_ = reporter;
-    this.options_ = options;
   }
 
   // Override to handle AnonBlock
@@ -219,8 +217,8 @@ export class ClassTransformer extends TempVarTransformer {
     let classExpression = new ClassExpression(tree.location, tree.name,
         tree.superClass, tree.elements, tree.annotations, tree.typeParameters);
     let transformed = this.transformClassExpression(classExpression);
-    let useLet = !this.options_.transformOptions.blockBinding &&
-                 this.options_.parseOptions.blockBinding;
+    let useLet = !this.options.transformOptions.blockBinding &&
+                 this.options.parseOptions.blockBinding;
     return createVariableStatement(useLet ? LET : VAR, tree.name, transformed);
   }
 
@@ -319,8 +317,8 @@ export class ClassTransformer extends TempVarTransformer {
 
       let functionStatement;
       if (tree.name &&
-          !this.options_.transformOptions.blockBinding &&
-          this.options_.parseOptions.blockBinding) {
+          !this.options.transformOptions.blockBinding &&
+          this.options.parseOptions.blockBinding) {
         functionStatement = createVariableStatement(CONST, tree.name, func);
       } else {
         functionStatement = functionExpressionToDeclaration(func, name);
@@ -353,7 +351,7 @@ export class ClassTransformer extends TempVarTransformer {
     let body = this.transformSuperInFunctionBody_(
         tree.body, homeObject, internalName);
 
-    if (this.options_.showDebugNames_) {
+    if (this.options.showDebugNames_) {
       tree.debugName = classMethodDebugName(originalName, methodNameFromTree(tree.name), isStatic);
     }
 

--- a/src/codegeneration/ComprehensionTransformer.js
+++ b/src/codegeneration/ComprehensionTransformer.js
@@ -44,10 +44,6 @@ import {
  * See subclasses for details on desugaring.
  */
 export class ComprehensionTransformer extends TempVarTransformer {
-  constructor(idGenerator, reporter, options) {
-    super(idGenerator);
-    this.options_ = options;
-  }
   /**
    * transformArrayComprehension and transformGeneratorComprehension calls
    * this
@@ -64,7 +60,7 @@ export class ComprehensionTransformer extends TempVarTransformer {
 
     // This should really be a let but we don't support let in generators.
     // https://code.google.com/p/traceur-compiler/issues/detail?id=6
-    let bindingKind = isGenerator || !this.options_.blockBinding ? VAR : LET;
+    let bindingKind = isGenerator || !this.options.blockBinding ? VAR : LET;
 
     let statements = prefix ? [prefix] : [];
 

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -166,8 +166,7 @@ export class DestructuringTransformer extends TempVarTransformer {
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
-    this.options_ = options;
+    super(identifierGenerator, reporter, options);
     this.parameterDeclarations = null;
   }
 
@@ -419,7 +418,7 @@ export class DestructuringTransformer extends TempVarTransformer {
 
     let body = this.transformAny(tree.catchBody);
     let statements = [];
-    let kind = this.options_.blockBinding ? LET : VAR;
+    let kind = this.options.blockBinding ? LET : VAR;
     let binding = this.desugarBinding_(tree.binding, statements, kind);
     statements.push(...body.statements);
     return new Catch(tree.location, binding, createBlock(statements));

--- a/src/codegeneration/ForOnTransformer.js
+++ b/src/codegeneration/ForOnTransformer.js
@@ -91,4 +91,3 @@ export class ForOnTransformer extends TempVarTransformer {
     return this.transformForOnStatement_(statement, labelSet);
   }
 }
-

--- a/src/codegeneration/GeneratorTransformPass.js
+++ b/src/codegeneration/GeneratorTransformPass.js
@@ -56,8 +56,7 @@ export class GeneratorTransformPass extends TempVarTransformer {
    * @param {ErrorReporter} reporter
    */
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
-    this.reporter_ = reporter;
+    super(identifierGenerator, reporter, options);
     this.tranformOptions_ = options.transformOptions;
     this.inBlock_ = false;
   }
@@ -139,17 +138,18 @@ export class GeneratorTransformPass extends TempVarTransformer {
     let finder = new ForInFinder();
     finder.visitAny(body);
     if (finder.found) {
-      body = new ForInTransformPass(this.identifierGenerator).
-          transformAny(body);
+      body = new ForInTransformPass(this.identifierGenerator, this.reporter,
+                                    this.options).transformAny(body);
     }
 
     if (this.tranformOptions_.generators && tree.isGenerator()) {
       body = GeneratorTransformer.transformGeneratorBody(
-          this.identifierGenerator, this.reporter_, body, nameExpression);
+          this.identifierGenerator, this.reporter, this.options, body,
+          nameExpression);
 
     } else if (this.tranformOptions_.asyncFunctions && tree.isAsyncFunction()) {
       body = AsyncTransformer.transformAsyncBody(
-          this.identifierGenerator, this.reporter_, body);
+          this.identifierGenerator, this.reporter, this.options, body);
     }
 
     // The generator has been transformed away.

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -66,8 +66,7 @@ export class ModuleTransformer extends TempVarTransformer {
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
-    this.options_ = options;
+    super(identifierGenerator, reporter, options);
     this.exportVisitor_ = new DirectExportVisitor();
     this.importSimplifier_ = new ImportSimplifyingTransformer();
     this.moduleName = null;
@@ -121,7 +120,7 @@ export class ModuleTransformer extends TempVarTransformer {
 
   wrapModule(statements) {
     let functionExpression;
-    if (this.options_.transformOptions.require) {
+    if (this.options.transformOptions.require) {
       functionExpression = parseExpression `function(require) {
         ${statements}
       }`;
@@ -303,10 +302,11 @@ export class ModuleTransformer extends TempVarTransformer {
 
     // If destructuring patterns are kept in the output code, keep this as is,
     // otherwise transform it here.
-    if (this.options_.transformOptions.destructuring ||
-        !this.options_.parseOptions.destructuring) {
+    if (this.options.transformOptions.destructuring ||
+        !this.options.parseOptions.destructuring) {
       let destructuringTransformer =
-          new DestructImportVarStatement(this.identifierGenerator);
+          new DestructImportVarStatement(this.identifierGenerator,
+                                         this.reporter, this.options);
       varStatement = varStatement.transform(destructuringTransformer);
     }
 

--- a/src/codegeneration/ObjectLiteralTransformer.js
+++ b/src/codegeneration/ObjectLiteralTransformer.js
@@ -109,9 +109,11 @@ function isProtoName(tree) {
 export class ObjectLiteralTransformer extends TempVarTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
+   * @param {ErrorReporter} reporter
+   * @param {Options} options
    */
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
+    super(identifierGenerator, reporter, options);
     this.transformOptions_ = options.transformOptions;
     this.protoExpression = null;
     this.needsAdvancedTransform = false;

--- a/src/codegeneration/ParameterTransformer.js
+++ b/src/codegeneration/ParameterTransformer.js
@@ -24,7 +24,6 @@ let stack = [];
  * Base class for rest, default and destructuring parameters.
  */
 export class ParameterTransformer extends TempVarTransformer {
-
   transformArrowFunctionExpression(tree) {
     // The stack is popped in transformFunctionBody.
     stack.push([]);

--- a/src/codegeneration/ProperTailCallTransformer.js
+++ b/src/codegeneration/ProperTailCallTransformer.js
@@ -53,9 +53,8 @@ export class ProperTailCallTransformer extends TempVarTransformer {
   // TODO(mnieper): This transformer currently expects that classes and template
   // literals have already been desugared. Otherwise they are not guaranteed
   // to have proper tail calls.
-
-  constructor(identifierGenerator) {
-    super(identifierGenerator);
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator, reporter, options);
     this.inBlock_ = false;
   }
 

--- a/src/codegeneration/SymbolTransformer.js
+++ b/src/codegeneration/SymbolTransformer.js
@@ -102,7 +102,6 @@ let runtimeOption = parseStatement `$traceurRuntime.options.symbols = true`;
  *   operand[$traceurRuntime.toProperty(memberExpression)] = value
  */
 export class SymbolTransformer extends TempVarTransformer {
-
   transformModule(tree) {
     return new Module(tree.location,
         prependStatements(this.transformList(tree.scriptItemList),

--- a/src/codegeneration/TempVarTransformer.js
+++ b/src/codegeneration/TempVarTransformer.js
@@ -21,7 +21,7 @@ import {
 } from '../syntax/trees/ParseTrees.js';
 import {ARGUMENTS} from '../syntax/PredefinedName.js';
 import {StringSet} from '../util/StringSet.js';
-import {VAR} from '../syntax/TokenType.js';
+import {LET, VAR} from '../syntax/TokenType.js';
 import {
   createFunctionBody,
   createThisExpression,
@@ -60,10 +60,13 @@ class TempScope {
 }
 
 class VarScope {
-  constructor() {
+  constructor(options) {
     this.thisName = null;
     this.argumentName = null;
     this.tempVarStatements = [];
+    this.declarationType_ =
+        options.blockBinding && !options.transformOptions.blockBinding ?
+            LET : VAR;
   }
 
   push(tempVarStatement) {
@@ -99,7 +102,7 @@ class VarScope {
     }
 
     return createVariableStatement(
-        createVariableDeclarationList(VAR, declarations));
+        createVariableDeclarationList(this.declarationType_, declarations));
   }
 }
 
@@ -110,13 +113,17 @@ class VarScope {
 export class TempVarTransformer extends ParseTreeTransformer {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
+   * @param {ErrorReporter} reporter
+   * @param {Options} options
    */
-  constructor(identifierGenerator) {
+  constructor(identifierGenerator, reporter, options) {
     super();
     this.identifierGenerator = identifierGenerator;
+    this.reporter = reporter;
+    this.options = options;
 
     // Stack used for variable declarations.
-    this.tempVarStack_ = [new VarScope()];
+    this.tempVarStack_ = [new VarScope(this.options)];
 
     // Stack used for the temp scopes. Temp scopes can be used to allow
     // temporary names to used sooner than after leaving the currently function
@@ -134,7 +141,7 @@ export class TempVarTransformer extends ParseTreeTransformer {
    * @private
    */
   transformStatements_(statements) {
-    this.tempVarStack_.push(new VarScope());
+    this.tempVarStack_.push(new VarScope(this.options));
 
     let transformedStatements = this.transformList(statements);
 

--- a/src/codegeneration/TypeAssertionTransformer.js
+++ b/src/codegeneration/TypeAssertionTransformer.js
@@ -60,7 +60,7 @@ export class TypeAssertionTransformer extends ParameterTransformer {
    * @param {UniqueIdentifierGenerator} identifierGenerator
    */
   constructor(identifierGenerator, reporter, options) {
-    super(identifierGenerator);
+    super(identifierGenerator, reporter, options);
     this.options_ = options;
     this.returnTypeStack_ = [];
     this.parametersStack_ = [];

--- a/src/codegeneration/generator/AsyncTransformer.js
+++ b/src/codegeneration/generator/AsyncTransformer.js
@@ -225,8 +225,8 @@ export class AsyncTransformer extends CPSTransformer {
    * @param {Block} body
    * @return {Block}
    */
-  static transformAsyncBody(identifierGenerator, reporter, body) {
-    return new AsyncTransformer(identifierGenerator, reporter).
+  static transformAsyncBody(identifierGenerator, reporter, options, body) {
+    return new AsyncTransformer(identifierGenerator, reporter, options).
         transformAsyncBody(body);
   }
 };

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -163,9 +163,8 @@ export class CPSTransformer extends TempVarTransformer {
   /**
    * @param {ErrorReporter} reporter
    */
-  constructor(identifierGenerator, reporter) {
-    super(identifierGenerator);
-    this.reporter = reporter;
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator,reporter, options);
     this.stateAllocator_ = new StateAllocator();
 
     // This is currently a Map<string, LabelState> where the key is the

--- a/src/codegeneration/generator/ForInTransformPass.js
+++ b/src/codegeneration/generator/ForInTransformPass.js
@@ -58,7 +58,6 @@ import {
  * Desugars for-in loops to be compatible with generators.
  */
 export class ForInTransformPass extends TempVarTransformer {
-
   // for ( var key in object ) statement
   //
   // var $keys = [];

--- a/src/codegeneration/generator/GeneratorTransformer.js
+++ b/src/codegeneration/generator/GeneratorTransformer.js
@@ -73,8 +73,8 @@ function scopeContainsYield(tree) {
  */
 export class GeneratorTransformer extends CPSTransformer {
 
-  constructor(identifierGenerator, reporter) {
-    super(identifierGenerator, reporter);
+  constructor(identifierGenerator, reporter, options) {
+    super(identifierGenerator, reporter, options);
     this.shouldAppendThrowCloseState_ = true;
   }
 
@@ -311,8 +311,9 @@ export class GeneratorTransformer extends CPSTransformer {
    * @param {IdentifierExpression} name
    * @return {Block}
    */
-  static transformGeneratorBody(identifierGenerator, reporter, body, name) {
-    return new GeneratorTransformer(identifierGenerator, reporter).
+  static transformGeneratorBody(identifierGenerator, reporter, options, body,
+                                name) {
+    return new GeneratorTransformer(identifierGenerator, reporter, options).
         transformGeneratorBody(body, name);
   }
 };

--- a/test/unit/codegeneration/AmdTransformer.js
+++ b/test/unit/codegeneration/AmdTransformer.js
@@ -15,6 +15,7 @@
 import {suite, test, assert, setup} from '../../unit/unitTestRunner.js';
 
 import {AmdTransformer} from '../../../src/codegeneration/AmdTransformer.js';
+import {Options} from '../../../src/Options.js';
 import * as ParseTreeFactory from '../../../src/codegeneration/ParseTreeFactory.js';
 import {write} from '../../../src/outputgeneration/TreeWriter.js';
 
@@ -23,7 +24,7 @@ suite('AmdTransformer.js', function() {
   var transformer = null
 
   setup(function() {
-    transformer = new AmdTransformer();
+    transformer = new AmdTransformer(null, null, new Options());
   });
 
   function str(s) {

--- a/test/unit/codegeneration/ES6ClassTransformer.js
+++ b/test/unit/codegeneration/ES6ClassTransformer.js
@@ -23,35 +23,33 @@ import {UniqueIdentifierGenerator} from '../../../src/codegeneration/UniqueIdent
 import {write} from '../../../src/outputgeneration/TreeWriter.js';
 
 suite('ES6ClassTransformer.js', function() {
-  var transformer;
 
-  setup(function() {
-    transformer = new ES6ClassTransformer(new UniqueIdentifierGenerator());
-  });
-
-  function parseScript(content, memberVariables = true) {
+  function parseScript(content, options) {
     var file = new SourceFile('test', content);
-    var options = new Options({
-      memberVariables: memberVariables,
-      annotations: true,
-      validate: true,
-    });
     var parser = new Parser(file, null, options);
     var tree = parser.parseScript();
     ParseTreeValidator.validate(tree);
     return tree;
   }
 
-  function normalizeScript(content) {
-    var tree = parseScript(content, false);
+  function normalizeScript(content, options) {
+    options.memberVariables = false;
+    var tree = parseScript(content, options);
     return write(tree);
   }
 
   function testTransform(name, content, expected) {
     test(name, function() {
-      var tree = parseScript(content);
+      var options = new Options({
+        memberVariables: true,
+        annotations: true,
+        validate: true,
+      });
+      var tree = parseScript(content, options);
+      var transformer = new ES6ClassTransformer(new UniqueIdentifierGenerator(),
+                                                null, options);
       var transformed = transformer.transformAny(tree);
-      assert.equal(normalizeScript(expected), write(transformed));
+      assert.equal(normalizeScript(expected, options), write(transformed));
     });
   }
 

--- a/test/unit/codegeneration/InlineModuleTransformer.js
+++ b/test/unit/codegeneration/InlineModuleTransformer.js
@@ -15,6 +15,7 @@
 import {suite, test, assert, setup} from '../../unit/unitTestRunner.js';
 
 import {InlineModuleTransformer} from '../../../src/codegeneration/InlineModuleTransformer.js';
+import {Options} from '../../../src/Options.js';
 import * as ParseTreeFactory from '../../../src/codegeneration/ParseTreeFactory.js';
 import {write} from '../../../src/outputgeneration/TreeWriter.js';
 
@@ -23,7 +24,7 @@ suite('InlineModuleTransformer.js', function() {
   var transformer = null
 
   setup(function() {
-    transformer = new InlineModuleTransformer();
+    transformer = new InlineModuleTransformer(null, null, new Options());
   });
 
   function str(s) {

--- a/test/unit/codegeneration/TempVarTransformerUseLet.js
+++ b/test/unit/codegeneration/TempVarTransformerUseLet.js
@@ -1,0 +1,75 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {CONST, LET, VAR} from '../../../src/syntax/TokenType.js';
+import {Compiler} from '../../../src/Compiler.js';
+import {ParseTreeVisitor} from '../../../src/syntax/ParseTreeVisitor.js';
+import {suite, test, assert} from '../../unit/unitTestRunner.js';
+
+suite('TempVarTransformerUseLet.js', function() {
+
+  class CheckDeclarations extends ParseTreeVisitor {
+    constructor(declarationType) {
+      super();
+      this.declarationType = declarationType;
+    }
+    visitVariableDeclarationList(tree) {
+      if (this.declarationType === LET) {
+        assert(tree.declarationType === LET || tree.declarationType === CONST,
+            `Expecte let or const but found ${tree.declarationType}`);
+      } else {
+        assert.equal(tree.declarationType, this.declarationType);
+      }
+      super.visitVariableDeclarationList(tree);
+    }
+
+  }
+
+  function testResult(declarationType, content, expectedResult) {
+    test('', function() {
+      let compiler = new Compiler({
+        exponentiation: true,
+        blockBinding: declarationType === VAR || 'parse',
+        script: true,
+        sourceMaps: false
+      });
+      let tree = compiler.parse(content);
+      let transformed = compiler.transform(tree);
+      let visitor = new CheckDeclarations(declarationType);
+      visitor.visitAny(transformed);
+    });
+  }
+
+  testResult(VAR, '({a, b} = {})');
+  testResult(LET, '({a, b} = {})');
+
+  testResult(VAR, 'const [x, y] = []');
+  testResult(LET, 'const [x, y] = []');
+
+  testResult(VAR, '() => this');
+  testResult(LET, '() => this');
+
+  testResult(VAR, 'function f() { () => arguments; }');
+  testResult(LET, 'function f() { () => arguments; }');
+
+  testResult(VAR, 'let x = 2; x **= 3;');
+  testResult(LET, 'let x = 2; x **= 3;');
+
+  // TODO(arv): ForOfTransformer does not do the right thing here.
+  // testResult(VAR, 'for (let x of []) {}');
+  // testResult(LET, 'for (let x of []) {}');
+
+  testResult(VAR, 'obj.m(1, ...[2, 3])');
+  testResult(LET, 'obj.m(1, ...[2, 3])');
+});


### PR DESCRIPTION
If the generated code outputs let then make the TempVarTransformer
use let bindings instead of vars.