### PR TITLE
Enforce valid assignment target in the parser

### DIFF
--- a/src/staticsemantics/isValidSimpleAssignmentTarget.js
+++ b/src/staticsemantics/isValidSimpleAssignmentTarget.js
@@ -1,0 +1,45 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  IDENTIFIER_EXPRESSION,
+  MEMBER_EXPRESSION,
+  MEMBER_LOOKUP_EXPRESSION,
+  PAREN_EXPRESSION,
+} from '../syntax/trees/ParseTreeType.js';
+
+/**
+ * Matches "Static Semantics: IsValidSimpleAssignmentTarget" in the spec.
+ * @param {ParseTree} tree
+ * @return {boolean}
+ */
+export default function isValidSimpleAssignmentTarget(tree, isStrict) {
+  switch (tree.type) {
+    case IDENTIFIER_EXPRESSION: {
+      if (!isStrict) return true;
+      let {value} = tree.identifierToken;
+      return value !== 'arguments' && value !== 'eval';
+    }
+
+    case PAREN_EXPRESSION:
+      return isValidSimpleAssignmentTarget(tree.expression, isStrict);
+
+    case MEMBER_EXPRESSION:
+    case MEMBER_LOOKUP_EXPRESSION:
+      return true;
+
+    default:
+      return false;
+  }
+}

--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -131,19 +131,11 @@ export class ParseTree {
   /** @return {boolean} */
   isLeftHandSideExpression() {
     switch (this.type) {
-      case THIS_EXPRESSION:
-      case CLASS_EXPRESSION:
-      case SUPER_EXPRESSION:
-      case IDENTIFIER_EXPRESSION:
-      case LITERAL_EXPRESSION:
-      case ARRAY_LITERAL_EXPRESSION:
-      case OBJECT_LITERAL_EXPRESSION:
-      case NEW_EXPRESSION:
+      case ARRAY_PATTERN:
+      case IDENTIFIER_EXPRESSION:  // This does not handle strict mode.
       case MEMBER_EXPRESSION:
       case MEMBER_LOOKUP_EXPRESSION:
-      case CALL_EXPRESSION:
-      case FUNCTION_EXPRESSION:
-      case TEMPLATE_LITERAL_EXPRESSION:
+      case OBJECT_PATTERN:
         return true;
       case PAREN_EXPRESSION:
         return this.expression.isLeftHandSideExpression();

--- a/test/feature/Syntax/Error_IsValidSimpleAssignmentTarget.js
+++ b/test/feature/Syntax/Error_IsValidSimpleAssignmentTarget.js
@@ -1,0 +1,41 @@
+// Options: --async-functions --async-generators --for-on
+// Error: :16:1: Invalid left-hand side expression in assignment
+// Error: :17:1: Invalid left-hand side expression in assignment
+// Error: :18:3: Invalid left-hand side expression in prefix operation
+// Error: :19:3: Invalid left-hand side expression in prefix operation
+// Error: :20:1: Invalid left-hand side expression in postfix operation
+// Error: :21:1: Invalid left-hand side expression in postfix operation
+// Error: :25:3: Invalid left-hand side expression in assignment
+// Error: :26:3: Invalid left-hand side expression in assignment
+// Error: :30:5: Invalid left-hand side expression in assignment
+// Error: :33:12: Invalid left-hand side expression in assignment
+// Error: :35:6: Invalid left-hand side expression in assignment
+// Error: :37:6: Invalid left-hand side expression in assignment
+// Error: :40:7: Invalid left-hand side expression in assignment
+
+this = 1;
+42 = 1;
+++42
+--42
+42++
+42--
+
+function f() {
+  'use strict';
+  arguments = 1;
+  eval = 1;
+}
+
+var x;
+[x, 42] = [1, 2];
+
+var y;
+({y, prop: 42} = {y: 2, prop: 3});
+
+for (42 in {}) {}
+
+for (42 of []) {}
+
+async function* ag() {
+ for (42 on {}) {}
+}

--- a/test/feature/Syntax/IsValidSimpleAssignmentTarget.js
+++ b/test/feature/Syntax/IsValidSimpleAssignmentTarget.js
@@ -1,0 +1,38 @@
+(function() {
+  var eval = 1;
+  eval++;
+  ++eval;
+  eval--;
+  --eval;
+  [eval] = [eval];
+  ({eval} = {eval});
+  eval += 1;
+  eval /= 2;
+  assert.equal(1, eval);
+})();
+
+(function() {
+  var arguments = 1;
+  arguments++;
+  ++arguments;
+  arguments--;
+  --arguments;
+  [arguments] = [arguments];
+  ({arguments} = {arguments});
+  arguments += 1;
+  arguments /= 2;
+  assert.equal(1, arguments);
+})();
+
+(function() {
+  var yield = 1;
+  yield++;
+  ++yield;
+  yield--;
+  --yield;
+  [yield] = [yield];
+  ({yield} = {yield});
+  yield += 1;
+  yield /= 2;
+  assert.equal(1, yield);
+})();


### PR DESCRIPTION
This adds a function that matches the IsValidSimpleAssignmentTarget
spec algorithm

Fixes #1929