### PR TITLE
Add super support to object literals

### DIFF
--- a/src/codegeneration/ClassTransformer.js
+++ b/src/codegeneration/ClassTransformer.js
@@ -25,17 +25,14 @@ import {
   PropertyMethodAssignment,
   SetAccessor
 } from '../syntax/trees/ParseTrees.js';
-import {
-  createBindingIdentifier,
-  createIdentifierToken
-} from '../codegeneration/ParseTreeFactory.js';
+import {createBindingIdentifier} from '../codegeneration/ParseTreeFactory.js';
 import {
   COMPUTED_PROPERTY_NAME,
   GET_ACCESSOR,
+  LITERAL_PROPERTY_NAME,
   PROPERTY_METHOD_ASSIGNMENT,
   SET_ACCESSOR,
 } from '../syntax/trees/ParseTreeType.js';
-import {SuperTransformer} from './SuperTransformer.js';
 import {TempVarTransformer} from './TempVarTransformer.js';
 import {
   CONST,
@@ -46,32 +43,15 @@ import {
 import {MakeStrictTransformer} from './MakeStrictTransformer.js';
 import {ParenTrait} from './ParenTrait.js';
 import {
-  createEmptyParameterList,
-  createFunctionBody,
   createIdentifierExpression as id,
-  createMemberExpression,
   createObjectLiteralExpression,
-  createThisExpression,
   createVariableStatement
 } from './ParseTreeFactory.js';
 import {hasUseStrict} from '../semantics/util.js';
 import {
   parseExpression,
-  parseStatements
+  parsePropertyDefinition,
 } from './PlaceholderParser.js';
-import {propName} from '../staticsemantics/PropName.js';
-
-
-// Interaction between ClassTransformer and SuperTransformer:
-// - The initial call to SuperTransformer will always be a transformBlock on
-//   the body of a function -- method, getter, setter, or constructor.
-// - SuperTransformer will never see anything that has not been touched first
-//   by ClassTransformer and (if applicable) a previous invocation of
-//   SuperTransformer on the functions of any inner classes. [see ref_1]
-// - This means that SuperTransformer should only ever see desugared class
-//   declarations, and should never see any super expressions that refer to
-//   any inner (or outer) classes.
-
 
 // Maximally minimal classes
 //
@@ -99,6 +79,7 @@ import {propName} from '../staticsemantics/PropName.js';
 //     }
 //   }, {}, B);
 //
+// The super property and super calls are transformed in the SuperTransformer.
 
 function classCall(func, object, staticObject, superClass) {
   if (superClass) {
@@ -140,6 +121,33 @@ function functionExpressionToDeclaration(tree, name) {
   }
   return new FunctionDeclaration(tree.location, name, tree.functionKind,
       tree.parameterList, tree.typeAnnotation, tree.annotations, tree.body);
+}
+
+function removeStaticModifier(tree) {
+  switch (tree.type) {
+    case GET_ACCESSOR:
+      return new GetAccessor(tree.location, false, tree.name,
+          tree.typeAnnotation, tree.annotations, tree.body);
+    case SET_ACCESSOR:
+      return new SetAccessor(tree.location, false, tree.name,
+          tree.parameterList, tree.annotations, tree.body);
+    case PROPERTY_METHOD_ASSIGNMENT:
+      return new PropertyMethodAssignment(tree.location, false,
+          tree.functionKind, tree.name, tree.parameterList, tree.typeAnnotation,
+          tree.annotations, tree.body, tree.debugName);
+    default:
+      throw new Error('unreachable');
+  }
+}
+
+export default function isConstructor(tree) {
+  if (tree.type !== PROPERTY_METHOD_ASSIGNMENT || tree.isStatic ||
+      tree.functionKind !== null) {
+    return false;
+  }
+  let {name} = tree;
+  return name.type === LITERAL_PROPERTY_NAME &&
+      name.literalToken.value === CONSTRUCTOR;
 }
 
 export class ClassTransformer extends ParenTrait(TempVarTransformer) {
@@ -196,12 +204,6 @@ export class ClassTransformer extends ParenTrait(TempVarTransformer) {
     return MakeStrictTransformer.transformTree(tree);
   }
 
-  /**
-   * Transforms a single class declaration
-   *
-   * @param {ClassDeclaration} tree
-   * @return {ParseTree}
-   */
   transformClassDeclaration(tree) {
     // `class C {}` is equivalent to `let C = class C {};`
     // Convert to class expression and transform that instead.
@@ -214,86 +216,40 @@ export class ClassTransformer extends ParenTrait(TempVarTransformer) {
   }
 
   transformClassExpression(tree) {
-    this.pushTempScope();
-
-    let name;
-    if (tree.name)
-      name = tree.name.identifierToken;
-    else
-      name = createIdentifierToken(this.getTempIdentifier());
-
-    let internalName = id(`${name}`);
-
-    let oldState = this.state_;
-    this.state_ = {hasSuper: false};
     let superClass = this.transformAny(tree.superClass);
+    let elements = this.transformList(tree.elements);
+    let annotations = this.transformList(tree.annotations);
 
-    let protoElements = [], staticElements = [];
-    let constructor;
-
-    tree.elements.forEach((tree) => {
-      let elements, homeObject, initVars;
-      if (tree.isStatic) {
-        elements = staticElements;
-        homeObject = internalName;
-      } else {
-        elements = protoElements;
-        homeObject = createMemberExpression(internalName, 'prototype');
+    let constructor = null;
+    let protoElements = elements.filter((tree) => {
+      if (tree.isStatic) return false;
+      if (isConstructor(tree)) {
+        constructor = tree;
+        return false;
       }
-
-      switch (tree.type) {
-        case GET_ACCESSOR:
-          elements.push(
-              this.transformGetAccessor_(tree, homeObject, internalName));
-          break;
-
-        case SET_ACCESSOR:
-          elements.push(
-              this.transformSetAccessor_(tree, homeObject, internalName));
-          break;
-
-        case PROPERTY_METHOD_ASSIGNMENT:
-          if (!tree.isStatic && propName(tree) === CONSTRUCTOR) {
-            constructor = tree;
-          } else {
-            let transformed = this.transformPropertyMethodAssignment_(
-                tree, homeObject, internalName, name);
-            elements.push(transformed);
-          }
-          break;
-
-        default:
-          throw new Error(`Unexpected class element: ${tree.type}`);
-      }
+      return true;
     });
+    let staticElements =
+        elements.filter((tree) => tree.isStatic).map(removeStaticModifier);
 
-    let object = createObjectLiteralExpression(protoElements);
+    let protoObject = createObjectLiteralExpression(protoElements);
     let staticObject = createObjectLiteralExpression(staticElements);
-    let func;
 
     if (!constructor) {
-      func = this.getDefaultConstructor_(tree, internalName);
-    } else {
-      let homeObject = createMemberExpression(internalName, 'prototype');
-      let transformedCtor = this.transformPropertyMethodAssignment_(
-          constructor, homeObject, internalName, CONSTRUCTOR);
-      func = new FunctionExpression(tree.location, tree.name, false,
-          transformedCtor.parameterList, null, [], transformedCtor.body);
+      constructor = this.getDefaultConstructor_(tree);
     }
+    let func = new FunctionExpression(tree.location, tree.name, null,
+                                      constructor.parameterList, null,
+                                      annotations,
+                                      constructor.body);
 
-    let state = this.state_;
-    this.state_ = oldState;
-
-    let hasSuper = state.hasSuper;
     let expression;
-
-    if (hasSuper || tree.name) {
-      // We need a binding name that can be referenced in the super calls and
-      // we hide this name in an IIFE.
-
+    if (tree.name) {
       let functionStatement;
-      if (tree.name &&
-          !this.options.transformOptions.blockBinding &&
+      let name = tree.name.identifierToken;
+      let nameId = id(`${name}`);
+
+      if (!this.options.transformOptions.blockBinding &&
           this.options.parseOptions.blockBinding) {
         functionStatement = createVariableStatement(CONST, tree.name, func);
       } else {
@@ -303,104 +259,30 @@ export class ClassTransformer extends ParenTrait(TempVarTransformer) {
       if (superClass) {
         expression = parseExpression `function($__super) {
           ${functionStatement};
-          return ($traceurRuntime.createClass)(${internalName}, ${object},
+          return ($traceurRuntime.createClass)(${nameId}, ${protoObject},
                                                ${staticObject}, $__super);
         }(${superClass})`;
       } else {
         expression = parseExpression `function() {
           ${functionStatement};
-          return ($traceurRuntime.createClass)(${internalName}, ${object},
+          return ($traceurRuntime.createClass)(${nameId}, ${protoObject},
                                                ${staticObject});
         }()`;
       }
     } else {
-      expression = classCall(func, object, staticObject, superClass);
+      expression = classCall(func, protoObject, staticObject, superClass);
     }
-
-    this.popTempScope();
 
     return this.makeStrict_(expression);
   }
 
-  transformPropertyMethodAssignment_(tree, homeObject, internalName,
-                                     originalName) {
-    let parameterList = this.transformAny(tree.parameterList);
-    let body = this.transformSuperInFunctionBody_(
-        tree.body, homeObject, internalName);
-
-    if (!tree.isStatic &&
-        parameterList === tree.parameterList &&
-        body === tree.body) {
-      return tree;
-    }
-
-    let debugName = tree.debugName;
-    if (this.options.showDebugNames_) {
-      debugName = classMethodDebugName(originalName,
-                                       methodNameFromTree(tree.name), isStatic);
-    }
-
-    let isStatic = false;
-    return new PropertyMethodAssignment(tree.location, isStatic,
-        tree.functionKind, tree.name, parameterList, tree.typeAnnotation,
-        tree.annotations, body, debugName);
-  }
-
-  transformGetAccessor_(tree, homeObject, internalName) {
-    let body =
-        this.transformSuperInFunctionBody_(tree.body, homeObject, internalName);
-    if (!tree.isStatic && body === tree.body)
-      return tree;
-    // not static
-    return new GetAccessor(tree.location, false, tree.name, tree.typeAnnotation,
-                           tree.annotations, body);
-  }
-
-  transformSetAccessor_(tree, homeObject, internalName) {
-    let parameterList = this.transformAny(tree.parameterList);
-    let body =
-        this.transformSuperInFunctionBody_(tree.body, homeObject, internalName);
-    if (!tree.isStatic && body === tree.body)
-      return tree;
-    return new SetAccessor(tree.location, false, tree.name, parameterList,
-                           tree.annotations, body);
-  }
-
-  transformSuperInFunctionBody_(tree, homeObject, internalName) {
-    this.pushTempScope();
-    let thisName = this.getTempIdentifier();
-    let thisDecl = createVariableStatement(VAR, thisName,
-                                           createThisExpression());
-    let superTransformer = new SuperTransformer(this, homeObject,
-                                                thisName, internalName);
-    // ref_1: the inner transformFunctionBody call is key to proper super nesting.
-    let transformedTree =
-        superTransformer.transformFunctionBody(this.transformFunctionBody(tree));
-
-    if (superTransformer.hasSuper)
-      this.state_.hasSuper = true;
-
-    this.popTempScope();
-
-    if (superTransformer.nestedSuper)
-      return createFunctionBody([thisDecl].concat(transformedTree.statements));
-    return transformedTree;
-  }
-
-  getDefaultConstructor_(tree, internalName) {
-    let constructorParams = createEmptyParameterList();
-    let statements;
+  getDefaultConstructor_(tree) {
     if (tree.superClass) {
-      statements = parseStatements `$traceurRuntime.superConstructor(
-          ${internalName}).apply(this, arguments)`;
-      constructorBody = createFunctionBody(statements);
-      this.state_.hasSuper = true;
-    } else {
-      statements = [];
+      let name = id(tree.name.identifierToken);
+      return parsePropertyDefinition `constructor() {
+        $traceurRuntime.superConstructor(${name}).apply(this, arguments)
+      }`;
     }
-    let constructorBody = createFunctionBody(statements);
-
-    return new FunctionExpression(tree.location, tree.name, false,
-                                  constructorParams, null, [], constructorBody);
+    return parsePropertyDefinition `constructor() {}`;
   }
 }

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -40,6 +40,7 @@ import {PropertyNameShorthandTransformer} from './PropertyNameShorthandTransform
 import {RegularExpressionTransformer} from './RegularExpressionTransformer.js';
 import {RestParameterTransformer} from './RestParameterTransformer.js';
 import {SpreadTransformer} from './SpreadTransformer.js';
+import {SuperTransformer} from './SuperTransformer.js';
 import {SymbolTransformer} from './SymbolTransformer.js';
 import {TemplateLiteralTransformer} from './TemplateLiteralTransformer.js';
 import {TypeAssertionTransformer} from './TypeAssertionTransformer.js';
@@ -151,16 +152,24 @@ export class FromOptionsTransformer extends MultiTransformer {
       }
     }
 
-    if (transformOptions.arrowFunctions)
-      append(ArrowFunctionTransformer);
-
+    // MemberVariableTransformer needs to be done before SuperTransformer.
     if (transformOptions.memberVariables) {
       append(MemberVariableTransformer);
     }
 
+    if (transformOptions.classes) {
+      append(SuperTransformer);
+    }
+
+    // ArrowFunctionTransformer needs to be done after SuperTransformer.
+    if (transformOptions.arrowFunctions) {
+      append(ArrowFunctionTransformer);
+    }
+
     // ClassTransformer needs to come before ObjectLiteralTransformer.
-    if (transformOptions.classes)
+    if (transformOptions.classes) {
       append(ClassTransformer);
+    }
 
     if (transformOptions.propertyMethods ||
         transformOptions.computedPropertyNames ||

--- a/test/feature/SuperObjectLiteral/Error_Super.js
+++ b/test/feature/SuperObjectLiteral/Error_Super.js
@@ -1,0 +1,10 @@
+// Error: :8:17: Unexpected token ;
+
+var p = {};
+
+var o = {
+  __proto__: p,
+  method() {
+    return super;
+  }
+};

--- a/test/feature/SuperObjectLiteral/SuperChaining.js
+++ b/test/feature/SuperObjectLiteral/SuperChaining.js
@@ -1,0 +1,30 @@
+var a = {
+  foo() {
+    return 'A';
+  }
+};
+
+var b = {
+  __proto__: a,
+  foo() {
+    return super.foo() + ' B';
+  }
+};
+
+var c = {
+  __proto__: b,
+  foo() {
+    return super.foo() + ' C';
+  }
+};
+
+var d = {
+  __proto__: c,
+  foo() {
+    return super.foo() + ' D';
+  }
+};
+
+// ----------------------------------------------------------------------------
+
+assert.equal('A B C D', d.foo());

--- a/test/feature/SuperObjectLiteral/SuperChangeProto.js
+++ b/test/feature/SuperObjectLiteral/SuperChangeProto.js
@@ -1,0 +1,22 @@
+var log = '';
+
+var base  = {
+  p() { log += '[base]'; }
+};
+
+var otherBase = {
+  p() { log += '[otherBase]'; }
+};
+
+var derived = {
+  __proto__: base,
+  p() {
+    log += '[derived]';
+    super.p();
+    derived.__proto__ = otherBase;
+    super.p();
+  }
+};
+
+derived.p();
+assert.equal(log, '[derived][base][otherBase]');

--- a/test/feature/SuperObjectLiteral/SuperInArrow.js
+++ b/test/feature/SuperObjectLiteral/SuperInArrow.js
@@ -1,0 +1,20 @@
+var x;
+
+var p = {
+  m(v) {
+    x = v;
+  }
+};
+
+var o = {
+  __proto__: p,
+  n(x) {
+    var f = (x) => {
+      super.m(x);
+    };
+    f(x);
+  }
+};
+
+o.n(42);
+assert.equal(x, 42);

--- a/test/feature/SuperObjectLiteral/SuperNestedObject.js
+++ b/test/feature/SuperObjectLiteral/SuperNestedObject.js
@@ -1,0 +1,37 @@
+var p = {
+  m() {
+    this.name = 'p';
+  },
+  n() {
+    return 'name';
+  }
+};
+
+var p2 = {
+  m() {
+    this.name = 'p2';
+  }
+};
+
+var o = {
+  __proto__: p,
+  name: 'o',
+  m() {
+    this.inner = {
+      __proto__: p2,
+      [super.n()]: 'inner',
+      m() {
+        super.m();
+      }
+    };
+    super.m();
+  }
+};
+
+o.m();
+assert.equal(o.name, 'p');
+assert.equal(o.inner.name, 'inner');
+
+o.inner.m();
+assert.equal(o.name, 'p');
+assert.equal(o.inner.name, 'p2');

--- a/test/feature/SuperObjectLiteral/SuperPostfix.js
+++ b/test/feature/SuperObjectLiteral/SuperPostfix.js
@@ -1,0 +1,22 @@
+var p = {
+  _x:  0,
+  get x() {
+    return this._x;
+  },
+  set x(x) {
+    this._x = x;
+  }
+};
+
+var o = {
+  __proto__: p,
+  m() {
+    assert.equal(this.x, 0);
+    assert.equal(super.x++, 0);
+    assert.equal(this.x, 1);
+    assert.equal(super.x--, 1);
+    assert.equal(this.x, 0);
+  }
+};
+
+o.m();

--- a/test/feature/SuperObjectLiteral/SuperSet.js
+++ b/test/feature/SuperObjectLiteral/SuperSet.js
@@ -1,0 +1,51 @@
+var p = {
+  _y: {v: 321},
+  _z: 1,
+
+  set x(value) {
+    this._x = value;
+  },
+  get x() {
+    return this._y;
+  },
+  getX() {
+    return this._x;
+  },
+  getV() {
+    return this._y.v;
+  },
+  set z(v) {
+    this._z = v;
+  },
+  get z() {
+    return this._z;
+  },
+};
+
+var o = {
+  __proto__: p,
+  set x(value) {
+    assert.equal(super.x = value, value);
+  },
+  set v(value) {
+    return super.x.v = value;
+  },
+  inc(val) {
+    assert.equal(super.z += val, 4);
+  },
+  incLookup(val) {
+    assert.equal(super['z'] += val, 9);
+  }
+};
+
+o.x = 42;
+assert.equal(42, o.getX());
+
+o.v = 123;
+assert.equal(123, o.getV());
+
+o.inc(3);
+assert.equal(4, o.z);
+
+o.incLookup(5);
+assert.equal(9, o.z);

--- a/test/feature/SuperObjectLiteral/SuperUnary.js
+++ b/test/feature/SuperObjectLiteral/SuperUnary.js
@@ -1,0 +1,25 @@
+var p = {
+  _x: 0,
+  get x() {
+    return this._x;
+  },
+  set x(x) {
+    this._x = x;
+  },
+};
+
+var o = {
+  __proto__: p,
+  m() {
+    assert.equal(this.x, 0);
+    assert.equal(++super.x, 1);
+    assert.equal(this.x, 1);
+    assert.equal(--super.x, 0);
+    assert.equal(this.x, 0);
+
+    // Don't use assert.typeOf since we are testing typeof.
+    assert.equal(typeof super.x, 'number');
+  }
+};
+
+o.m();

--- a/test/feature/SuperObjectLiteral/SuperWithoutProto.js
+++ b/test/feature/SuperObjectLiteral/SuperWithoutProto.js
@@ -1,0 +1,8 @@
+var o = {
+  x: true,
+  m() {
+    return super.hasOwnProperty('x');
+  }
+};
+
+assert.isTrue(o.m());


### PR DESCRIPTION
This refactors the SuperTransformer to be a stand alone transformer
that is run before the class transformer.

All super handling is now gone from the ClassTransformer and the
ClassTransformer has been simplified further.

Fixes #1790