### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "transpiler"
   ],
   "author": "Traceur Authors",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=0.10"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Updated to "Apache-2.0" per https://spdx.org/licenses/