### PR TITLE
Correctly parse and transform `yield`

### DIFF
--- a/src/codegeneration/generator/GeneratorTransformer.js
+++ b/src/codegeneration/generator/GeneratorTransformer.js
@@ -96,8 +96,6 @@ export class GeneratorTransformer extends CPSTransformer {
       ({expression, machine} = this.expressionToStateMachine(tree.expression));
     } else {
       expression = this.transformAny(tree.expression);
-      if (!expression)
-        expression = createUndefinedExpression();
     }
 
     if (tree.isYieldFor)

--- a/src/codegeneration/generator/YieldState.js
+++ b/src/codegeneration/generator/YieldState.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {State} from './State.js';
-import {parseStatement} from '../PlaceholderParser.js';
+import {createReturnStatement} from '../ParseTreeFactory.js';
 
 /**
  * Represents a simple yield expression that has been added to a StateMachine.
@@ -56,8 +56,7 @@ export class YieldState extends State {
       //      $ctx.state = enclosingFinally.finallyState;
       //      $fallThrough = this.fallThroughState;
       ...State.generateAssignState(enclosingFinally, this.fallThroughState),
-
-      parseStatement `return ${this.expression}`,
+      createReturnStatement(this.expression)
     ];
   }
 }

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -1223,8 +1223,10 @@ export class ParseTreeWriter extends ParseTreeVisitor {
    */
   visitReturnStatement(tree) {
     this.write_(RETURN);
-    this.writeSpace_(tree.expression);
-    this.visitAny(tree.expression);
+    if (tree.expression) {
+      this.writeSpace_(tree.expression);
+      this.visitAny(tree.expression);
+    }
     this.write_(SEMI_COLON);
   }
 

--- a/test/feature/Yield/YieldNoExpression.js
+++ b/test/feature/Yield/YieldNoExpression.js
@@ -1,0 +1,19 @@
+function sum(x, y) {
+  return x + y;
+}
+
+function* f() {
+  yield;
+  yield sum(yield, yield);
+  return yield;
+}
+
+var g = f(42);
+
+assert.deepEqual(g.next(), {value: undefined, done: false});
+assert.deepEqual(g.next(), {value: undefined, done: false});
+assert.deepEqual(g.next(3), {value: undefined, done: false});
+assert.deepEqual(g.next(39), {value: 42, done: false});
+assert.deepEqual(g.next(), {value: undefined, done: false});
+assert.deepEqual(g.next('abc'), {value: 'abc', done: true});
+assert.deepEqual(g.next(), {value: undefined, done: true});

--- a/test/unit/codegeneration/ExplodeExpressionTransformer.js
+++ b/test/unit/codegeneration/ExplodeExpressionTransformer.js
@@ -104,6 +104,18 @@ suite('ExplodeExpressionTransformer.js', function() {
   testExplode('YieldExpression', 'yield (yield a.b)',
       '$0 = a.b, $1 = yield $0, $2 = yield $1, $2');
 
+  testExplode('YieldExpression', 'yield', '$0 = yield, $0');
+  testExplode('YieldExpression', '(yield, yield)', '$0 = yield, $1 = yield, $1');
+  testExplode('YieldExpression', '[yield, yield]',
+      '$0 = yield, $1 = yield, $2 = [$0, $1], $2');
+  testExplode('YieldExpression', 'fun(yield, yield)',
+      '$0 = yield, $1 = yield, $2 = fun($0, $1), $2');
+  testExplode('YieldExpression', '{x: yield}', '$0 = yield, $1 = {x: $0}, $1');
+  testExplode('YieldExpression', '{x: yield, y: yield}',
+      '$0 = yield, $1 = yield, $2 = {\n  x: $0,\n  y: $1\n}, $2');
+  testExplode('YieldExpression', 'true ? yield : yield',
+      'true ? ($0 = yield, $2 = $0) : ($1 = yield, $2 = $1), $2');
+
   testExplode('CommaExpression', '1, 2', '1, 2');
   testExplode('CommaExpression', 'a.b, c.d', '$0 = a.b, $1 = c.d, $1');
 


### PR DESCRIPTION
We didn't handle expression-less yield expressions correctly before.

Fixes #1899