### PR TITLE
Fix error reporting to output new lines

### DIFF
--- a/demo/repl-module.js
+++ b/demo/repl-module.js
@@ -181,7 +181,18 @@ function onFailure(error, metadata) {
     output.setValue(metadata.transcoded);
   hasError = true;
   errorElement.hidden = false;
-  errorElement.textContent = error.stack || error;
+
+  let s;
+  if (error) {
+    if (error.stack) {
+      s = error.stack;
+    } else if (error.name === 'MultipleErrors') {
+      s = error.errors.join('\n');
+    }
+  } else {
+    s = String(error);
+  }
+  errorElement.textContent = s;
 }
 
 function compileContents(contents) {

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -161,7 +161,7 @@ export class Compiler {
 
   throwIfErrors(errorReporter) {
     if (errorReporter.hadError())
-      throw errorReporter.errors;
+      throw errorReporter.toError();
   }
 
   /**

--- a/src/node/command.js
+++ b/src/node/command.js
@@ -137,10 +137,13 @@ function compileAll(out, sources, options) {
     traceurAPI.recursiveModuleCompileToSingleFile(out, sources, options).then(function() {
       process.exit(0);
     }).catch(function(err) {
-      var errors = err.errors || [err];
-      errors.forEach(function(err) {
-        console.error(err.stack || err);
-      });
+      if (err.name === 'MultipleErrors') {
+        err.errors.forEach(function(err) {
+          console.error(err);
+        });
+      } else {
+        console.error(err);
+      }
       process.exit(1);
     });
   }

--- a/src/util/CollectingErrorReporter.js
+++ b/src/util/CollectingErrorReporter.js
@@ -17,8 +17,8 @@ import {ErrorReporter} from '../util/ErrorReporter.js';
 export class MultipleErrors extends Error {
   constructor(errors) {
     super();
-    this.message = errors ? errors.join('\n')  + '': '';
-    this.name = errors && (errors.length > 1) ? 'MultipleErrors' : '';
+    this.message = errors ? errors.join('\n') : '';
+    this.name = 'MultipleErrors';
     // Access for alternative formatting.
     this.errors = errors;
   }

--- a/test/unit/node/require.js
+++ b/test/unit/node/require.js
@@ -31,8 +31,9 @@ suite('require.js', function() {
       traceurRequire(path.join(System.dirname(__moduleName), './' + filename));
       assert.notOk(true);
     } catch (ex) {
-      assert.equal(ex.length, 1, 'One error is reported');
-      assert.include(ex[0].replace(/\\/g, '/'), filename,
+      assert.equal('MultipleErrors', ex.name);
+      assert.equal(ex.errors.length, 1, 'One error is reported');
+      assert.include(ex.errors[0].replace(/\\/g, '/'), filename,
           'The error message should contain the filename');
     }
   });

--- a/test/unit/util/ErrorReporter.js
+++ b/test/unit/util/ErrorReporter.js
@@ -105,16 +105,17 @@ suite('ErrorReporter.js', function() {
     assert.throws(function() {
       throw error;
     }, MultipleErrors);
-    assert.equal(error + '', accumulated.join('\n'));
+    assert.equal(error + '', 'MultipleErrors: ' + accumulated.join('\n'));
+
   });
 
   test('No MultipleErrors', function() {
-    var accumulated = null;
+    var accumulated = [];
     var error = new MultipleErrors(accumulated);
     assert.throws(function() {
       throw error;
     }, MultipleErrors);
-    assert.equal(error + '', '');
+    assert.equal(error + '', 'MultipleErrors');
   });
 
   test('Format', function() {


### PR DESCRIPTION
Our errors were reported as an array of strings which is not very useful.