### PR TITLE
Add test for outputLanguage=es6 and fix TypeTransformer.

### DIFF
--- a/src/codegeneration/TypeTransformer.js
+++ b/src/codegeneration/TypeTransformer.js
@@ -123,7 +123,7 @@ export class TypeTransformer extends ParseTreeTransformer {
   }
 
   transformImportDeclaration(tree) {
-    if (tree.importClause.type === IMPORT_TYPE_CLAUSE) {
+    if (!tree.importClause || tree.importClause.type === IMPORT_TYPE_CLAUSE) {
       return new AnonBlock(null, []);
     }
     return super.transformImportDeclaration(tree);

--- a/src/node/command.js
+++ b/src/node/command.js
@@ -142,7 +142,7 @@ function compileAll(out, sources, options) {
           console.error(err);
         });
       } else {
-        console.error(err);
+        console.error(err.stack || err);
       }
       process.exit(1);
     });

--- a/test/unit/codegeneration/PureES6Transformer.js
+++ b/test/unit/codegeneration/PureES6Transformer.js
@@ -29,7 +29,7 @@ suite('PureES6Transformer.js', function() {
     return parser.parseModule();
   }
 
-  test('Inline', function() {
+  test('Inline', function(done) {
     var options = new Options({
       modules: 'inline'
     });
@@ -39,6 +39,7 @@ suite('PureES6Transformer.js', function() {
     var reporter = new ErrorReporter();
 
     var code = [
+      `import './resources/test_0.js';`,
       `import {TestA} from ${"'./resources/test_a.js'"};`,
       `import {TestB} from ${"'./resources/test_b.js'"};`,
       'export class App {',
@@ -69,5 +70,6 @@ suite('PureES6Transformer.js', function() {
     var transformer = new PureES6Transformer(reporter, options, metadata);
     var transformed = transformer.transform(tree);
     assert.equal(write(transformed), write(expectedTree));
+    done();
   });
 });


### PR DESCRIPTION
    When there is no import clause, we throw in TypeTransformer.
    TBR @arv