### PR TITLE
Fix issue with missing parens

### DIFF
--- a/src/codegeneration/ArrowFunctionTransformer.js
+++ b/src/codegeneration/ArrowFunctionTransformer.js
@@ -16,6 +16,7 @@ import {ARGUMENTS, CONSTRUCTOR, THIS} from '../syntax/PredefinedName.js';
 import {AlphaRenamer} from './AlphaRenamer.js';
 import {FunctionExpression} from '../syntax/trees/ParseTrees.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
+import {ParenTrait} from './ParenTrait.js';
 import alphaRenameThisAndArguments from './alphaRenameThisAndArguments.js';
 import {FUNCTION_BODY, LITERAL_PROPERTY_NAME} from '../syntax/trees/ParseTreeType.js';
 import {FindThisOrArguments} from './FindThisOrArguments.js';
@@ -24,7 +25,6 @@ import {
   createCommaExpression,
   createFunctionBody,
   createIdentifierExpression,
-  createParenExpression,
   createReturnStatement,
   createThisExpression,
 } from './ParseTreeFactory.js';
@@ -45,7 +45,7 @@ function convertConciseBody(tree) {
  *
  * @see <a href="http://wiki.ecmascript.org/doku.php?id=strawman:arrow_function_syntax">strawman:arrow_function_syntax</a>
  */
-export class ArrowFunctionTransformer extends TempVarTransformer {
+export class ArrowFunctionTransformer extends ParenTrait(TempVarTransformer) {
   constructor(identifierGenerator, reporter, options) {
     super(identifierGenerator, reporter, options);
     this.inDerivedClass_ = false;
@@ -101,11 +101,11 @@ export class ArrowFunctionTransformer extends TempVarTransformer {
     }
 
     if (expressions.length === 0) {
-      return createParenExpression(functionExpression);
+      return functionExpression;
     }
 
     expressions.push(functionExpression);
-    return createParenExpression(createCommaExpression(expressions));
+    return createCommaExpression(expressions);
   }
 
   // This transforms the arrow function into:
@@ -128,7 +128,7 @@ export class ArrowFunctionTransformer extends TempVarTransformer {
     let functionExpression = new FunctionExpression(tree.location, null,
         tree.functionKind, parameterList, null, [], body);
 
-    return createParenExpression(functionExpression);
+    return functionExpression;
   }
 
   transformClassExpression(tree) {

--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -45,6 +45,7 @@ import {
   STRING
 } from '../syntax/TokenType.js';
 import {MakeStrictTransformer} from './MakeStrictTransformer.js';
+import {ParenTrait} from './ParenTrait.js';
 import {
   createEmptyParameterList,
   createExpressionStatement,
@@ -52,7 +53,6 @@ import {
   createIdentifierExpression as id,
   createMemberExpression,
   createObjectLiteralExpression,
-  createParenExpression,
   createPropertyNameAssignment,
   createThisExpression,
   createVariableStatement
@@ -68,6 +68,7 @@ import {
   transformConstructor,
   getInstanceInitExpression,
 } from './MemberVariableConstructorTransformer.js';
+
 
 // Interaction between ClassTransformer and SuperTransformer:
 // - The initial call to SuperTransformer will always be a transformBlock on
@@ -149,7 +150,7 @@ function functionExpressionToDeclaration(tree, name) {
       tree.parameterList, tree.typeAnnotation, tree.annotations, tree.body);
 }
 
-export class ClassTransformer extends TempVarTransformer {
+export class ClassTransformer extends ParenTrait(TempVarTransformer) {
   /**
    * @param {UniqueIdentifierGenerator} identifierGenerator
    * @param {ErrorReporter} reporter
@@ -343,7 +344,7 @@ export class ClassTransformer extends TempVarTransformer {
 
     this.popTempScope();
 
-    return createParenExpression(this.makeStrict_(expression));
+    return this.makeStrict_(expression);
   }
 
   transformPropertyMethodAssignment_(tree, homeObject, internalName,

--- a/src/codegeneration/ExponentiationTransformer.js
+++ b/src/codegeneration/ExponentiationTransformer.js
@@ -14,13 +14,14 @@
 
 import {ExplodeExpressionTransformer} from './ExplodeExpressionTransformer.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
+import {ParenTrait} from './ParenTrait.js';
 import {
   STAR_STAR,
   STAR_STAR_EQUAL
 } from '../syntax/TokenType.js';
 import {parseExpression} from './PlaceholderParser.js';
 
-export class ExponentiationTransformer extends TempVarTransformer {
+export class ExponentiationTransformer extends ParenTrait(TempVarTransformer) {
   transformBinaryExpression(tree) {
     switch (tree.operator.type) {
       case STAR_STAR:

--- a/src/codegeneration/ParenTrait.js
+++ b/src/codegeneration/ParenTrait.js
@@ -1,0 +1,133 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  ArgumentList,
+  ArrayLiteralExpression,
+  ExpressionStatement,
+  NewExpression,
+  ParenExpression,
+  VariableDeclaration,
+} from '../syntax/trees/ParseTrees.js';
+import {
+  CALL_EXPRESSION,
+  COMMA_EXPRESSION,
+  FUNCTION_EXPRESSION,
+  OBJECT_LITERAL_EXPRESSION,
+  OBJECT_PATTERN,
+  TEMPLATE_LITERAL_EXPRESSION,
+} from '../syntax/trees/ParseTreeType.js';
+
+function wrap(tree) {
+  return new ParenExpression(tree.location, tree);
+}
+
+/**
+ * This function is used as trait to generate a class that that adds parens
+ * around trees as needed.
+ *
+ * Usage:
+ *
+ *  class MyTransformer extends ParenTrait(ParseTreeTransformer) {
+ *    ...
+ *  }
+ *
+ * @param {Function} ParseTreeTransformerClass A class that extends
+ *     ParseTreeTransformer.
+ * @return {Function}
+ */
+export function ParenTrait(ParseTreeTransformerClass) {
+  return class extends ParseTreeTransformerClass {
+    transformVariableDeclaration(tree) {
+      let lvalue = this.transformAny(tree.lvalue);
+      let typeAnnotation = this.transformAny(tree.typeAnnotation);
+      let initializer = this.transformAny(tree.initializer);
+      if (initializer !== null && initializer.type === COMMA_EXPRESSION) {
+        initializer = wrap(initializer);
+      } else if (tree.lvalue === lvalue &&
+          tree.typeAnnotation === typeAnnotation &&
+          tree.initializer === initializer) {
+        return tree;
+      }
+      return new VariableDeclaration(tree.location, lvalue, typeAnnotation,
+                                     initializer);
+    }
+
+    transformExpressionStatement(tree) {
+      let expression = this.transformAny(tree.expression);
+      switch (expression.type) {
+        case OBJECT_LITERAL_EXPRESSION:
+        case OBJECT_PATTERN:
+        case FUNCTION_EXPRESSION:
+          expression = wrap(expression);
+          break;
+      }
+      if (tree.expression === expression) {
+        return tree;
+      }
+      return new ExpressionStatement(tree.location, expression);
+    }
+
+    transformNewExpression(tree) {
+      let operand = this.transformAny(tree.operand);
+      let args = this.transformAny(tree.args);
+      switch (operand.type) {
+        case CALL_EXPRESSION:
+        case TEMPLATE_LITERAL_EXPRESSION:
+          operand = wrap(operand);
+      }
+      if (operand === tree.operand && args === tree.args) {
+        return tree;
+      }
+      return new NewExpression(tree.location, operand, args);
+    }
+
+    transformExpressionList_(list) {
+      let expressions = this.transformList(list);
+      let newList = null;
+      for (let i = 0; i < list.length; i++) {
+        let expression = expressions[i];
+        if (expression !== null && expression.type === COMMA_EXPRESSION) {
+          expression = wrap(expression);
+          if (newList === null) {
+            newList = expressions.slice(0, i);
+          }
+          newList.push(expression);
+        } else if (newList !== null) {
+          newList.push(expression);
+        }
+      }
+      if (newList !== null) {
+        return newList;
+      }
+      return expressions;
+    }
+
+    transformArgumentList(tree) {
+      let args = this.transformExpressionList_(tree.args);
+      if (tree.args === args) {
+        return tree;
+      }
+      return new ArgumentList(tree.location, args);
+    }
+
+    transformArrayLiteralExpression(tree) {
+      let elements = this.transformExpressionList_(tree.elements);
+      if (tree.elements === elements) {
+        return tree;
+      }
+      return new ArrayLiteralExpression(tree.location, elements);
+    }
+  };
+}

--- a/src/codegeneration/TemplateLiteralTransformer.js
+++ b/src/codegeneration/TemplateLiteralTransformer.js
@@ -24,6 +24,7 @@ import {
   NewExpression
 } from '../syntax/trees/ParseTrees.js';
 import {LiteralToken} from '../syntax/LiteralToken.js';
+import {ParenTrait} from './ParenTrait.js';
 import {ParseTreeTransformer} from './ParseTreeTransformer.js';
 import {
   PERCENT,
@@ -201,25 +202,8 @@ function toCookedString(s) {
   return sb.join('');
 }
 
-export class TemplateLiteralTransformer extends ParseTreeTransformer {
-  transformNewExpression(tree) {
-    if (tree.operand) {
-      let operand = tree.operand;
-      do {
-        // If operand contains a tagged TemplateLiteral, parenthesize the entire
-        // operand.
-        if (operand.type === TEMPLATE_LITERAL_EXPRESSION &&
-            operand.operand !== null) {
-          tree = new NewExpression(tree.location,
-                                   createParenExpression(tree.operand),
-                                   tree.args);
-          break;
-        }
-      } while (operand = operand.operand);
-    }
-    return super.transformNewExpression(tree);
-  }
-
+export class TemplateLiteralTransformer extends
+    ParenTrait(ParseTreeTransformer) {
   transformTemplateLiteralExpression(tree) {
     if (!tree.operand) {
       return this.createDefaultTemplateLiteral(tree);

--- a/test/feature/Exponentiation/Basics.js
+++ b/test/feature/Exponentiation/Basics.js
@@ -22,4 +22,21 @@
 
   assert.equal(512, 2 ** (3 ** 2));
   assert.equal(512, 2 ** 3 ** 2);
+
+  var y = 4;
+  var z = y **= 2;
+  assert.equal(16, z);
+
+  function f(x) {
+    assert.equal(1, arguments.length);
+    return x;
+  }
+  var a = 2;
+  var b = [a **= 2];
+  assert.equal(4, a);
+  assert.equal(1, b.length);
+  assert.equal(4, b[0]);
+
+  assert.equal(64, f(a **= 3));
+  assert.equal(64, a);
 })();


### PR DESCRIPTION
This is by adding the parens when we see a comma expression in places
where do not expect commas (variable declarations, arrays and calls).

This also adds parens in case the expression of an expression statement
cannot start with the that expression. Currently this is function
expression and object/object pattern. This allows us to generate
cleaner code since we only add the parens for arrow functions as needed.