### PR TITLE
Ensure export star does not export default

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -369,7 +369,7 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
       if (exportStarBinding) {
         setterStatements = setterStatements.concat(parseStatements `
           Object.keys($__m).forEach(function(p) {
-            if (!$__exportNames[p])
+            if (p !== 'default' && !$__exportNames[p])
               $__export(p, $__m[p]);
           });
         `);

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -429,7 +429,7 @@
         var names = $getOwnPropertyNames(arguments[i]);
         for (var j = 0; j < names.length; j++) {
           var name = names[j];
-          if (name === '__esModule' || isSymbolString(name)) continue;
+          if (name === '__esModule' || name === 'default' || isSymbolString(name)) continue;
           (function(mod, name) {
             $defineProperty(object, name, {
               get: function() { return mod[name]; },

--- a/test/feature/Modules/ExportStar.module.js
+++ b/test/feature/Modules/ExportStar.module.js
@@ -4,3 +4,4 @@ assert.equal(1, o.a);
 assert.equal(2, o.b);
 assert.equal(3, o.c);
 assert.equal(4, o.d);
+assert.equal(undefined, o.default);

--- a/test/feature/Modules/resources/n.js
+++ b/test/feature/Modules/resources/n.js
@@ -1,2 +1,3 @@
 export var c = 3;
 export var d = 4;
+export default 5;

--- a/test/node-instantiate-test.js
+++ b/test/node-instantiate-test.js
@@ -129,6 +129,7 @@ suite('instantiate', function() {
         ma.reassign(); // updates the a export variable to 10, which should push the change out
         assert.equal(mb.a, 10);
         assert.equal(mb.b, 'localvalue');
+        assert.equal(mb.default, undefined);
         done();
       });
     }).catch(done);


### PR DESCRIPTION
Export * is not supposed to export the default export.

> 15.2.1.16.2 GetExportedNames( exportStarSet ) Concrete Method

>    For each ExportEntry Record e in module.[[StarExportEntries]], do
    Let requestedModule be HostResolveImportedModule(module, e.[[ModuleRequest]]).
    ReturnIfAbrupt(requestedModule).
    Let starNames be requestedModule.GetExportedNames(exportStarSet).
    For each element n of starNames, do
    If SameValue(n, "default") is false, then
    If n is not an element of exportedNames, then
    Append n to exportedNames.

> 15.2.1.16.3 ResolveExport( exportName, resolveSet, exportStarSet ) Concrete Method

>    If SameValue(exportName, "default") is true, then
    Assert: A default export was not explicitly defined by this module.
    Throw a SyntaxError exception.
    NOTE A default export cannot be provided by an export *.