### PR TITLE
Implement bulk re-exports for instantiate setter perf

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -349,28 +349,26 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
 
       // then do export bindings of re-exported dependencies
       if (externalExportBindings) {
-        let reexports = {};
+        let reexports = Object.create(null);
         externalExportBindings.forEach(({exportName, importName}) => {
           reexports[exportName] = importName === null ?
               parseExpression `$__m` : parseExpression `$__m.${importName}`;
         });
         setterStatements.push(
-          parseStatement `$__export(${createObjectLiteral(reexports)})`
-        );
+            parseStatement `$__export(${createObjectLiteral(reexports)})`);
       }
 
       // create local module bindings
       if (moduleBinding) {
         setterStatements.push(
-          parseStatement `${id(moduleBinding)} = $__m;`
-        );
+            parseStatement `${id(moduleBinding)} = $__m;`);
       }
 
       // finally run export * if applying to this dependency, for not-already
       // exported dependencies
       if (exportStarBinding) {
         setterStatements = setterStatements.concat(parseStatements `
-          var exportObj = {};
+          var exportObj = Object.create(null);
           Object.keys($__m).forEach(function(p) {
             if (p !== 'default' && !$__exportNames[p])
               exportObj[p] = $__m[p];

--- a/third_party/es6-module-loader/loader.js
+++ b/third_party/es6-module-loader/loader.js
@@ -687,7 +687,16 @@ function logloads(loads) {
         // NB This should be an Object.defineProperty, but that is very slow.
         //    By disaling this module write-protection we gain performance.
         //    It could be useful to allow an option to enable or disable this.
-        moduleObj[name] = value;
+
+        // bulk export object
+        if (typeof name == 'object') {
+          for (var p in name)
+            moduleObj[p] = name[p];
+        }
+        // single export name / value pair
+        else {
+          moduleObj[name] = value;
+        }
 
         for (var i = 0, l = module.importers.length; i < l; i++) {
           var importerModule = module.importers[i];


### PR DESCRIPTION
Aurelia had some issues with bulk exports causing performance bottlenecks due to the repeated bindings being called in quadratic multiples of the depth of `export *` usage. This function flattens the binding call in one go. It may be worth always having `$__export({ name: 'value' })` as an object so we don't need to overload the function, so could look at a PR to do this if you think it is worthwhile, but the named form of `$__export(name, 'value')` will still be necessary for backwards compatibility for a while regardless.

Associated ModuleLoader PR is at https://github.com/ModuleLoader/es6-module-loader/pull/387.