### PR TITLE
Add abstraction for private symbols

### DIFF
--- a/src/runtime/async.js
+++ b/src/runtime/async.js
@@ -16,14 +16,12 @@ if (typeof $traceurRuntime !== 'object') {
   throw new Error('traceur runtime not found.');
 }
 
-var {createPrivateSymbol} = $traceurRuntime;
+var {createPrivateSymbol, getPrivate, setPrivate} = $traceurRuntime;
 var {
   create,
   defineProperty,
 } = Object;
 
-var thisName = createPrivateSymbol();
-var argsName = createPrivateSymbol();
 var observeName = createPrivateSymbol();
 
 function AsyncGeneratorFunction() {}
@@ -102,7 +100,7 @@ class AsyncGeneratorContext {
 
 AsyncGeneratorFunctionPrototype.prototype[Symbol.observer] =
     function (observer) {
-      var observe = this[observeName];
+      var observe = getPrivate(this, observeName);
       var ctx = new AsyncGeneratorContext(observer);
       $traceurRuntime.schedule(() => observe(ctx)).then(value => {
         if (!ctx.done) {
@@ -128,9 +126,7 @@ function initAsyncGeneratorFunction(functionObject) {
 
 function createAsyncGeneratorInstance(observe, functionObject, ...args) {
   var object = create(functionObject.prototype);
-  object[thisName] = this;
-  object[argsName] = args;
-  object[observeName] = observe;
+  setPrivate(object, observeName, observe);
   return object;
 }
 

--- a/src/runtime/async.js
+++ b/src/runtime/async.js
@@ -16,15 +16,15 @@ if (typeof $traceurRuntime !== 'object') {
   throw new Error('traceur runtime not found.');
 }
 
-var {createPrivateName} = $traceurRuntime;
+var {createPrivateSymbol} = $traceurRuntime;
 var {
   create,
   defineProperty,
 } = Object;
 
-var thisName = createPrivateName();
-var argsName = createPrivateName();
-var observeName = createPrivateName();
+var thisName = createPrivateSymbol();
+var argsName = createPrivateSymbol();
+var observeName = createPrivateSymbol();
 
 function AsyncGeneratorFunction() {}
 

--- a/src/runtime/generators.js
+++ b/src/runtime/generators.js
@@ -17,7 +17,7 @@ if (typeof $traceurRuntime !== 'object') {
 }
 
 var $TypeError = TypeError;
-var {createPrivateSymbol} = $traceurRuntime;
+var {createPrivateSymbol, getPrivate, setPrivate} = $traceurRuntime;
 var {
   create,
   defineProperties,
@@ -226,15 +226,16 @@ defineProperty(GeneratorFunctionPrototype, 'constructor',
 GeneratorFunctionPrototype.prototype = {
   constructor: GeneratorFunctionPrototype,
   next: function(v) {
-    return nextOrThrow(this[ctxName], this[moveNextName], 'next', v);
+    return nextOrThrow(getPrivate(this, ctxName), getPrivate(this, moveNextName), 'next', v);
   },
   throw: function(v) {
-    return nextOrThrow(this[ctxName], this[moveNextName], 'throw', v);
+    return nextOrThrow(getPrivate(this, ctxName), getPrivate(this, moveNextName), 'throw', v);
   },
   return: function (v) {
-    this[ctxName].oldReturnValue = this[ctxName].returnValue;
-    this[ctxName].returnValue = v;
-    return nextOrThrow(this[ctxName], this[moveNextName], 'throw', RETURN_SENTINEL);
+    let ctx = getPrivate(this, ctxName);
+    ctx.oldReturnValue = ctx.returnValue;
+    ctx.returnValue = v;
+    return nextOrThrow(ctx, getPrivate(this, moveNextName), 'throw', RETURN_SENTINEL);
   }
 };
 
@@ -256,8 +257,8 @@ function createGeneratorInstance(innerFunction, functionObject, self) {
   var ctx = new GeneratorContext();
 
   var object = create(functionObject.prototype);
-  object[ctxName] = ctx;
-  object[moveNextName] = moveNext;
+  setPrivate(object, ctxName, ctx);
+  setPrivate(object, moveNextName, moveNext);
   return object;
 }
 

--- a/src/runtime/generators.js
+++ b/src/runtime/generators.js
@@ -17,7 +17,7 @@ if (typeof $traceurRuntime !== 'object') {
 }
 
 var $TypeError = TypeError;
-var {createPrivateName} = $traceurRuntime;
+var {createPrivateSymbol} = $traceurRuntime;
 var {
   create,
   defineProperties,
@@ -211,8 +211,8 @@ function nextOrThrow(ctx, moveNext, action, x) {
   }
 }
 
-var ctxName = createPrivateName();
-var moveNextName = createPrivateName();
+var ctxName = createPrivateSymbol();
+var moveNextName = createPrivateSymbol();
 
 function GeneratorFunction() {}
 

--- a/src/runtime/polyfills/Map.js
+++ b/src/runtime/polyfills/Map.js
@@ -18,7 +18,7 @@ import {
 } from './utils.js'
 import {deleteFrozen, getFrozen, setFrozen} from '../frozen-data.js';
 
-const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
 const {
   defineProperty,
   getOwnPropertyDescriptor,
@@ -29,7 +29,7 @@ const {
 const deletedSentinel = {};
 
 let counter = 0;
-const hashCodeName = createPrivateName();
+const hashCodeName = createPrivateSymbol();
 
 function getHashCodeForObject(obj) {
   let hc = obj[hashCodeName];

--- a/src/runtime/polyfills/Map.js
+++ b/src/runtime/polyfills/Map.js
@@ -18,7 +18,7 @@ import {
 } from './utils.js'
 import {deleteFrozen, getFrozen, setFrozen} from '../frozen-data.js';
 
-const {hasNativeSymbol, newUniqueString} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
 const {
   defineProperty,
   getOwnPropertyDescriptor,
@@ -29,7 +29,7 @@ const {
 const deletedSentinel = {};
 
 let counter = 0;
-const hashCodeName = newUniqueString();
+const hashCodeName = createPrivateName();
 
 function getHashCodeForObject(obj) {
   let hc = obj[hashCodeName];

--- a/src/runtime/polyfills/Map.js
+++ b/src/runtime/polyfills/Map.js
@@ -18,7 +18,12 @@ import {
 } from './utils.js'
 import {deleteFrozen, getFrozen, setFrozen} from '../frozen-data.js';
 
-const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
+const {
+  createPrivateSymbol,
+  getPrivate,
+  hasNativeSymbol,
+  setPrivate
+} = $traceurRuntime;
 const {
   defineProperty,
   getOwnPropertyDescriptor,
@@ -28,24 +33,20 @@ const {
 
 const deletedSentinel = {};
 
-let counter = 0;
+let counter = 1;
 const hashCodeName = createPrivateSymbol();
 
 function getHashCodeForObject(obj) {
-  let hc = obj[hashCodeName];
-  if (hc === undefined || !hasOwnProperty.call(obj, hashCodeName)) {
-    return undefined;
-  }
-  return hc;
+  return getPrivate(obj, hashCodeName);
 }
 
 function getOrSetHashCodeForObject(obj) {
-  if (hasOwnProperty.call(obj, hashCodeName)) {
-    return obj[hashCodeName];
+  let hash = getHashCodeForObject(obj);
+  if (!hash) {
+    hash = counter++;
+    setPrivate(obj, hashCodeName, hash);
   }
-  let hc = counter++;
-  defineProperty(obj, hashCodeName, {value: hc});
-  return hc;
+  return hash;
 }
 
 function lookupIndex(map, key) {

--- a/src/runtime/polyfills/Object.js
+++ b/src/runtime/polyfills/Object.js
@@ -18,14 +18,10 @@ import {
 } from './utils.js';
 
 var {
-  getOwnPropertyNames,
-  isPrivateName,
-  keys,
-} = $traceurRuntime;
-
-var {
   defineProperty,
   getOwnPropertyDescriptor,
+  getOwnPropertyNames,
+  keys
 } = Object;
 
 // Object.is
@@ -45,7 +41,6 @@ export function assign(target) {
     var p, length = props.length;
     for (p = 0; p < length; p++) {
       var name = props[p];
-      if (isPrivateName(name)) continue;
       target[name] = source[name];
     }
   }
@@ -58,7 +53,6 @@ export function mixin(target, source) {
   var p, descriptor, length = props.length;
   for (p = 0; p < length; p++) {
     var name = props[p];
-    if (isPrivateName(name)) continue;
     descriptor = getOwnPropertyDescriptor(source, props[p]);
     defineProperty(target, props[p], descriptor);
   }

--- a/src/runtime/polyfills/Set.js
+++ b/src/runtime/polyfills/Set.js
@@ -18,26 +18,21 @@ import {
 } from './utils.js';
 import {Map} from './Map.js'
 
-var getOwnHashObject = $traceurRuntime.getOwnHashObject;
-var $hasOwnProperty = Object.prototype.hasOwnProperty;
-
-function initSet(set) {
-  set.map_ = new Map();
-}
+let {hasOwnProperty} = Object.prototype;
 
 export class Set {
   constructor(iterable = undefined) {
     if (!isObject(this))
       throw new TypeError('Set called on incompatible type');
 
-    if ($hasOwnProperty.call(this, 'map_')) {
+    if (hasOwnProperty.call(this, 'map_')) {
       throw new TypeError('Set can not be reentrantly initialised');
     }
 
-    initSet(this);
+    this.map_ = new Map();
 
     if (iterable !== null && iterable !== undefined) {
-      for (var item of iterable) {
+      for (let item of iterable) {
         this.add(item);
       }
     }
@@ -93,7 +88,7 @@ Object.defineProperty(Set.prototype, 'keys', {
 });
 
 function needsPolyfill(global) {
-  var {Set, Symbol} = global;
+  let {Set, Symbol} = global;
   if (!Set || !$traceurRuntime.hasNativeSymbol() ||
       !Set.prototype[Symbol.iterator] || !Set.prototype.values) {
     return true;

--- a/src/runtime/polyfills/WeakMap.js
+++ b/src/runtime/polyfills/WeakMap.js
@@ -24,7 +24,7 @@ import {
 } from './utils.js'
 
 const {defineProperty, getOwnPropertyDescriptor, isExtensible} = Object;
-const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
@@ -32,7 +32,7 @@ const sentinel = {};
 
 export class WeakMap {
   constructor() {
-    this.name_ = createPrivateName();
+    this.name_ = createPrivateSymbol();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/polyfills/WeakMap.js
+++ b/src/runtime/polyfills/WeakMap.js
@@ -24,7 +24,7 @@ import {
 } from './utils.js'
 
 const {defineProperty, getOwnPropertyDescriptor, isExtensible} = Object;
-const {hasNativeSymbol, newUniqueString} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
@@ -32,7 +32,7 @@ const sentinel = {};
 
 export class WeakMap {
   constructor() {
-    this.name_ = newUniqueString();
+    this.name_ = createPrivateName();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/polyfills/WeakMap.js
+++ b/src/runtime/polyfills/WeakMap.js
@@ -24,7 +24,14 @@ import {
 } from './utils.js'
 
 const {defineProperty, getOwnPropertyDescriptor, isExtensible} = Object;
-const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
+const {
+  createPrivateSymbol,
+  deletePrivate,
+  getPrivate,
+  hasNativeSymbol,
+  hasPrivate,
+  setPrivate
+} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
@@ -41,11 +48,7 @@ export class WeakMap {
     if (!isExtensible(key)) {
       setFrozen(this.frozenData_, key, value);
     } else {
-      defineProperty(key, this.name_, {
-        configurable: true,
-        value,
-        writable: true,
-      });
+      setPrivate(key, this.name_, value);
     }
     return this;
   }
@@ -55,8 +58,7 @@ export class WeakMap {
     if (!isExtensible(key)) {
       return getFrozen(this.frozenData_, key);
     }
-    let desc = getOwnPropertyDescriptor(key, this.name_);
-    return desc && desc.value;
+    return getPrivate(key, this.name_);
   }
 
   delete(key) {
@@ -64,7 +66,7 @@ export class WeakMap {
     if (!isExtensible(key)) {
       return deleteFrozen(this.frozenData_, key);
     }
-    return hasOwnProperty.call(key, this.name_) && delete key[this.name_];
+    return deletePrivate(key, this.name_);
   }
 
   has(key) {
@@ -72,7 +74,7 @@ export class WeakMap {
     if (!isExtensible(key)) {
       return hasFrozen(this.frozenData_, key);
     }
-    return hasOwnProperty.call(key, this.name_);
+    return hasPrivate(key, this.name_);
   }
 }
 

--- a/src/runtime/polyfills/WeakSet.js
+++ b/src/runtime/polyfills/WeakSet.js
@@ -23,13 +23,13 @@ import {
 } from './utils.js'
 
 const {defineProperty, isExtensible} = Object;
-const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
 export class WeakSet {
   constructor() {
-    this.name_ = createPrivateName();
+    this.name_ = createPrivateSymbol();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/polyfills/WeakSet.js
+++ b/src/runtime/polyfills/WeakSet.js
@@ -23,7 +23,14 @@ import {
 } from './utils.js'
 
 const {defineProperty, isExtensible} = Object;
-const {hasNativeSymbol, createPrivateSymbol} = $traceurRuntime;
+const {
+  createPrivateSymbol,
+  deletePrivate,
+  getPrivate,
+  hasNativeSymbol,
+  hasPrivate,
+  setPrivate,
+} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
@@ -38,11 +45,7 @@ export class WeakSet {
     if (!isExtensible(value)) {
       setFrozen(this.frozenData_, value, value);
     } else {
-      defineProperty(value, this.name_, {
-        configurable: true,
-        value: true,
-        writable: true,
-      });
+      setPrivate(value, this.name_, true);
     }
     return this;
   }
@@ -52,7 +55,7 @@ export class WeakSet {
     if (!isExtensible(value)) {
       return deleteFrozen(this.frozenData_, value);
     }
-    return hasOwnProperty.call(value, this.name_) && delete value[this.name_];
+    return deletePrivate(value, this.name_);
   }
 
   has(value) {
@@ -60,7 +63,7 @@ export class WeakSet {
     if (!isExtensible(value)) {
       return getFrozen(this.frozenData_, value) === value;
     }
-    return hasOwnProperty.call(value, this.name_);
+    return hasPrivate(value, this.name_);
   }
 }
 

--- a/src/runtime/polyfills/WeakSet.js
+++ b/src/runtime/polyfills/WeakSet.js
@@ -23,13 +23,13 @@ import {
 } from './utils.js'
 
 const {defineProperty, isExtensible} = Object;
-const {hasNativeSymbol, newUniqueString} = $traceurRuntime;
+const {hasNativeSymbol, createPrivateName} = $traceurRuntime;
 const $TypeError = TypeError;
 const {hasOwnProperty} = Object.prototype;
 
 export class WeakSet {
   constructor() {
-    this.name_ = newUniqueString();
+    this.name_ = createPrivateName();
     this.frozenData_ = [];
   }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -34,6 +34,7 @@
   var $isExtensible = Object.isExtensible;
   var $apply = Function.prototype.call.bind(Function.prototype.apply)
   var random = Math.random;
+  var $getOwnPropertySymbols = $Object.getOwnPropertySymbols;
 
   function $bind(operand, thisArg, args) {
     // args may be an arguments-like object
@@ -49,6 +50,9 @@
     var object = new ($bind(func, null, argArray));
     return object; // prevent tail call
   }
+
+
+  var hasNativeSymbol = typeof global.Symbol === 'function';
 
   // ### Support for proper tail recursion
   //
@@ -74,7 +78,7 @@
   }
 
   function createPrivateName() {
-    var s = newUniqueString();
+    var s = hasNativeSymbol ? Symbol() : newUniqueString();
     privateNames[s] = true;
     return s;
   }
@@ -212,9 +216,9 @@
      * @param {string=} string Optional string used for toString.
      * @constructor
      */
-    function Symbol(description) {
+    let SymbolImpl = function Symbol(description) {
       var value = new SymbolValue(description);
-      if (!(this instanceof Symbol))
+      if (!(this instanceof SymbolImpl))
         return value;
 
       // new Symbol should throw.
@@ -224,10 +228,10 @@
       // this. To correctly handle these two would require a lot of work for very
       // little gain so we are not doing those at the moment.
       throw new TypeError('Symbol cannot be new\'ed');
-    }
+    };
 
-    $defineProperty(Symbol.prototype, 'constructor', nonEnum(Symbol));
-    $defineProperty(Symbol.prototype, 'toString', method(function() {
+    $defineProperty(SymbolImpl.prototype, 'constructor', nonEnum(SymbolImpl));
+    $defineProperty(SymbolImpl.prototype, 'toString', method(function() {
       var symbolValue = this[symbolDataProperty];
       return symbolValue[symbolInternalProperty];
       /* The implementation of toString below matches the spec, but prevents
@@ -241,7 +245,7 @@
       return 'Symbol(' + desc + ')';
       */
     }));
-    $defineProperty(Symbol.prototype, 'valueOf', method(function() {
+    $defineProperty(SymbolImpl.prototype, 'valueOf', method(function() {
       var symbolValue = this[symbolDataProperty];
       if (!symbolValue)
         throw TypeError('Conversion from symbol to string');
@@ -256,13 +260,13 @@
       freeze(this);
       symbolValues[key] = this;
     }
-    $defineProperty(SymbolValue.prototype, 'constructor', nonEnum(Symbol));
+    $defineProperty(SymbolValue.prototype, 'constructor', nonEnum(SymbolImpl));
     $defineProperty(SymbolValue.prototype, 'toString', {
-      value: Symbol.prototype.toString,
+      value: SymbolImpl.prototype.toString,
       enumerable: false
     });
     $defineProperty(SymbolValue.prototype, 'valueOf', {
-      value: Symbol.prototype.valueOf,
+      value: SymbolImpl.prototype.valueOf,
       enumerable: false
     });
 
@@ -277,7 +281,6 @@
       return symbolValues[s] || privateNames[s];
     }
 
-    // Override getOwnPropertyNames to filter out symbols keys.
     function removeSymbolKeys(array) {
       var rv = [];
       for (var i = 0; i < array.length; i++) {
@@ -288,6 +291,7 @@
       return rv;
     }
 
+    // Override getOwnPropertyNames to filter out symbols keys.
     function getOwnPropertyNames(object) {
       return removeSymbolKeys($getOwnPropertyNames(object));
     }
@@ -296,23 +300,32 @@
       return removeSymbolKeys($keys(object));
     }
 
-    function getOwnPropertySymbols(object) {
+    var getOwnPropertySymbolsImpl = function getOwnPropertySymbols(object) {
       var rv = [];
-      var names = $getOwnPropertyNames(object);
-      for (var i = 0; i < names.length; i++) {
-        var symbol = symbolValues[names[i]];
-        if (symbol) {
-          rv.push(symbol);
+      if ($getOwnPropertySymbols) {
+        var symbols = $getOwnPropertySymbols(object);
+        for (var i = 0; i < symbols.length; i++) {
+          var symbol = symbols[i];
+          if (!isPrivateName(symbol)) {
+            rv.push(symbol);
+          }
+        }
+      } else {
+        var names = $getOwnPropertyNames(object);
+        for (var i = 0; i < names.length; i++) {
+          var symbol = symbolValues[names[i]];
+          if (symbol) {
+            rv.push(symbol);
+          }
         }
       }
       return rv;
-    }
+    };
 
     function polyfillObject(Object) {
-      $defineProperty(Object, 'getOwnPropertyNames',
-                      {value: getOwnPropertyNames});
-      $defineProperty(Object, 'keys', {value: keys});
-      // getOwnPropertySymbols is added in polyfillSymbol.
+      // Override/define to support private symbols
+      $defineProperty(Object, 'getOwnPropertySymbols',
+          nonEnum(getOwnPropertySymbolsImpl));
     }
 
     function exportStar(object) {
@@ -350,16 +363,15 @@
       return argument;
     }
 
-    var hasNativeSymbol;
-
-    function polyfillSymbol(global, Symbol) {
-      if (!global.Symbol) {
-        global.Symbol = Symbol;
-        Object.getOwnPropertySymbols = getOwnPropertySymbols;
-        hasNativeSymbol = false;
-      } else {
-        hasNativeSymbol = true;
+    function polyfillSymbol(global) {
+      if (!hasNativeSymbol) {
+        global.Symbol = SymbolImpl;
+        let {Object} = global;
+        Object.getOwnPropertyNames = getOwnPropertyNames;
+        Object.keys = keys;
+        // getOwnPropertySymbols is done in polyfillObject.
       }
+
       if (!global.Symbol.iterator) {
         global.Symbol.iterator = Symbol('Symbol.iterator');
       }
@@ -373,11 +385,10 @@
     }
 
     function setupGlobals(global) {
-      polyfillSymbol(global, Symbol)
+      polyfillObject(global.Object);
+      polyfillSymbol(global)
       global.Reflect = global.Reflect || {};
       global.Reflect.global = global.Reflect.global || global;
-
-      polyfillObject(global.Object);
     }
 
     setupGlobals(global);
@@ -392,14 +403,9 @@
       continuation: createContinuation,
       createPrivateName: createPrivateName,
       exportStar: exportStar,
-      getOwnPropertyNames: $getOwnPropertyNames,
       hasNativeSymbol: hasNativeSymbolFunc,
       initTailRecursiveFunction: initTailRecursiveFunction,
       isObject: isObject,
-      isPrivateName: isPrivateName,
-      isSymbolString: isSymbolString,
-      keys: $keys,
-      newUniqueString: newUniqueString,
       options: {},
       setupGlobals: setupGlobals,
       toObject: toObject,

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -84,6 +84,30 @@
     return s;
   }
 
+  // Provide abstraction so that we can replace the symbol with a WeakMap in
+  // the future.
+  function hasPrivate(obj, sym) {
+    return hasOwnProperty.call(obj, sym);
+  }
+
+  function deletePrivate(obj, sym) {
+    if (!hasPrivate(obj, sym)) {
+      return false;
+    }
+    delete obj[sym];
+    return true;
+  }
+
+  function setPrivate(obj, sym, val) {
+    obj[sym] = val;
+  }
+
+  function getPrivate(obj, sym) {
+    var val = obj[sym];
+    if (val === undefined) return undefined;
+    return hasOwnProperty.call(obj, sym) ? val : undefined;
+  }
+
   var CONTINUATION_TYPE = Object.create(null);
 
   function createContinuation(operand, thisArg, argsArray) {
@@ -129,12 +153,12 @@
     if (isTailRecursiveName === null) {
       setupProperTailCalls();
     }
-    func[isTailRecursiveName] = true;
+    setPrivate(func, isTailRecursiveName, true);
     return func;
   }
 
   function isTailRecursive(func) {
-    return !!func[isTailRecursiveName];
+    return !!getPrivate(func, isTailRecursiveName);
   }
 
   function tailCall(func, thisArg, argArray) {
@@ -403,11 +427,15 @@
       construct: construct,
       continuation: createContinuation,
       createPrivateSymbol: createPrivateSymbol,
+      deletePrivate: deletePrivate,
       exportStar: exportStar,
+      getPrivate: getPrivate,
       hasNativeSymbol: hasNativeSymbolFunc,
+      hasPrivate: hasPrivate,
       initTailRecursiveFunction: initTailRecursiveFunction,
       isObject: isObject,
       options: {},
+      setPrivate: setPrivate,
       setupGlobals: setupGlobals,
       toObject: toObject,
       typeof: typeOf,

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -27,12 +27,10 @@
   var $TypeError = TypeError;
   var $create = $Object.create;
   var $defineProperty = $Object.defineProperty;
-  var $freeze = $Object.freeze;
+  var {freeze} = $Object;
   var $getOwnPropertyNames = $Object.getOwnPropertyNames;
   var $keys = $Object.keys;
   var $toString = $Object.prototype.toString;
-  var $preventExtensions = Object.preventExtensions;
-  var $seal = Object.seal;
   var $isExtensible = Object.isExtensible;
   var $apply = Function.prototype.call.bind(Function.prototype.apply)
   var random = Math.random;
@@ -268,56 +266,6 @@
       enumerable: false
     });
 
-    var hashProperty = createPrivateName();
-
-    // cached objects to avoid allocation of new object in defineHashObject
-    var hashPropertyDescriptor = {
-      value: undefined
-    };
-    var hashObjectProperties = {
-      hash: {
-        value: undefined
-      },
-      self: {
-        value: undefined
-      }
-    };
-
-    var hashCounter = 0;
-    function getOwnHashObject(object) {
-      var hashObject = object[hashProperty];
-      // Make sure we got the own property
-      if (hashObject && hashObject.self === object)
-        return hashObject;
-
-      if ($isExtensible(object)) {
-        hashObjectProperties.hash.value = hashCounter++;
-        hashObjectProperties.self.value = object;
-
-        hashPropertyDescriptor.value = $create(null, hashObjectProperties);
-
-        $defineProperty(object, hashProperty, hashPropertyDescriptor);
-        return hashPropertyDescriptor.value;
-      }
-
-      return undefined;
-    }
-
-    function freeze(object) {
-      getOwnHashObject(object);
-      return $freeze.apply(this, arguments);
-    }
-
-    function preventExtensions(object) {
-      getOwnHashObject(object);
-      return $preventExtensions.apply(this, arguments);
-    }
-
-    function seal(object) {
-      getOwnHashObject(object);
-      return $seal.apply(this, arguments);
-    }
-
     freeze(SymbolValue.prototype);
 
     /**
@@ -363,9 +311,6 @@
     function polyfillObject(Object) {
       $defineProperty(Object, 'getOwnPropertyNames',
                       {value: getOwnPropertyNames});
-      $defineProperty(Object, 'freeze', {value: freeze});
-      $defineProperty(Object, 'preventExtensions', {value: preventExtensions});
-      $defineProperty(Object, 'seal', {value: seal});
       $defineProperty(Object, 'keys', {value: keys});
       // getOwnPropertySymbols is added in polyfillSymbol.
     }
@@ -447,7 +392,6 @@
       continuation: createContinuation,
       createPrivateName: createPrivateName,
       exportStar: exportStar,
-      getOwnHashObject: getOwnHashObject,
       getOwnPropertyNames: $getOwnPropertyNames,
       hasNativeSymbol: hasNativeSymbolFunc,
       initTailRecursiveFunction: initTailRecursiveFunction,

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -77,7 +77,8 @@
     return privateNames[s];
   }
 
-  function createPrivateName() {
+  // This creates a Symbol that we filter out in getOwnPropertySymbols.
+  function createPrivateSymbol() {
     var s = hasNativeSymbol ? Symbol() : newUniqueString();
     privateNames[s] = true;
     return s;
@@ -96,7 +97,7 @@
   var isTailRecursiveName = null;
 
   function setupProperTailCalls() {
-    isTailRecursiveName = createPrivateName();
+    isTailRecursiveName = createPrivateSymbol();
 
     // By 19.2.3.1 and 19.2.3.3, Function.prototype.call and
     // Function.prototype.apply do proper tail calls.
@@ -401,7 +402,7 @@
       checkObjectCoercible: checkObjectCoercible,
       construct: construct,
       continuation: createContinuation,
-      createPrivateName: createPrivateName,
+      createPrivateSymbol: createPrivateSymbol,
       exportStar: exportStar,
       hasNativeSymbol: hasNativeSymbolFunc,
       initTailRecursiveFunction: initTailRecursiveFunction,

--- a/test/feature/Collections/Map.js
+++ b/test/feature/Collections/Map.js
@@ -12,6 +12,11 @@ var frozenKey = Object.freeze({});
 
 assert.equal(t.size, 0);
 
+assert.isUndefined(t.get(objectKey));
+assert.isUndefined(t.get(frozenKey));
+assert.isFalse(t.has(objectKey));
+assert.isFalse(t.has(frozenKey));
+
 t.set(undefinedKey, 'value8');
 t.set(nullKey, 'value9');
 t.set(stringKey, 'value5');

--- a/test/feature/Collections/Set.js
+++ b/test/feature/Collections/Set.js
@@ -11,6 +11,9 @@ var zeroKey = 0;
 var frozenKey = Object.freeze({});
 var addReturnValue;
 
+assert.isFalse(t.has(objectKey));
+assert.isFalse(t.has(frozenKey));
+
 t.add(objectKey);
 t.add(stringKey);
 t.add(numberKey);

--- a/test/feature/Yield/ObjectModel.js
+++ b/test/feature/Yield/ObjectModel.js
@@ -18,6 +18,9 @@ assert.equal(g.__proto__, f.prototype);
 assert.deepEqual([], Object.getOwnPropertyNames(f.prototype));
 assert.deepEqual([], Object.getOwnPropertyNames(g));
 
+assert.deepEqual([], Object.getOwnPropertySymbols(f.prototype));
+assert.deepEqual([], Object.getOwnPropertySymbols(g));
+
 f.prototype.x = 42;
 
 var g2 = f();


### PR DESCRIPTION
Add the following runtime functions:

- getPrivate
- setPrivate
- hasPrivate
- deletePrivate

(These are all own property)

The motivation is that we can then use a WeakMap if it is natively
supported.