### PR TITLE
JSX: Tag name starting with an uppercase should use identifier

### DIFF
--- a/src/codegeneration/JsxTransformer.js
+++ b/src/codegeneration/JsxTransformer.js
@@ -26,6 +26,7 @@ import {ParseTreeTransformer} from './ParseTreeTransformer.js';
 import {STRING} from '../syntax/TokenType.js';
 import {
   createArgumentList,
+  createIdentifierExpression,
   createIdentifierToken,
   createMemberExpression,
   createNullLiteral,
@@ -94,7 +95,11 @@ export class JsxTransformer extends ParseTreeTransformer {
 
   transformJsxElementName(tree) {
     if (tree.names.length === 1) {
-      return createStringLiteral(tree.names[0].value);
+      let {value} = tree.names[0];
+      if (value[0] === value[0].toUpperCase()) {
+        return createIdentifierExpression(value);;
+      }
+      return createStringLiteral(value);
     }
 
     let names = tree.names.map(jsxIdentifierToToken);

--- a/test/feature/JSX/TagName.js
+++ b/test/feature/JSX/TagName.js
@@ -32,3 +32,13 @@ log = [];
 <b-b.toString/>;
 
 assert.deepEqual(['a-a', String.prototype.toString], log);
+
+const A = {a: 1};
+const Bb = {b: 2};
+
+log = [];
+
+<A/>;
+<Bb/>;
+
+assert.deepEqual([A, Bb], log);


### PR DESCRIPTION
`<Abc/>` should generate `React.createElement(Abc, null)` and
not `React.createElement('Abc', null)`.