### PR TITLE
Rename module format option 'register' -> 'bootstrap'

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -80,7 +80,7 @@ export class Compiler {
     return new Compiler(options).compile(content);
   }
   /**
-   * Use Traceur to compile ES6 module source code to 'register' module format.
+   * Use Traceur to compile ES6 module source code to 'bootstrap' module format.
    *
    * @param  {string} content ES6 source code.
    * @param  {Object=} options Traceur options to override defaults.
@@ -88,7 +88,7 @@ export class Compiler {
    */
   static module(content, options = {}) {
     options = new Options(options);  // fresh copy, don't write on argument.
-    options.modules = 'register';
+    options.modules = 'bootstrap';
     return new Compiler(options).compile(content);
   }
   /**

--- a/src/Options.js
+++ b/src/Options.js
@@ -47,7 +47,7 @@ export const optionsV01 = enumerableOnlyObject({
   lowResolutionSourceMap: false,
   memberVariables: false,
   moduleName: 'default',
-  modules: 'register',
+  modules: 'bootstrap',
   numericLiterals: true,
   outputLanguage: 'es5',
   properTailCalls: false,
@@ -92,7 +92,7 @@ let defaultValues = Object.create(null);
 let featureOptions = Object.create(null);
 let experimentalOptions = Object.create(null);
 let moduleOptions =
-    ['amd', 'commonjs', 'closure', 'instantiate', 'inline', 'register'];
+    ['amd', 'commonjs', 'closure', 'instantiate', 'inline', 'bootstrap'];
 
 const EXPERIMENTAL = 0;
 const ON_BY_DEFAULT = 1;
@@ -292,7 +292,7 @@ export class Options {
 
   set modules(value) {
     if (typeof value === 'boolean' && !value)
-      value = 'register';
+      value = 'bootstrap';
     if (moduleOptions.indexOf(value) === -1) {
       throw new Error('Invalid \'modules\' option \'' + value + '\', not in ' +
         moduleOptions.join(', '));
@@ -334,7 +334,7 @@ export class Options {
    * boolean values.
    */
   setDefaults() {
-    this.modules = 'register';
+    this.modules = 'bootstrap';
     this.moduleName = 'default';
     this.outputLanguage = 'es5';
     this.referrer = '';

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -142,7 +142,7 @@ export class FromOptionsTransformer extends MultiTransformer {
         case 'instantiate':
           append(InstantiateModuleTransformer);
           break;
-        case 'register':
+        case 'bootstrap':
           append(ModuleTransformer);
           break;
         default:

--- a/src/node/recursiveModuleCompile.js
+++ b/src/node/recursiveModuleCompile.js
@@ -137,7 +137,7 @@ function recursiveModuleCompile(fileNamesAndTypes, options) {
 
     if (input.type === 'script') {
       loadFunction = loader.loadAsScript;
-    } else if (optionsCopy.modules === 'register') {
+    } else if (optionsCopy.modules === 'bootstrap') {
       doEvaluateModule = true;
     }
 

--- a/test/node-api-test.js
+++ b/test/node-api-test.js
@@ -29,7 +29,7 @@ suite('node public api', function() {
   test('moduleName from filename with backslashes', function() {
     var compiler = new traceurAPI.NodeCompiler({
       // build ES6 style modules rather then cjs
-      modules: 'register',
+      modules: 'bootstrap',
 
       // single file compile defaults to moduleName false
       moduleName: true,
@@ -54,7 +54,7 @@ suite('node public api', function() {
   test('sourceRoot with backslashes', function() {
     var compiler = new traceurAPI.NodeCompiler({
       // build ES6 style modules rather then cjs
-      modules: 'register',
+      modules: 'bootstrap',
 
       // ensure the source map works
       sourceMaps: true
@@ -80,7 +80,7 @@ suite('node public api', function() {
   test('sourceRoot with full windows path and backslashes', function() {
     var compiler = new traceurAPI.NodeCompiler({
       // build ES6 style modules rather then cjs
-      modules: 'register',
+      modules: 'bootstrap',
 
       // ensure the source map works
       sourceMaps: true
@@ -105,7 +105,7 @@ suite('node public api', function() {
     var compiler = new traceurAPI.NodeCompiler({
 
       // build ES6 style modules rather then cjs
-      modules: 'register',
+      modules: 'bootstrap',
 
       // single file compile defaults to moduleName false
       moduleName: true,

--- a/test/unit/CompileOptions.js
+++ b/test/unit/CompileOptions.js
@@ -25,7 +25,7 @@ suite('options', function() {
     assert.isTrue(options.experimental);
 
     options.modules = false;
-    assert.equal(options.modules, 'register');
+    assert.equal(options.modules, 'bootstrap');
     options.modules = 'inline';
     assert.equal(options.modules, 'inline');
     assert.throws(function() {
@@ -70,7 +70,7 @@ suite('options', function() {
       blockBinding);
     assert.isFalse(CommandOptions.fromString('--classes=false').classes);
     assert.equal(CommandOptions.fromString('--modules=amd').modules,'amd');
-    assert.equal(CommandOptions.fromString('--modules=false').modules, 'register');
+    assert.equal(CommandOptions.fromString('--modules=false').modules, 'bootstrap');
     assert.equal(CommandOptions.fromString('--referrer=traceur@0.0.1').
       referrer,'traceur@0.0.1');
 

--- a/test/unit/node/api.js
+++ b/test/unit/node/api.js
@@ -36,7 +36,7 @@ suite('api.js', function() {
   });
 
   test('api compile filename', function() {
-    var options = {modules: 'register', moduleName: true};
+    var options = {modules: 'bootstrap', moduleName: true};
     var result = api.compile('var a = 1;', options, 'a.js');
     assert.equal(
         result.indexOf('System.registerModule("a.js", [], function() {'),
@@ -46,7 +46,7 @@ suite('api.js', function() {
 
   test('api compile require', function() {
     var options = {
-      modules: 'register',
+      modules: 'bootstrap',
       moduleName: true,
       require: true
     };


### PR DESCRIPTION
The current 'instantiate' wants the option named 'register'.