### PR TITLE
Add modules ignore option

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -91,7 +91,7 @@ let defaultValues = Object.create(null);
 let featureOptions = Object.create(null);
 let experimentalOptions = Object.create(null);
 let moduleOptions =
-    ['amd', 'commonjs', 'closure', 'instantiate', 'inline', 'bootstrap'];
+    ['amd', 'commonjs', 'closure', 'instantiate', 'inline', 'bootstrap', 'parse'];
 
 const EXPERIMENTAL = 0;
 const ON_BY_DEFAULT = 1;

--- a/src/codegeneration/FromOptionsTransformer.js
+++ b/src/codegeneration/FromOptionsTransformer.js
@@ -141,6 +141,8 @@ export class FromOptionsTransformer extends MultiTransformer {
         case 'bootstrap':
           append(ModuleTransformer);
           break;
+        case 'parse':
+          break;
         default:
           // The options processing should prevent us from getting here.
           throw new Error('Invalid modules transform option');

--- a/test/node-api-test.js
+++ b/test/node-api-test.js
@@ -208,4 +208,15 @@ suite('node public api', function() {
 
     assert.equal(gotName, 'test-module');
   });
+
+  test('modules parse option', function() {
+    var contents = "export var p = 5;";
+    var compiled = traceurAPI.compile(contents, {
+      modules: 'parse'
+    }, 'test-module');
+
+    assert.ok(compiled, 'can compile');
+
+    assert(compiled.match(/^export var p = 5;/));
+  });
 });


### PR DESCRIPTION
I'm in the process of splitting SystemJS out so that transpilation always happens through plugins and not as part of SystemJS core itself.

In order to construct a Traceur plugin that can optimize ES modules nicely for builds, the ability to ignore module syntax entirely would be incredibly useful.