### PR TITLE
Split src/traceur.js into compiler, loader, and util imports.

### DIFF
--- a/src/compiler-imports.js
+++ b/src/compiler-imports.js
@@ -1,4 +1,4 @@
-// Copyright 2012 Traceur Authors.
+// Copyright 2015 Traceur Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/compiler-imports.js
+++ b/src/compiler-imports.js
@@ -1,0 +1,64 @@
+// Copyright 2012 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export {Compiler} from './Compiler.js';
+
+import {Parser} from './syntax/Parser.js';
+import {Script} from './syntax/trees/ParseTrees.js';
+import {SourceFile} from './syntax/SourceFile.js';
+
+export let syntax = {
+  Parser,
+  SourceFile,
+  trees: {
+    Script
+  }
+};
+
+import {ParseTreeMapWriter} from './outputgeneration/ParseTreeMapWriter.js';
+import {ParseTreeWriter} from './outputgeneration/ParseTreeWriter.js';
+import {regexpuRewritePattern} from './outputgeneration/regexpuRewritePattern.js';
+import {SourceMapConsumer} from './outputgeneration/SourceMapIntegration.js';
+import {SourceMapGenerator} from './outputgeneration/SourceMapIntegration.js';
+import {TreeWriter} from './outputgeneration/TreeWriter.js';
+
+export let outputgeneration = {
+  ParseTreeMapWriter,
+  ParseTreeWriter,
+  regexpuRewritePattern,
+  SourceMapConsumer,
+  SourceMapGenerator,
+  TreeWriter
+};
+
+import {AttachModuleNameTransformer} from './codegeneration/module/AttachModuleNameTransformer.js';
+import {CloneTreeTransformer} from './codegeneration/CloneTreeTransformer.js';
+import {FromOptionsTransformer} from './codegeneration/FromOptionsTransformer.js';
+import {PureES6Transformer} from './codegeneration/PureES6Transformer.js';
+import {createModuleEvaluationStatement} from './codegeneration/module/createModuleEvaluationStatement.js';
+import {parseExpression, parseModule, parseScript, parseStatement} from './codegeneration/PlaceholderParser.js';
+
+export let codegeneration = {
+  CloneTreeTransformer,
+  FromOptionsTransformer,
+  PureES6Transformer,
+  parseExpression,
+  parseModule,
+  parseScript,
+  parseStatement,
+  module: {
+    AttachModuleNameTransformer,
+    createModuleEvaluationStatement
+  }
+};

--- a/src/runtime/loader-imports.js
+++ b/src/runtime/loader-imports.js
@@ -1,4 +1,4 @@
-// Copyright 2012 Traceur Authors.
+// Copyright 2015 Traceur Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/runtime/loader-imports.js
+++ b/src/runtime/loader-imports.js
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './util-imports.js';
-export * from './compiler-imports.js';
-export * from './runtime/loader-imports.js';
+import {Loader} from './Loader.js';
+import {LoaderCompiler} from './LoaderCompiler.js';
+import {BrowserTraceurLoader} from './TraceurLoader.js';
+import {NodeLoaderCompiler} from '../node/NodeLoaderCompiler.js';
+import {InlineLoaderCompiler} from './InlineLoaderCompiler.js';
+import {NodeTraceurLoader} from './NodeTraceurLoader.js';
+import {TraceurLoader} from './TraceurLoader.js';
+
+export let runtime = {
+  BrowserTraceurLoader,
+  InlineLoaderCompiler,
+  Loader,
+  LoaderCompiler,
+  NodeLoaderCompiler,
+  NodeTraceurLoader,
+  TraceurLoader
+};

--- a/src/util-imports.js
+++ b/src/util-imports.js
@@ -1,4 +1,4 @@
-// Copyright 2012 Traceur Authors.
+// Copyright 2015 Traceur Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/util-imports.js
+++ b/src/util-imports.js
@@ -1,0 +1,42 @@
+// Copyright 2012 Traceur Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Used by unit tests only
+import './util/MutedErrorReporter.js';
+
+export {WebPageTranscoder} from './WebPageTranscoder.js';
+export {HTMLImportTranscoder} from './HTMLImportTranscoder.js';
+import {addOptions, CommandOptions, Options} from './Options.js';
+
+// The ModuleStore has to be instantiated before we can register any modules.
+// That means our normal module registration, System.registerModule()
+// cannot be applied to ModuleStore. We can use System.set() to store the
+// ModuleStore module, but that function does not work for --modules=inline.
+let ModuleStore = $traceurRuntime.ModuleStore;
+
+export function get(name) {
+  return ModuleStore.get(ModuleStore.normalize('./' + name, __moduleName));
+}
+
+import {ErrorReporter} from './util/ErrorReporter.js';
+import {CollectingErrorReporter} from './util/CollectingErrorReporter.js';
+
+export let util = {
+  addOptions,
+  CommandOptions,
+  CollectingErrorReporter,
+  ErrorReporter,
+  Options
+};
+


### PR DESCRIPTION
This is a first step to separate out the Loader from the Compiler as well as removing test-only code from the compiler. 