### PR TITLE
Set the compiler version by explicit function call during boot.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ bin/traceur.js: build/compiled-by-previous-traceur.js $(SRC_NODE)
 	@cp $< $@; touch -t 197001010000.00 bin/traceur.js
 	./traceur --source-maps=file --out bin/traceur.js --referrer='traceur@$(PACKAGE_VERSION)/bin/' \
 	  $(RUNTIME_SCRIPTS) $(TFLAGS) $(SRC)
+	echo "System.setCompilerVersion('traceur@$(PACKAGE_VERSION)');\n" >> $@
 
 # Use last-known-good compiler to compile current source
 build/compiled-by-previous-traceur.js: \

--- a/src/runtime/ModuleStore.js
+++ b/src/runtime/ModuleStore.js
@@ -284,6 +284,14 @@
     getAnonymousModule(func) {
       return new Module(func.call(global), liveModuleSentinel);
     },
+
+    setCompilerVersion(version) {
+      ModuleStore.compilerVersion = version;
+    },
+
+    getCompilerVersion() {
+      return ModuleStore.compilerVersion;
+    }
   };
 
   var moduleStoreModule = new Module({ModuleStore});
@@ -302,6 +310,8 @@
     get: ModuleStore.get,
     set: ModuleStore.set,
     normalize: ModuleStore.normalize,
+    setCompilerVersion: ModuleStore.setCompilerVersion,
+    getCompilerVersion: ModuleStore.getCompilerVersion,
   };
 
 })(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : this);

--- a/src/runtime/TraceurLoader.js
+++ b/src/runtime/TraceurLoader.js
@@ -258,7 +258,8 @@ export class TraceurLoader extends Loader {
   }
 
   get version() {
-    return version;
+    // Fall back to deprecated __moduleName version for one release.
+    return $traceurRuntime.ModuleStore.getCompilerVersion() || version;
   }
 
   /**


### PR DESCRIPTION
 
    The compiler version needs to be written into the compiler source then loaded
    in to the runtime when the compiler is loaded. The current method uses the
    version numbers embedded in the module names. In addition to being obscure,
    it fails when modules=inline messes with the modules names.  Here we emit a statement
    to set the version at the end of the source.
