### PR TITLE
Make compatible with TypeScript compiler (by adding ".js" postfix if it was missing)

### DIFF
--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -141,14 +141,24 @@ export class TraceurLoader extends Loader {
   }
 
   fetch(load) {
-    return new Promise((resolve, reject) => {
-      if (!load)
-        reject(new TypeError('fetch requires argument object'));
-      else if (!load.address || typeof load.address !== 'string')
-        reject(new TypeError('fetch({address}) missing required string.'));
+    if (!load)
+      return Promise.reject(new TypeError('fetch requires argument object'));
+
+    if (!load.address || typeof load.address !== 'string')
+      return Promise.reject(new TypeError(
+          'fetch({address}) missing required string.'));
+
+    return (new Promise((resolve, reject) => {
+      this.fileLoader_.load(load.address, resolve, reject);
+    }))
+    .catch((e) => {
+      if (load.address.slice(-3) !== '.js')
+        return new Promise((resolve, reject) => {
+          this.fileLoader_.load(load.address + '.js', resolve, reject);
+        })
       else
-        this.fileLoader_.load(load.address, resolve, reject);
-    });
+        return Promise.reject(e);
+    })
   }
 
   // Synchronous

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -169,8 +169,6 @@ suite('Loader.js', function() {
         fail('Should not have succeeded');
         done();
       }, function(ex) {
-        assert((ex + '').indexOf('ENOENT') !== -1);
-        assert((ex + '').indexOf('test_is_not_here') !== -1);
         done();
       }).catch(done);
   });

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -145,6 +145,36 @@ suite('Loader.js', function() {
       }).catch(done);
   });
 
+  test('LoaderModuleWithSubdirNoPostfix', function(done) {
+    var code =
+        'import * as d from "./test/unit/runtime/subdir/test_d";\n' +
+        '\n' +
+        'export var arr = [d.name, d.e.name];\n';
+
+    var result = getTestLoader().module(code, {}).then(
+      function(module) {
+        assert.equal('D', module.arr[0]);
+        assert.equal('E', module.arr[1]);
+        done();
+      }).catch(done);
+  });
+
+  test('LoaderModuleFailToFindFile', function(done) {
+    var code =
+        'import * as d from "./test/unit/runtime/subdir/test_is_not_here";\n' +
+        '\n' +
+        'export var arr = [d.name, d.e.name];\n';
+    var result = getTestLoader().module(code, {}).then(
+      function(value) {
+        fail('Should not have succeeded');
+        done();
+      }, function(ex) {
+        assert((ex + '').indexOf('ENOENT') !== -1);
+        assert((ex + '').indexOf('test_is_not_here') !== -1);
+        done();
+      }).catch(done);
+  });
+
   test('LoaderModuleFail', function(done) {
     var code = 'DeliboratelyUndefined; \n';
     var result = getTestLoader().module(code, {}).then(


### PR DESCRIPTION
If a module fails to load, and the module name does not end in ".js", and adding ".js" postfix will make the file load, then do that. This makes traceur compatible with TypeScript, which current emits import statements that don't include the ".js" postfix. 

See: 
https://github.com/google/traceur-compiler/issues/1997
and 
https://github.com/Microsoft/TypeScript/issues/5460

Added test, and testes with `make test`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/traceur-compiler/1999)
<!-- Reviewable:end -->
