### PR TITLE
Conditionally override functions for Symbols

### DIFF
--- a/src/runtime/async.js
+++ b/src/runtime/async.js
@@ -16,15 +16,15 @@ if (typeof $traceurRuntime !== 'object') {
   throw new Error('traceur runtime not found.');
 }
 
-var {createPrivateName} = $traceurRuntime;
+var {createPrivateSymbol} = $traceurRuntime;
 var {
   create,
   defineProperty,
 } = Object;
 
-var thisName = createPrivateName();
-var argsName = createPrivateName();
-var observeName = createPrivateName();
+var thisName = createPrivateSymbol();
+var argsName = createPrivateSymbol();
+var observeName = createPrivateSymbol();
 
 function AsyncGeneratorFunction() {}
 

--- a/src/runtime/generators.js
+++ b/src/runtime/generators.js
@@ -17,7 +17,7 @@ if (typeof $traceurRuntime !== 'object') {
 }
 
 var $TypeError = TypeError;
-var {createPrivateName} = $traceurRuntime;
+var {createPrivateSymbol} = $traceurRuntime;
 var {
   create,
   defineProperties,
@@ -211,8 +211,8 @@ function nextOrThrow(ctx, moveNext, action, x) {
   }
 }
 
-var ctxName = createPrivateName();
-var moveNextName = createPrivateName();
+var ctxName = createPrivateSymbol();
+var moveNextName = createPrivateSymbol();
 
 function GeneratorFunction() {}
 

--- a/src/runtime/polyfills/Map.js
+++ b/src/runtime/polyfills/Map.js
@@ -18,7 +18,7 @@ import {
 } from './utils.js'
 import {deleteFrozen, getFrozen, setFrozen} from '../frozen-data.js';
 
-const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
 const {
   defineProperty,
   getOwnPropertyDescriptor,
@@ -29,7 +29,7 @@ const {
 const deletedSentinel = {};
 
 let counter = 0;
-const hashCodeName = createPrivateName();
+const hashCodeName = createPrivateSymbol();
 
 function getHashCodeForObject(obj) {
   let hc = obj[hashCodeName];

--- a/src/runtime/polyfills/Map.js
+++ b/src/runtime/polyfills/Map.js
@@ -18,7 +18,7 @@ import {
 } from './utils.js'
 import {deleteFrozen, getFrozen, setFrozen} from '../frozen-data.js';
 
-const {hasNativeSymbol, newUniqueString} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
 const {
   defineProperty,
   getOwnPropertyDescriptor,
@@ -29,7 +29,7 @@ const {
 const deletedSentinel = {};
 
 let counter = 0;
-const hashCodeName = newUniqueString();
+const hashCodeName = createPrivateName();
 
 function getHashCodeForObject(obj) {
   let hc = obj[hashCodeName];

--- a/src/runtime/polyfills/Object.js
+++ b/src/runtime/polyfills/Object.js
@@ -18,14 +18,10 @@ import {
 } from './utils.js';
 
 var {
-  getOwnPropertyNames,
-  isPrivateName,
-  keys,
-} = $traceurRuntime;
-
-var {
   defineProperty,
   getOwnPropertyDescriptor,
+  getOwnPropertyNames,
+  keys
 } = Object;
 
 // Object.is
@@ -45,7 +41,6 @@ export function assign(target) {
     var p, length = props.length;
     for (p = 0; p < length; p++) {
       var name = props[p];
-      if (isPrivateName(name)) continue;
       target[name] = source[name];
     }
   }
@@ -58,7 +53,6 @@ export function mixin(target, source) {
   var p, descriptor, length = props.length;
   for (p = 0; p < length; p++) {
     var name = props[p];
-    if (isPrivateName(name)) continue;
     descriptor = getOwnPropertyDescriptor(source, props[p]);
     defineProperty(target, props[p], descriptor);
   }

--- a/src/runtime/polyfills/WeakMap.js
+++ b/src/runtime/polyfills/WeakMap.js
@@ -24,7 +24,7 @@ import {
 } from './utils.js'
 
 const {defineProperty, getOwnPropertyDescriptor, isExtensible} = Object;
-const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
@@ -32,7 +32,7 @@ const sentinel = {};
 
 export class WeakMap {
   constructor() {
-    this.name_ = createPrivateName();
+    this.name_ = createPrivateSymbol();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/polyfills/WeakMap.js
+++ b/src/runtime/polyfills/WeakMap.js
@@ -24,7 +24,7 @@ import {
 } from './utils.js'
 
 const {defineProperty, getOwnPropertyDescriptor, isExtensible} = Object;
-const {hasNativeSymbol, newUniqueString} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
@@ -32,7 +32,7 @@ const sentinel = {};
 
 export class WeakMap {
   constructor() {
-    this.name_ = newUniqueString();
+    this.name_ = createPrivateName();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/polyfills/WeakSet.js
+++ b/src/runtime/polyfills/WeakSet.js
@@ -23,13 +23,13 @@ import {
 } from './utils.js'
 
 const {defineProperty, isExtensible} = Object;
-const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
 export class WeakSet {
   constructor() {
-    this.name_ = createPrivateName();
+    this.name_ = createPrivateSymbol();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/polyfills/WeakSet.js
+++ b/src/runtime/polyfills/WeakSet.js
@@ -23,13 +23,13 @@ import {
 } from './utils.js'
 
 const {defineProperty, isExtensible} = Object;
-const {hasNativeSymbol, newUniqueString} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
 export class WeakSet {
   constructor() {
-    this.name_ = newUniqueString();
+    this.name_ = createPrivateName();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -77,7 +77,8 @@
     return privateNames[s];
   }
 
-  function createPrivateName() {
+  // This creates a Symbol that we filter out in getOwnPropertySymbols.
+  function createPrivateSymbol() {
     var s = hasNativeSymbol ? Symbol() : newUniqueString();
     privateNames[s] = true;
     return s;
@@ -96,7 +97,7 @@
   var isTailRecursiveName = null;
 
   function setupProperTailCalls() {
-    isTailRecursiveName = createPrivateName();
+    isTailRecursiveName = createPrivateSymbol();
 
     // By 19.2.3.1 and 19.2.3.3, Function.prototype.call and
     // Function.prototype.apply do proper tail calls.
@@ -401,7 +402,7 @@
       checkObjectCoercible: checkObjectCoercible,
       construct: construct,
       continuation: createContinuation,
-      createPrivateName: createPrivateName,
+      createPrivateSymbol: createPrivateSymbol,
       exportStar: exportStar,
       hasNativeSymbol: hasNativeSymbolFunc,
       initTailRecursiveFunction: initTailRecursiveFunction,

--- a/test/feature/Yield/ObjectModel.js
+++ b/test/feature/Yield/ObjectModel.js
@@ -18,6 +18,9 @@ assert.equal(g.__proto__, f.prototype);
 assert.deepEqual([], Object.getOwnPropertyNames(f.prototype));
 assert.deepEqual([], Object.getOwnPropertyNames(g));
 
+assert.deepEqual([], Object.getOwnPropertySymbols(f.prototype));
+assert.deepEqual([], Object.getOwnPropertySymbols(g));
+
 f.prototype.x = 42;
 
 var g2 = f();


### PR DESCRIPTION
Only conditionally override `Object.keys` and
`Object.getOwnPropertyNames` if there is no native support for Symbol.

Private names are now done using a symbol. This symbol gets added to an
object as map so that we can filter these out when someone does
`Object.getOwnPropertySymbols`.

We always override `Object.getOwnPropertySymbols` since we now use
symbols for private state.

Fixes #1993