### PR TITLE
Fix Map/Set polyfill detection

### DIFF
--- a/src/runtime/polyfills/Set.js
+++ b/src/runtime/polyfills/Set.js
@@ -14,7 +14,6 @@
 
 import {
   isObject,
-  maybeAddIterator,
   registerPolyfill
 } from './utils.js';
 import {Map} from './Map.js'
@@ -93,15 +92,22 @@ Object.defineProperty(Set.prototype, 'keys', {
   value: Set.prototype.values
 });
 
+function needsPolyfill(global) {
+  var {Set, Symbol} = global;
+  if (!Set || !$traceurRuntime.hasNativeSymbol() ||
+      !Set.prototype[Symbol.iterator] || !Set.prototype.values) {
+    return true;
+  }
+  try {
+    return new Set([1]).size !== 1;
+  } catch (e) {
+    return false;
+  }
+}
+
 export function polyfillSet(global) {
-  var {Object, Symbol} = global;
-  if (!global.Set)
+  if (needsPolyfill(global)) {
     global.Set = Set;
-  var setPrototype = global.Set.prototype;
-  if (setPrototype.values) {
-    maybeAddIterator(setPrototype, setPrototype.values, Symbol);
-    maybeAddIterator(Object.getPrototypeOf(new global.Set().values()),
-        function() { return this; }, Symbol);
   }
 }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -459,10 +459,15 @@
       return argument;
     }
 
+    var hasNativeSymbol;
+
     function polyfillSymbol(global, Symbol) {
       if (!global.Symbol) {
         global.Symbol = Symbol;
         Object.getOwnPropertySymbols = getOwnPropertySymbols;
+        hasNativeSymbol = false;
+      } else {
+        hasNativeSymbol = true;
       }
       if (!global.Symbol.iterator) {
         global.Symbol.iterator = Symbol('Symbol.iterator');
@@ -470,6 +475,10 @@
       if (!global.Symbol.observer) {
         global.Symbol.observer = Symbol('Symbol.observer');
       }
+    }
+
+    function hasNativeSymbolFunc() {
+      return hasNativeSymbol;
     }
 
     function setupGlobals(global) {
@@ -494,6 +503,7 @@
       getOwnHashObject: getOwnHashObject,
       getOwnPropertyDescriptor: $getOwnPropertyDescriptor,
       getOwnPropertyNames: $getOwnPropertyNames,
+      hasNativeSymbol: hasNativeSymbolFunc,
       initTailRecursiveFunction: initTailRecursiveFunction,
       isObject: isObject,
       isPrivateName: isPrivateName,


### PR DESCRIPTION
Safari does not support ES6 Map/Set correctly which leads to trouble.
Be more strict in detecting whether the native Map/Set is good enough.

Fixes #1650, #1810