### PR TITLE
JSX: Support boolean shorthand attributes

### DIFF
--- a/src/codegeneration/JsxTransformer.js
+++ b/src/codegeneration/JsxTransformer.js
@@ -34,6 +34,7 @@ import {
   createPropertyNameAssignment,
   createStringLiteral,
   createStringLiteralToken,
+  createTrueLiteral,
 } from './ParseTreeFactory.js';
 import {parseExpression} from './PlaceholderParser.js';
 
@@ -115,7 +116,12 @@ export class JsxTransformer extends ParseTreeTransformer {
     let name =
         new LiteralPropertyName(tree.name.location,
                                 jsxIdentifierToToken(tree.name));
-    let value = this.transformAny(tree.value);
+    let value;
+    if (tree.value === null) {
+      value = createTrueLiteral();
+    } else {
+      value = this.transformAny(tree.value);
+    }
     return createPropertyNameAssignment(name, value);
   }
 

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -960,8 +960,10 @@ export class ParseTreeWriter extends ParseTreeVisitor {
 
   visitJsxAttribute(tree) {
     this.writeToken_(tree.name);
-    this.write_(EQUAL);
-    this.visitAny(tree.value);
+    if (tree.value !== null) {
+      this.write_(EQUAL);
+      this.visitAny(tree.value);
+    }
   }
 
   visitJsxElement(tree) {

--- a/src/syntax/Parser.js
+++ b/src/syntax/Parser.js
@@ -4475,8 +4475,11 @@ export class Parser {
   parseJsxAttribute_() {
     let name = this.eatJsx_(JSX_IDENTIFIER);
     let start = name.location.start;
-    this.eatJsx_(EQUAL);
-    let value = this.parseJsxAttributeValue_();
+    let value = null;
+    if (peekJsxToken().type === EQUAL) {
+      this.eatJsx_(EQUAL);
+      value = this.parseJsxAttributeValue_();
+    }
     return new JsxAttribute(this.getTreeLocation_(start), name, value);
   }
 

--- a/test/feature/JSX/Attributes.js
+++ b/test/feature/JSX/Attributes.js
@@ -13,3 +13,8 @@ assert.equal('d', <p a="b" c="d"/>.c);
 assert.equal('f', <p e-e="f"/>['e-e']);
 
 assert.deepEqual('j', <p g=<h i="j"/>/>.g.i);
+
+// Boolean attribute shorthand.
+assert.deepEqual({b: true}, <a b/>);
+assert.deepEqual({b: true, c:true}, <a b c/>);
+assert.deepEqual({b: 'b', c: true, d: 'd'}, <a b='b' c d='d'/>);


### PR DESCRIPTION
`<a b/>` is short for `<a b={true}/>`.