### PR TITLE
Exclude var __moduleName statement in System.register

### DIFF
--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -36,6 +36,7 @@ import {
   createFunctionExpression,
   createIdentifierExpression as id,
   createObjectLiteralForDescriptor,
+  createUseStrictDirective,
   createVariableDeclarationList,
   createVariableStatement
 } from './ParseTreeFactory.js';
@@ -271,7 +272,7 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
   }
 
   wrapModule(statements) {
-    let prolog = super.moduleProlog();
+    let prolog = [createUseStrictDirective()];
 
     statements = prolog.concat(statements);
 


### PR DESCRIPTION
This removes the unnecessary `var __moduleName` output from System.register since we have a new wrapping format for this.

There is still a `var __moduleName` creation in https://github.com/google/traceur-compiler/blob/master/src/codegeneration/ModuleTransformer.js#L132 which can be removed unless this is being used for other formats?

//cc @johnjbarton 

@arv I guess you will ask for a test here :) But such a test would be like testing for the non-existence of any arbitrary nonsense scope variable in an output - it shouldn't have been there to begin with.