### PR TITLE
implement async generator methods

### DIFF
--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -1122,11 +1122,14 @@ export class ParseTreeWriter extends ParseTreeVisitor {
       this.writeSpace_();
     }
 
-    if (tree.isGenerator())
+    if (tree.isAsyncFunction() || tree.isAsyncGenerator())
+      this.write_(ASYNC);
+
+    if (tree.isGenerator() || tree.isAsyncGenerator())
       this.write_(STAR);
 
-    if (tree.isAsyncFunction())
-      this.write_(ASYNC);
+    if (tree.isAsyncGenerator())
+      this.writeSpace_();
 
     this.visitAny(tree.name);
     this.write_(OPEN_PAREN);

--- a/test/feature/AsyncGenerators/Method.js
+++ b/test/feature/AsyncGenerators/Method.js
@@ -1,0 +1,20 @@
+// Options: --async-generators --for-on --async-functions
+// Async.
+
+class C {
+  static async* f() {
+    yield 1;
+  }
+}
+
+(async function() {
+  var list = [];
+  var g = C.f();
+  for (var i on g) {
+    list.push(i);
+  }
+  assert.deepEqual(list, [1]);
+
+  done();
+})().catch(done);
+

--- a/test/feature/AsyncGenerators/Property.js
+++ b/test/feature/AsyncGenerators/Property.js
@@ -1,0 +1,20 @@
+// Options: --async-generators --for-on --async-functions
+// Async.
+
+var C = {
+  async* f() {
+    yield 1;
+  }
+};
+
+(async function() {
+  var list = [];
+  var g = C.f();
+  for (var i on g) {
+    list.push(i);
+  }
+  assert.deepEqual(list, [1]);
+
+  done();
+})().catch(done);
+


### PR DESCRIPTION
1. Correct identification of async generator contexts in the parser.
2. Allow for-on in async functions (not only generators). (Already worked by chance due to first bug.)
3. Implement async generator methods.
4. Implement async generator property definitions.
