### PR TITLE
Move parameter override to ParameterTransformer

### DIFF
--- a/src/codegeneration/DefaultParametersTransformer.js
+++ b/src/codegeneration/DefaultParametersTransformer.js
@@ -100,13 +100,4 @@ export class DefaultParametersTransformer extends ParameterTransformer {
 
     return new FormalParameterList(tree.location, parameters);
   }
-
-  transformConstructorType(tree) {
-    return tree;
-  }
-
-  transformFunctionType(tree) {
-    return tree;
-  }
-
 }

--- a/src/codegeneration/ParameterTransformer.js
+++ b/src/codegeneration/ParameterTransformer.js
@@ -80,4 +80,12 @@ export class ParameterTransformer extends TempVarTransformer {
   get parameterStatements() {
     return stack[stack.length - 1];
   }
+
+  transformConstructorType(tree) {
+    return tree;
+  }
+
+  transformFunctionType(tree) {
+    return tree;
+  }
 }

--- a/src/codegeneration/RestParameterTransformer.js
+++ b/src/codegeneration/RestParameterTransformer.js
@@ -64,12 +64,4 @@ export class RestParameterTransformer extends ParameterTransformer {
 
     return transformed;
   }
-
-  transformConstructorType(tree) {
-    return tree;
-  }
-
-  transformFunctionType(tree) {
-    return tree;
-  }
 }


### PR DESCRIPTION
At the moment all subclasses override it to not transform type
annotations but the ParameterTransformer should never transform
parameters in type annotations.