### PR TITLE
Add a simple tool for printing the dependencies

### DIFF
--- a/src/node/get-dependencies.js
+++ b/src/node/get-dependencies.js
@@ -1,0 +1,47 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ModuleSpecifierVisitor} from '../codegeneration/module/ModuleSpecifierVisitor.js';
+import {Parser} from '../syntax/Parser.js';
+import {SourceFile} from '../syntax/SourceFile.js';
+
+const {normalize, resolve, dirname} = require('path');
+const {readFileSync} = require('fs');
+
+function addDependencies(deps, path) {
+  path = resolve(path);
+  if (deps.has(path)) return;
+
+  let content = readFileSync(path, 'utf-8');
+  let sourceFile = new SourceFile(path, content);
+  let parser = new Parser(sourceFile);
+  let tree = parser.parseModule();
+  let options = {};
+  let visitor = new ModuleSpecifierVisitor(options);
+  visitor.visitAny(tree);
+
+  deps.add(path);
+  for (let spec of visitor.moduleSpecifiers) {
+    let resolved = resolve(dirname(path), spec);
+    addDependencies(deps, resolved);
+  }
+}
+
+export default function getDependencies(...paths) {
+  let deps = new Set();
+  for (let path of paths) {
+    addDependencies(deps, path);
+  }
+  return deps;
+}

--- a/test/unit/tools/get-dependencies.js
+++ b/test/unit/tools/get-dependencies.js
@@ -1,0 +1,41 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {suite, test, assert} from '../../unit/unitTestRunner.js';
+import getDependencies from '../../../src/node/get-dependencies.js';
+
+suite('get-dependencies.js', () => {
+  test('Empty', () => {
+    let deps = getDependencies();
+    assert.equal(deps.size, 0);
+  });
+
+  test('Basic', () => {
+    let path = './test/unit/runtime/resources/test_module.js';
+    let deps = getDependencies(path);
+    assert.equal(deps.size, 4);
+    let a = [...deps].map((d) => {
+      d = d.replace(/\\/g, '/');
+      let i = d.indexOf('/test/');
+      return d.slice(i);
+    });
+    assert.deepEqual(a, [
+      '/test/unit/runtime/resources/test_module.js',
+      '/test/unit/runtime/resources/test_a.js',
+      '/test/unit/runtime/resources/test_b.js',
+      '/test/unit/runtime/resources/test_c.js'
+    ]);
+  });
+
+});

--- a/tools/print-dependencies.js
+++ b/tools/print-dependencies.js
@@ -1,0 +1,29 @@
+// Copyright 2015 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import getDependencies from '../src/node/get-dependencies.js';
+
+function main() {
+  if (process.argv.length < 3) {
+    console.error('Usage: ./tval print-deps.js paths...')
+    return;
+  }
+
+  let deps = getDependencies(...process.argv.slice(2));
+  for (let name of deps) {
+    console.log(name);
+  }
+}
+
+main();


### PR DESCRIPTION
This adds a simple command line tool for printing the dependencies
of a module.

  $ ./tval tools/print-dependencies.js src/syntax/Parser.js