### PR TITLE
Rewrite make-based publish into npm publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,31 @@
   ],
   "scripts": {
     "test": "make test",
-    "start": "make && node ./demo/expressServer.js"
+    "start": "make && node ./demo/expressServer.js",
+    "precheckout-upstream": "git fetch upstream && git branch -D upstream_master || true",
+    "checkout-upstream":  "git checkout -b upstream_master upstream/master",
+    "rebuild": "make clean && make test",
+    "prepublish": "npm run checkout-upstream && npm run rebuild",
+    "postpublish": "npm run push-published && npm run push-gh-pages",
+
+    "/** Update Version Number **/": "After publishing version N, update the version number and commit the result",
+    "store-semver": "node build/printSemver.js > build/npm-version-number",
+    "update-semver": "npm run store-semver && git diff --quiet -- package.json && node build/incrementSemver.js",
+    "precommit-published": "npm run update-semver && npm run rebuild",
+    "commit-published": "cat build/npm-version-number | xargs -I VERSION git commit -a -m \"VERSION\"",
+    "tag-published": "cat build/npm-version-number | xargs -I VERSION git tag -a VERSION -m \"Tagged version VERSION \"",
+    "pre-push-published": "npm run commit-published && npm run tag-published",
+    "push-published": "git push --tags upstream upstream_master:master && git push upstream upstream_master:master  # Push source for version N+1",
+    "postpush-published": "git checkout master && git branch -D upstream_master",
+
+    "/** Update gh-pages branch **/": "Ater publishing version N, update the github docs and REPL",
+    "precheckout-ghpages": "git branch -D upstream_gh_pages || true",
+    "checkout-ghpages": "git checkout -b upstream_gh_pages upstream/master",
+    "precommit-gh-pages": "npm run checkout-ghpages && npm run rebuild && cp gh-pages.gitignore .gitignore # tell git to commit built files.",
+    "commit-gh-pages": "git add -- src/ bin/ && ./traceur -v | xargs -I VERSION git commit -a -m \"Commit binaries for VERSION\"",
+    "prepush-gh-pages": "npm run commit-ghpages",
+    "push-gh-pages": "git push -f upstream upstream_gh_pages:gh-pages",
+    "postpush-gh-pages": "git checkout master && git branch -D upstream_gh_pages"
   },
   "homepage": "https://github.com/google/traceur-compiler",
   "bugs": "https://github.com/google/traceur-compiler/issues",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "precheckout-upstream": "git fetch upstream && git branch -D upstream_master || true",
     "checkout-upstream":  "git checkout -b upstream_master upstream/master",
     "rebuild": "make clean && make test",
-    "prepublish": "npm run checkout-upstream && npm run rebuild",
-    "postpublish": "npm run push-published && npm run push-gh-pages",
+    "prejust-publish": "npm run checkout-upstream && npm run rebuild",
+    "just-publish": "npm publish # workaround https://github.com/npm/npm/issues/10074 ",
+    "postjust-publish": "npm run push-published && npm run push-gh-pages",
 
     "/** Update Version Number **/": "After publishing version N, update the version number and commit the result",
     "store-semver": "node build/printSemver.js > build/npm-version-number",


### PR DESCRIPTION
make is not great with ordered tasks with no file-system state.
Let's see if npm is any better.

TBR=arv@