### PR TITLE
Fix parsing issue with trailing comma in destructuring

### DIFF
--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -168,6 +168,10 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   visitArrayLiteralExpression(tree) {
     this.write_(OPEN_SQUARE);
     this.writeList_(tree.elements, COMMA, false);
+    if (tree.elements[tree.elements.length - 1] === null) {
+      this.write_(COMMA);
+      this.writeSpace_();
+    }
     this.write_(CLOSE_SQUARE);
   }
 
@@ -177,6 +181,10 @@ export class ParseTreeWriter extends ParseTreeVisitor {
   visitArrayPattern(tree) {
     this.write_(OPEN_SQUARE);
     this.writeList_(tree.elements, COMMA, false);
+    if (tree.elements[tree.elements.length - 1] === null) {
+      this.write_(COMMA);
+      this.writeSpace_();
+    }
     this.write_(CLOSE_SQUARE);
   }
 

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -3475,19 +3475,22 @@ export class Parser {
     let start = this.getTreeStartLocation_();
     let elements = [];
     this.eat_(OPEN_SQUARE);
-    let type;
-    while ((type = peekType()) !== CLOSE_SQUARE && type !== END_OF_FILE) {
-      this.parseElisionOpt_(elements);
-      if (this.peekRest_(peekType())) {
+    while (true) {
+      let type = peekType();
+      if (type === COMMA) {
+        elements.push(null);
+      } else if (this.peekSpread_(type)) {
         elements.push(this.parsePatternRestElement_(useBinding));
+        break;
+      } else if (type === CLOSE_SQUARE || type === END_OF_FILE) {
         break;
       } else {
         elements.push(this.parsePatternElement_(useBinding));
-        // Trailing commas are not allowed in patterns.
-        if (peek(COMMA) &&
-            !peekLookahead(CLOSE_SQUARE)) {
-          nextToken();
-        }
+      }
+
+      type = peekType();
+      if (type !== CLOSE_SQUARE) {
+        this.eat_(COMMA);
       }
     }
     this.eat_(CLOSE_SQUARE);

--- a/test/feature/Destructuring/ArrayPatternTrailingComma.js
+++ b/test/feature/Destructuring/ArrayPatternTrailingComma.js
@@ -1,0 +1,8 @@
+var [a, b, , ] = [0, 1, , ];
+assert.equal(a, 0);
+assert.equal(b, 1);
+
+var c, d;
+[c, d, , ] = [0, 1, , ];
+assert.equal(c, 0);
+assert.equal(d, 1);


### PR DESCRIPTION
Also make sure the ParseTreeWriter prints trailnig holes.