### PR TITLE
Refactor scanner to not use a dummy class

### DIFF
--- a/src/traceur.js
+++ b/src/traceur.js
@@ -40,13 +40,11 @@ export let util = {
 };
 
 import {Parser} from './syntax/Parser.js';
-import {Scanner} from './syntax/Scanner.js';
 import {Script} from './syntax/trees/ParseTrees.js';
 import {SourceFile} from './syntax/SourceFile.js';
 
 export let syntax = {
   Parser,
-  Scanner,
   SourceFile,
   trees: {
     Script


### PR DESCRIPTION
Previously we had a class for the scanner but most of the
implementation used non instance state for performance. Now, we use
functions that operate on the module local variables.