### PR TITLE
make bin/traceur.js before dist/commonjs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ updateSemver: # unless the package.json has been manually edited.
 	node build/versionInfo.js -v > build/npm-version-number
 	git diff --quiet -- package.json && node build/incrementSemver.js
 
-dist/commonjs:
+dist/commonjs: bin/traceur.js
 	./traceur --dir src/ dist/commonjs/ --modules=commonjs
 
 prepublish: bin/traceur.js bin/traceur-runtime.js


### PR DESCRIPTION
make clean removes bin/traceur.js so dist/commonjs must depend upon it.

TBR @arv