### PR TITLE
Add support for TypeAliasDeclaration

### DIFF
--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -101,8 +101,9 @@ export class FromOptionsTransformer extends MultiTransformer {
     if (transformOptions.templateLiterals)
       append(TemplateLiteralTransformer);
 
-    if (transformOptions.types)
+    if (transformOptions.types && transformOptions.annotations) {
       append(TypeToExpressionTransformer);
+    }
 
     if (transformOptions.unicodeEscapeSequences)
       append(UnicodeEscapeSequenceTransformer);
@@ -111,11 +112,12 @@ export class FromOptionsTransformer extends MultiTransformer {
       append(AnnotationsTransformer);
 
     if (options.typeAssertions) {
+      append(TypeToExpressionTransformer);
+
       // Transforming member variables to getters/setters only make
       // sense when the type assertions are enabled.
-      if (options.typeAssertions) {
-        append(TypedMemberVariableTransformer);
-      }
+      append(TypedMemberVariableTransformer);
+
       append(TypeAssertionTransformer);
     }
 

--- a/src/codegeneration/TypeTransformer.js
+++ b/src/codegeneration/TypeTransformer.js
@@ -106,4 +106,8 @@ export class TypeTransformer extends ParseTreeTransformer {
   transformInterfaceDeclaration(tree) {
     return new AnonBlock(null, []);
   }
+
+  transformTypeAliasDeclaration(tree) {
+    return new AnonBlock(null, []);
+  }
 }

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -30,7 +30,8 @@ import {
   GET,
   OF,
   ON,
-  SET
+  SET,
+  TYPE,
 } from '../syntax/PredefinedName.js';
 import {
   isIdentifierPart,
@@ -1345,6 +1346,20 @@ export class ParseTreeWriter extends ParseTreeVisitor {
       this.writeSpace_();
       this.visitAny(tree.finallyBlock);
     }
+  }
+
+  /**
+   * @param {TypeAliasDeclaration} tree
+   */
+  visitTypeAliasDeclaration(tree) {
+    this.write_(TYPE);
+    this.writeRequiredSpace_();
+    this.writeToken_(tree.name);
+    this.writeSpace_();
+    this.write_(EQUAL);
+    this.writeSpace_();
+    this.visitAny(tree.value);
+    this.write_(SEMI_COLON);
   }
 
   /**

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -99,6 +99,7 @@ import {
   SET_ACCESSOR,
   TEMPLATE_LITERAL_PORTION,
   TEMPLATE_SUBSTITUTION,
+  TYPE_ALIAS_DECLARATION,
   TYPE_ARGUMENTS,
   TYPE_NAME,
   TYPE_PARAMETER,
@@ -477,7 +478,8 @@ export class ParseTreeValidator extends ParseTreeVisitor {
         declType === FUNCTION_DECLARATION ||
         declType === CLASS_DECLARATION ||
         declType === NAMED_EXPORT ||
-        declType === EXPORT_DEFAULT,
+        declType === EXPORT_DEFAULT ||
+        declType === TYPE_ALIAS_DECLARATION,
         tree.declaration,
         'expected valid export tree');
   }

--- a/src/syntax/PredefinedName.js
+++ b/src/syntax/PredefinedName.js
@@ -48,5 +48,6 @@ export const SET = 'set';
 export const SLICE = 'slice';
 export const THIS = 'this';
 export const TRACEUR_RUNTIME = '$traceurRuntime';
+export const TYPE = 'type';
 export const UNDEFINED = 'undefined';
 export const WRITABLE = 'writable';

--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -40,24 +40,26 @@ import {
   CLASS_EXPRESSION,
   COMMA_EXPRESSION,
   CONDITIONAL_EXPRESSION,
+  CONSTRUCTOR_TYPE,
   CONTINUE_STATEMENT,
   DEBUGGER_STATEMENT,
   DO_WHILE_STATEMENT,
   EMPTY_STATEMENT,
   EXPORT_DECLARATION,
   EXPRESSION_STATEMENT,
-  FORMAL_PARAMETER,
   FOR_IN_STATEMENT,
   FOR_OF_STATEMENT,
   FOR_ON_STATEMENT,
   FOR_STATEMENT,
+  FORMAL_PARAMETER,
   FUNCTION_DECLARATION,
   FUNCTION_EXPRESSION,
+  FUNCTION_TYPE,
   GENERATOR_COMPREHENSION,
   IDENTIFIER_EXPRESSION,
   IF_STATEMENT,
-  IMPORTED_BINDING,
   IMPORT_DECLARATION,
+  IMPORTED_BINDING,
   INTERFACE_DECLARATION,
   LABELLED_STATEMENT,
   LITERAL_EXPRESSION,
@@ -67,6 +69,7 @@ import {
   NEW_EXPRESSION,
   OBJECT_LITERAL,
   OBJECT_PATTERN,
+  OBJECT_TYPE,
   PAREN_EXPRESSION,
   POSTFIX_EXPRESSION,
   PREDEFINED_TYPE,
@@ -81,13 +84,15 @@ import {
   THIS_EXPRESSION,
   THROW_STATEMENT,
   TRY_STATEMENT,
+  TYPE_ALIAS_DECLARATION,
+  TYPE_NAME,
   TYPE_REFERENCE,
   UNARY_EXPRESSION,
   VARIABLE_DECLARATION,
   VARIABLE_STATEMENT,
   WHILE_STATEMENT,
   WITH_STATEMENT,
-  YIELD_EXPRESSION
+  YIELD_EXPRESSION,
 } from './ParseTreeType.js';
 
 export {ParseTreeType};
@@ -238,7 +243,13 @@ export class ParseTree {
   }
 
   isStatementListItem() {
-    return this.isStatement() || this.isDeclaration();
+    return this.isStatement() || this.isDeclaration() ||
+        // TODO(arv): When transforming modules we can get a type-alias. Once
+        // #1995 is fixed we can change the order of these transformers and the
+        // type-alias will get removed before it gets inserted into an invalid
+        // location.
+        // https://github.com/google/traceur-compiler/issues/1995
+        this.type === TYPE_ALIAS_DECLARATION;
   }
 
   isStatement() {
@@ -319,6 +330,7 @@ export class ParseTree {
       case IMPORT_DECLARATION:
       case INTERFACE_DECLARATION:
       case VARIABLE_DECLARATION:
+      case TYPE_ALIAS_DECLARATION:
         return true;
     }
     return this.isStatement();
@@ -342,13 +354,14 @@ export class ParseTree {
 
   isType() {
     switch (this.type) {
+      case CONSTRUCTOR_TYPE:
+      case FUNCTION_TYPE:
+      case OBJECT_TYPE:
       case PREDEFINED_TYPE:
+      case TYPE_NAME:
       case TYPE_REFERENCE:
       // TODO(arv): Implement the rest.
       // case TYPE_QUERY:
-      // case OBJECT_TYPE:
-      // case FUNCTION_TYPE:
-      // case CONSTRUCTOR_TYPE:
         return true;
     }
     return false;

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -1134,6 +1134,17 @@
       "Finally"
     ]
   },
+  "TypeAliasDeclaration": {
+    "location": [
+      "SourceRange"
+    ],
+    "name": [
+      "IdentifierToken"
+    ],
+    "value": [
+      "ParseTree"
+    ]
+  },
   "TypeArguments": {
     "location": [
       "SourceRange"

--- a/test/feature/Types/TypeAlias.js
+++ b/test/feature/Types/TypeAlias.js
@@ -1,0 +1,5 @@
+// Options: --types
+
+type A = string;
+type
+    B = Array<T>;

--- a/test/feature/Types/TypeAlias.module.js
+++ b/test/feature/Types/TypeAlias.module.js
@@ -1,0 +1,7 @@
+// Options: --types
+
+type A = string;
+type
+    B = Array<T>;
+
+export type C = number;


### PR DESCRIPTION
This adds support for TypeScript/Flow's type alias declaration:

  type NumberArray = Array<number>;