### PR TITLE
Support IdentifierName in extended export

### DIFF
--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -759,8 +759,13 @@ export class Parser {
           exportTree = this.parseNamedExport_();
         }
         break;
-      default:
-        return this.parseUnexpectedToken_(peekToken());
+      default: {
+        let token = peekToken();
+        if (!token.isKeyword()) {
+          return this.parseUnexpectedToken_(peekToken());
+        }
+        exportTree = this.parseNamedExport_();
+      }
     }
     return new ExportDeclaration(this.getTreeLocation_(start), exportTree,
                                  annotations);
@@ -845,14 +850,14 @@ export class Parser {
         }
         break;
 
-      case IDENTIFIER:
-        exportClause = this.parseForwardDefaultExport_();
+      case STAR:
+        exportClause = this.parseExportStar_();
         this.eatId_(FROM);
         moduleSpecifier = this.parseModuleSpecifier_();
         break;
 
-      case STAR:
-        exportClause = this.parseExportStar_();
+      default:  // IDENTIFIER or isKeyword
+        exportClause = this.parseForwardDefaultExport_();
         this.eatId_(FROM);
         moduleSpecifier = this.parseModuleSpecifier_();
         break;

--- a/test/feature/Modules/ExportForwardDefault.module.js
+++ b/test/feature/Modules/ExportForwardDefault.module.js
@@ -1,7 +1,9 @@
 // Options: --export-from-extended
 
 import {a, b, default as C} from './resources/export-forward-default-as.js';
+import {new as n} from './resources/export-extended-keyword.js';
 
 assert.equal(42, a);
 assert.equal(123, b());
 assert.equal('m', new C().m());
+assert.equal('default', n);

--- a/test/feature/Modules/resources/export-extended-keyword.js
+++ b/test/feature/Modules/resources/export-extended-keyword.js
@@ -1,0 +1,1 @@
+export new from './default-and-named.js';


### PR DESCRIPTION
The following is now valid:

```js
// Options: --export-from-extended
export new from './file.js';
```

Fixes #2003