### PR TITLE
Use a context argument in System.register

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -118,6 +118,30 @@ class DeclarationExtractionTransformer extends HoistVariablesTransformer {
 }
 
 /**
+ * Replaces __moduleName with $__moduleContext.id
+ *
+ * This allows code to use the __moduleName temporary syntax to reference 
+ * the current module name for relative importing via System.import('./x', __moduleName)
+ * In the future this will be deprecated and $__moduleContext extended in the implementation
+ * to support any contextual metadata and loading features determined in the spec.
+ */
+class ModuleNameIdentifierTransformer extends ScopeTransformer {
+  constructor() {
+    super('__moduleName');
+    this.usesModuleName = false;
+  }
+
+  transformIdentifierExpression(tree) {
+    if (tree.identifierToken.value === '__moduleName') {
+      this.usesModuleName = true;
+      return parseExpression `$__moduleContext.id`;
+    }
+    return super.transformIdentifierExpression(tree);
+  }
+
+}
+
+/**
  * Replaces assignments of an identifier with an update function to update
  * dependent modules
  *
@@ -253,12 +277,6 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
     this.exportStarBindings = [];
   }
 
-  transformIdentifierExpression(tree) {
-    if (tree.identifierToken.value === '__moduleName')
-      this.usesModuleName = true;
-    return super.transformIdentifierExpression(tree);
-  }
-
   getModuleName(tree) {
     if (this.anonymousModule)
       return null;
@@ -278,13 +296,13 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
     if (this.usesModuleName) {
       if (this.moduleName) {
         return parseStatements `System.register(${this.moduleName},
-            ${this.dependencies}, function($__export, __moduleName) {
+            ${this.dependencies}, function($__export, $__moduleContext) {
               ${statements}
             });`;
       }
 
       return parseStatements
-          `System.register(${this.dependencies}, function($__export, __moduleName) {
+          `System.register(${this.dependencies}, function($__export, $__moduleContext) {
             ${statements}
           });`;
     }
@@ -345,6 +363,12 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
    */
   appendExportStatement(statements) {
     let declarationExtractionTransformer = new DeclarationExtractionTransformer();
+
+    // convert __moduleName identifiers into $__moduleContext.id
+    let moduleNameIdentifierTransformer = new ModuleNameIdentifierTransformer();
+    statements = moduleNameIdentifierTransformer.transformList(statements);
+    if (moduleNameIdentifierTransformer.usesModuleName)
+      this.usesModuleName = true;
 
     // replace local export assignments with binding functions
     // using InsertBindingAssignmentTransformer

--- a/third_party/es6-module-loader/loader.js
+++ b/third_party/es6-module-loader/loader.js
@@ -709,7 +709,7 @@ function logloads(loads) {
           }
         }
         return value;
-      }, load.name);
+      }, {id: load.name});
 
       // setup our setters and execution function
       load.module.setters = registryEntry.setters;


### PR DESCRIPTION
Thanks so much for the previous work in removing the `System` global dependency. I'm in the process of finalising the new Traceur plugin for SystemJS and will report back further if there are any further hitches.

I just wanted to go back to this format adjustment in System.register before it is too late though.

While discussing with @sebmck in the related Babel PR, it seemed a context object might be more appropriate as it can the accommodate and expand to fill whatever role the ES Module contextual syntax uses in future.

I'd be interested to hear both your thoughts on this format adjustment.

The PR here updates Traceur to use this idea of a context object argument with just one `id` property for now, which may well be a much more adaptable approach.

This is in line with the updated Babel PR at https://github.com/babel/babel/pull/3166 and I will also see if I can update the TypeScript PR at https://github.com/Microsoft/TypeScript/pull/6098 as well.