### PR TITLE
Import runtime modules in dependency order.

### DIFF
--- a/src/runtime/InternalLoader.js
+++ b/src/runtime/InternalLoader.js
@@ -433,7 +433,7 @@ export class InternalLoader {
         this.abortAll(`No module specifiers in ${referrerName}`);
         return;
       }
-      codeUnit.dependencies = moduleSpecifiers.sort().map((name) => {
+      codeUnit.dependencies = moduleSpecifiers.map((name) => {
         return this.getOrCreateCodeUnit_(name, referrerName, null,
             this.defaultModuleMetadata_(codeUnit.metadata));
       });

--- a/src/runtime/runtime-modules.js
+++ b/src/runtime/runtime-modules.js
@@ -14,12 +14,12 @@
 
 /** @fileoverview import all runtime modules, eg for Traceur self-build. */
 
+import './classes.js';
 import './exportStar.js';
 import './properTailCalls.js';
 import './relativeRequire.js';
 import './spread.js';
 import './destructuring.js';
-import './classes.js';
 import './async.js';
 import './generators.js';
 import './template.js';


### PR DESCRIPTION
Some runtime files use classes, but do not explicitly import classes.js.
When compiling with --modules=inline, the order of import is order of evaluation.
Here we reorder the imports and stop sorting them in to alphabetical order.