### PR TITLE
Fix issue with parens and arrow functions

### DIFF
--- a/src/codegeneration/ParenTrait.js
+++ b/src/codegeneration/ParenTrait.js
@@ -18,6 +18,7 @@ import {
   ExpressionStatement,
   NewExpression,
   ParenExpression,
+  PropertyNameAssignment,
   VariableDeclaration,
 } from '../syntax/trees/ParseTrees.js';
 import {
@@ -128,6 +129,17 @@ export function ParenTrait(ParseTreeTransformerClass) {
         return tree;
       }
       return new ArrayLiteralExpression(tree.location, elements);
+    }
+
+    transformPropertyNameAssignment(tree) {
+      let name = this.transformAny(tree.name);
+      let value = this.transformAny(tree.value);
+      if (value.type === COMMA_EXPRESSION) {
+        value = wrap(value);
+      } else if (name === tree.name && value === tree.value) {
+        return tree;
+      }
+      return new PropertyNameAssignment(tree.location, name, value);
     }
   };
 }

--- a/test/feature/ArrowFunctions/Parens.js
+++ b/test/feature/ArrowFunctions/Parens.js
@@ -1,0 +1,19 @@
+class C {
+  constructor() {
+  }
+}
+
+class D extends C {
+  constructor() {
+    super();
+    this.x = {
+      y: () => {
+        return this;
+      }
+    };
+  }
+}
+
+var o = new D();
+assert.equal(typeof o.x.y, 'function');
+assert.equal(o.x.y(), o);


### PR DESCRIPTION
The ParenTrait did not add the required paren around comma expressions
in object literals.

Fixes #1962