### PR TITLE
[strong] Add arity checking to functions

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -58,6 +58,7 @@ export const optionsV01 = enumerableOnlyObject({
   require: false,
   restParameters: true,
   strongMode: false,
+  strongModeAsserts: false,
   script: false,
   sourceMaps: false,
   sourceRoot: false,
@@ -156,6 +157,7 @@ addFeatureOption('generatorComprehension', EXPERIMENTAL);
 addFeatureOption('memberVariables', EXPERIMENTAL);
 addFeatureOption('require', EXPERIMENTAL);
 addFeatureOption('strongMode', EXPERIMENTAL);
+addFeatureOption('strongModeAsserts', EXPERIMENTAL);
 addFeatureOption('types', EXPERIMENTAL);
 
 let transformOptionsPrototype = {};

--- a/src/codegeneration/DefaultParametersTransformer.js
+++ b/src/codegeneration/DefaultParametersTransformer.js
@@ -69,7 +69,6 @@ function createDefaultAssignment(index, binding, initializer) {
  * @see <a href="http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values">harmony:parameter_default_values</a>
  */
 export class DefaultParametersTransformer extends ParameterTransformer {
-
   transformFormalParameterList(tree) {
     let parameters = [];
     let changed = false;

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -47,6 +47,7 @@ import {ProperTailCallTransformer} from './ProperTailCallTransformer.js';
 import {RegularExpressionTransformer} from './RegularExpressionTransformer.js';
 import {RestParameterTransformer} from './RestParameterTransformer.js';
 import {SpreadTransformer} from './SpreadTransformer.js';
+import {StrongArityTransformer} from './strong/StrongArityTransformer.js';
 import {StrongModeTransformer} from './strong/StrongModeTransformer.js';
 import {SymbolTransformer} from './SymbolTransformer.js';
 import {TemplateLiteralTransformer} from './TemplateLiteralTransformer.js';
@@ -76,8 +77,14 @@ export class FromOptionsTransformer extends MultiTransformer {
       });
     };
 
-    if (transformOptions.strongMode)
+    if (transformOptions.strongMode) {
+      if (transformOptions.strongModeAsserts) {
+        append(StrongArityTransformer);
+      }
+
       append(StrongModeTransformer);
+    }
+
 
     if (transformOptions.blockBinding) {
       this.append((tree) => {

--- a/src/codegeneration/LanguageModeTransformerTrait.js
+++ b/src/codegeneration/LanguageModeTransformerTrait.js
@@ -1,0 +1,121 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strong';
+
+import {FUNCTION_BODY} from '../syntax/trees/ParseTreeType.js';
+import {
+  SLOPPY_MODE,
+  STRONG_MODE,
+  findLanguageMode
+} from '../staticsemantics/LanguageMode.js';
+
+/**
+ * This function is used as trait to generate a class that that keeps track of
+ * the language mode.
+ *
+ * Usage:
+ *
+ *  class MyTransformer extends
+ *      LanguageModeTransformerTrait(ParseTreeTransformer) {
+ *    ...
+ *  }
+ *
+ * @param {Function} ParseTreeTransformerClass A class that extends
+ *     ParseTreeTransformer.
+ * @return {Function}
+ */
+export function LanguageModeTransformerTrait(ParseTreeTransformerClass) {
+  return class extends ParseTreeTransformerClass {
+    constructor(idGen, reporter, options) {
+      super(idGen, reporter, options);
+      this.languageMode_ = SLOPPY_MODE;
+    }
+
+    get languageMode() {
+      return this.languageMode_;
+    }
+
+    isSloppyMode() {
+      return this.languageMode_ === SLOPPY_MODE;
+    }
+
+    isStrongMode() {
+      return this.languageMode_ === STRONG_MODE;
+    }
+
+    isStrictMode() {
+      return this.languageMode_ !== SLOPPY_MODE;
+    }
+
+    transformAndUpdateLanguageMode_(statements, transformFunction) {
+      let oldLanguageMode = this.languageMode_;
+      this.languageMode_ = findLanguageMode(statements, oldLanguageMode);
+      let transformed = transformFunction();
+      this.languageMode_ = oldLanguageMode;
+      return transformed;
+    }
+
+    transformScript(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.scriptItemList,
+          () => super.transformScript(tree));
+    }
+
+    transformModule(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.scriptItemList,
+          () => super.transformModule(tree));
+    }
+
+    transformFunctionDeclaration(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.body.statements,
+          () => super.transformFunctionDeclaration(tree));
+    }
+
+    transformFunctionExpression(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.body.statements,
+          () => super.transformFunctionExpression(tree));
+    }
+
+    transformPropertyMethodAssignment(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.body.statements,
+          () => super.transformPropertyMethodAssignment(tree));
+    }
+
+    transformArrowFunctionExpression(tree) {
+      if (tree.body.type === FUNCTION_BODY) {
+        return this.transformAndUpdateLanguageMode_(
+            tree.body.statements,
+            () => super.transformArrowFunctionExpression(tree));
+      }
+      return super.transformArrowFunctionExpression(tree);
+    }
+
+    transformGetAccessor(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.body.statements,
+          () => super.transformGetAccessor(tree));
+    }
+
+    transformSetAccessor(tree) {
+      return this.transformAndUpdateLanguageMode_(
+          tree.body.statements,
+          () => super.transformSetAccessor(tree));
+    }
+  }
+}

--- a/src/codegeneration/RestParameterTransformer.js
+++ b/src/codegeneration/RestParameterTransformer.js
@@ -36,7 +36,6 @@ function getRestParameterLiteralToken(parameterList) {
  * @see <a href="http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters">harmony:rest_parameters</a>
  */
 export class RestParameterTransformer extends ParameterTransformer {
-
   transformFormalParameterList(tree) {
     let transformed = super.transformFormalParameterList(tree);
     if (hasRestParameter(transformed)) {

--- a/src/codegeneration/strong/StrongArityTransformer.js
+++ b/src/codegeneration/strong/StrongArityTransformer.js
@@ -1,0 +1,66 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strong';
+
+import {ArrowFunctionExpression} from '../../syntax/trees/ParseTrees.js';
+import {LanguageModeTransformerTrait} from '../LanguageModeTransformerTrait.js';
+import {ParameterTransformer} from '../ParameterTransformer.js';
+import {parseStatement} from '../PlaceholderParser.js';
+import expectedArgumentCount from '../../staticsemantics/ExpectedArgumentCount.js';
+
+/**
+ * In strong mode it is a TypeError to call a function with too few parameters.
+ *
+ * This transformer injects a check for the number of arguments passed:
+ *
+ *   function f(x) {
+ *     'use strong';
+ *     ...
+ *   }
+ *
+ *   Generates:
+ *
+ *   function f(x) {
+ *     'use strong';
+ *     if (arguments.length < 1) throw ...
+ *     ...
+ *   }
+ */
+export class StrongArityTransformer extends
+    LanguageModeTransformerTrait(ParameterTransformer) {
+  constructor(idGen, reporter, options) {
+    super(idGen, reporter, options);
+    this.currentArrowFormals_ = null;
+  }
+  transformFormalParameterList(tree) {
+    if (this.isStrongMode() && tree !== this.currentArrowFormals_) {
+      let arity = expectedArgumentCount(tree);
+      if (arity > 0) {
+        let ifStatement = parseStatement
+            `if (arguments.length < ${arity}) throw new TypeError(
+                'In strong mode it is illegal to call a function with too few arguments')`;
+        this.parameterStatements.push(ifStatement);
+      }
+    }
+    this.currentArrowFormals_ = null;
+    return super.transformFormalParameterList(tree);
+  }
+
+  transformArrowFunctionExpression(tree) {
+    // Arrow functions do not have arguments so we cannot check them.
+    this.currentArrowFormals_ = tree.parameterList;
+    return super.transformArrowFunctionExpression(tree);
+  }
+}

--- a/src/semantics/util.js
+++ b/src/semantics/util.js
@@ -26,21 +26,19 @@ import {
 import {
   VOID
 } from '../syntax/TokenType.js';
+import {
+  SLOPPY_MODE,
+  STRONG_MODE,
+  findLanguageMode,
+} from '../staticsemantics/LanguageMode.js';
 
 /**
  * @param {Array<ParseTree>} list
  * @return {boolean}
  */
 export function hasUseStrict(list) {
-  for (let i = 0; i < list.length; i++) {
-    if (!list[i].isDirectivePrologue()) {
-      return false;
-    }
-    if (list[i].isUseStrongDirective() || list[i].isUseStrictDirective()) {
-      return true;
-    }
-  }
-  return false;
+  let newMode = findLanguageMode(list, SLOPPY_MODE);
+  return newMode !== SLOPPY_MODE;
 }
 
 /**
@@ -48,15 +46,8 @@ export function hasUseStrict(list) {
  * @return {boolean}
  */
 export function hasUseStrong(list) {
-  for (let i = 0; i < list.length; i++) {
-    if (!list[i].isDirectivePrologue()) {
-      return false;
-    }
-    if (list[i].isUseStrongDirective()) {
-      return true;
-    }
-  }
-  return false;
+  let newMode = findLanguageMode(list, SLOPPY_MODE);
+  return newMode === STRONG_MODE;
 }
 
 /**

--- a/src/staticsemantics/ExpectedArgumentCount.js
+++ b/src/staticsemantics/ExpectedArgumentCount.js
@@ -1,0 +1,31 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strong';
+
+/**
+ * This matches the ExpectedArgumentCount spec algorithm.
+ * @param {FormalParameterList} tree
+ * @return {number}
+ */
+export default function expectedArgumentCount(tree) {
+  let n = tree.parameters.length - 1;
+  for (; n >= 0; n--) {
+    let parameter = tree.parameters[n].parameter;
+    if (!parameter.isRestParameter() && parameter.initializer === null) {
+      break;
+    }
+  }
+  return n + 1;
+}

--- a/src/staticsemantics/LanguageMode.js
+++ b/src/staticsemantics/LanguageMode.js
@@ -1,0 +1,37 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Enums for language mode. Strong mode implies strict mode.
+export const SLOPPY_MODE = 0;
+export const STRICT_MODE = 1;
+export const STRONG_MODE = 2;
+
+export function findLanguageMode(statements, mode) {
+  if (mode !== STRONG_MODE) {
+    for (let i = 0; i < statements.length; i++) {
+      if (!statements[i].isDirectivePrologue()) {
+        break;
+      }
+      if (statements[i].isUseStrictDirective()) {
+        if (mode === SLOPPY_MODE) {
+          mode = STRICT_MODE;
+        }
+      } else if (statements[i].isUseStrongDirective()) {
+        return STRONG_MODE;  // Cannot get any stronger than this!
+      }
+    }
+  }
+
+  return mode;
+}

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -279,6 +279,7 @@ import {
   WithStatement,
   YieldExpression
 }  from './trees/ParseTrees.js';
+import {SLOPPY_MODE, STRICT_MODE, STRONG_MODE} from '../staticsemantics/LanguageMode.js';
 
 /**
  * Differentiates between parsing for 'In' vs. 'NoIn'
@@ -293,11 +294,6 @@ const NO_IN = false;
  */
 const INITIALIZER_REQUIRED = true;
 const INITIALIZER_OPTIONAL = false;
-
-// Enums for language mode. Strong mode implies strict mode.
-const SLOPPY_MODE = 0;
-const STRICT_MODE = 1;
-const STRONG_MODE = 2;
 
 /**
  * Used to find invalid CoverInitializedName trees. This is used when we know

--- a/test/feature/StrongMode/ArityChecking.js
+++ b/test/feature/StrongMode/ArityChecking.js
@@ -1,0 +1,139 @@
+// Options: --strong-mode --strong-mode-asserts
+
+function f(x) {}
+f();
+
+function f0() { 'use strong'; }
+f0();
+f0(1);
+
+function f1(x) { 'use strong'; }
+assert.throws(f1, TypeError);
+f1(1);
+f1(1, 2);
+
+function f2(x = 1) { 'use strong'; }
+f2();
+f2(1);
+f2(1, 2);
+
+function f3(...xs) { 'use strong'; }
+f3();
+
+function f4(x, y = 1) { 'use strong'; }
+f4(1);
+
+function f5(x, ...xs) { 'use strong'; }
+f5(1);
+
+function f6(x = 1, y) { 'use strong'; }
+assert.throws(f6, TypeError);
+assert.throws(() => f6(2), TypeError);
+f6(1, 2);
+
+function f7(x, y = 1, z) { 'use strong'; }
+assert.throws(f7, TypeError);
+assert.throws(() => f7(1), TypeError);
+assert.throws(() => f7(1, 2), TypeError);
+f7(1, 2, 3);
+f7(1, 2, 3, 4);
+
+function f8({x} = {x :1}) { 'use strong'; }
+f8();
+f8(1);
+
+function f9({x}) { 'use strong'; }
+assert.throws(f9, TypeError);
+f9({x: 1});
+
+let f10 = function(x) { 'use strong'; }
+assert.throws(f10, TypeError);
+f10(1);
+
+assert.throws(() => f10.call(null), TypeError);
+assert.throws(() => f10.apply(null, []), TypeError);
+f10.call(null, 1);
+f10.apply(null, [1]);
+
+(() => {
+  'use strong';
+  function f0() {}
+  f0();
+  f0(1);
+
+  function f1(x) {}
+  assert.throws(f1, TypeError);
+  f1(1);
+  f1(1, 2);
+
+  function f2(x = 1) {}
+  f2();
+  f2(1);
+  f2(1, 2);
+
+  function f3(...xs) {}
+  f3();
+
+  function f4(x, y = 1) {}
+  f4(1);
+
+  function f5(x, ...xs) {}
+  f5(1);
+
+  function f6(x = 1, y) {}
+  assert.throws(f6, TypeError);
+  assert.throws(() => f6(2), TypeError);
+  f6(1, 2);
+
+  function f7(x, y = 1, z) {}
+  assert.throws(f7, TypeError);
+  assert.throws(() => f7(1), TypeError);
+  assert.throws(() => f7(1, 2), TypeError);
+  f7(1, 2, 3);
+  f7(1, 2, 3, 4);
+
+  function f8({x} = {x :1}) {}
+  f8();
+  f8(1);
+
+  function f9({x}) {}
+  assert.throws(f9, TypeError);
+  f9({x: 1});
+
+  let f10 = function(x) {}
+  assert.throws(f10, TypeError);
+  f10(1);
+})();
+
+class C {
+  m(x) { 'use strong'; }
+  set x(_) { 'use strong'; }
+}
+
+assert.throws(() => new C().m(), TypeError);
+new C().m(1);
+
+let descr = Object.getOwnPropertyDescriptor(C.prototype, 'x');
+assert.throws(() => {
+  descr.set();
+}, TypeError);
+descr.set(1);
+
+(() => {
+  class C {
+    m(x) { 'use strong'; }
+    set x(_) { 'use strong'; }
+  }
+
+  assert.throws(() => new C().m(), TypeError);
+  new C().m(1);
+
+  let descr = Object.getOwnPropertyDescriptor(C.prototype, 'x');
+  assert.throws(() => {
+    descr.set();
+  }, TypeError);
+  descr.set(1);
+})();
+
+// Cannot verify arrow functions because arrow functions have no arguments
+// object.

--- a/test/unit/staticsemantics/ExpectedArgumentCount.js
+++ b/test/unit/staticsemantics/ExpectedArgumentCount.js
@@ -1,0 +1,56 @@
+// Copyright 2011 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {suite, test, assert} from '../../unit/unitTestRunner.js';
+import {
+  FORMAL_PARAMETER_LIST,
+  FUNCTION_DECLARATION
+} from '../../../src/syntax/trees/ParseTreeType.js';
+import {Parser} from '../../../src/syntax/Parser.js';
+import {SourceFile} from '../../../src/syntax/SourceFile.js';
+import expectedArgumentCount from '../../../src/staticsemantics/ExpectedArgumentCount.js';
+
+suite('ExpectedArgumentCount.js', function() {
+
+  function assertExpectedArgumentCount(expected, code) {
+    test(code, () => {
+      var file = new SourceFile('inline', code);
+      var tree = new Parser(file).parseScript();
+      assert.equal(1, tree.scriptItemList.length);
+      var func = tree.scriptItemList[0];
+      assert.equal(func.type, FUNCTION_DECLARATION);
+      var params = func.parameterList;
+      assert.equal(params.type, FORMAL_PARAMETER_LIST);
+      assert.equal(expected, ExpectedArgumentCount(params));
+    });
+  }
+
+  assertExpectedArgumentCount(0, 'function f() {}');
+  assertExpectedArgumentCount(1, 'function f(x) {}');
+  assertExpectedArgumentCount(2, 'function f(x, y) {}');
+  assertExpectedArgumentCount(3, 'function f(x, y, z) {}');
+
+  assertExpectedArgumentCount(0, 'function f(...xs) {}');
+  assertExpectedArgumentCount(1, 'function f(x, ...xs) {}');
+  assertExpectedArgumentCount(2, 'function f(x = 1, y, ...xs) {}');
+
+  assertExpectedArgumentCount(0, 'function f(x = 0) {}');
+  assertExpectedArgumentCount(0, 'function f(x = 0, y = 1) {}');
+  assertExpectedArgumentCount(1, 'function f(x, y = 1) {}');
+  assertExpectedArgumentCount(2, 'function f(x = 0, y) {}');
+
+  assertExpectedArgumentCount(1, 'function f(x, {y} = {}) {}');
+
+  assertExpectedArgumentCount(3, 'function f(x = 0, y = 1, z) {}');
+});


### PR DESCRIPTION
In strong mode it is illegal to call a function with too few arguments.

This introduces a new option: --strong-mode-runtime which injects
runtime checks as needed. This is of by default for strong mode at the
moment but we can revisit the default for this later.