### PR TITLE
JSX: Add support for JSXSpreadAttribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ INDIVIDUAL_RUNTIME_MODULES = \
   src/runtime/generators.js \
   src/runtime/async.js \
   src/runtime/template.js \
+  src/runtime/jsx.js \
   #end runtime modules
 SRC = \
   $(RUNTIME_MODULES) \

--- a/src/outputgeneration/ParseTreeWriter.js
+++ b/src/outputgeneration/ParseTreeWriter.js
@@ -970,9 +970,7 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     this.write_(OPEN_ANGLE);
     this.visitAny(tree.name);
     for (let i = 0; i < tree.attributes.length; i++) {
-      if (i > 0) {
-        this.writeRequiredSpace_();
-      }
+      this.writeSpace_();
       this.visitAny(tree.attributes[i]);
     }
     if (tree.children.length === 0) {
@@ -1005,6 +1003,13 @@ export class ParseTreeWriter extends ParseTreeVisitor {
     if (tree.expression !== null) {
       this.visitAny(tree.expression);
     }
+    this.write_(CLOSE_CURLY)
+  }
+
+  visitJsxSpreadAttribute(tree) {
+    this.write_(OPEN_CURLY)
+    this.write_(DOT_DOT_DOT);
+    this.visitAny(tree.expression);
     this.write_(CLOSE_CURLY)
   }
 

--- a/src/runtime/jsx.js
+++ b/src/runtime/jsx.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Traceur Authors.
+// Copyright 2016 Traceur Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview import all runtime modules, eg for Traceur self-build.
- */
-
-import './symbols.js';
-import './classes.js';
-import './exportStar.js';
-import './properTailCalls.js';
-import './relativeRequire.js';
-import './spread.js';
-import './destructuring.js';
-import './async.js';
-import './generators.js';
-import './template.js';
-import './jsx.js';
+import jsxSpreadAttributes from './modules/jsxSpreadAttributes.js';
+$traceurRuntime.jsxSpreadAttributes = jsxSpreadAttributes;

--- a/src/runtime/modules/jsxSpreadAttributes.js
+++ b/src/runtime/modules/jsxSpreadAttributes.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Traceur Authors.
+// Copyright 2016 Traceur Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview import all runtime modules, eg for Traceur self-build.
- */
-
-import './symbols.js';
-import './classes.js';
-import './exportStar.js';
-import './properTailCalls.js';
-import './relativeRequire.js';
-import './spread.js';
-import './destructuring.js';
-import './async.js';
-import './generators.js';
-import './template.js';
-import './jsx.js';
+export {default as default} from '../polyfills/assign.js';

--- a/src/runtime/polyfills/Object.js
+++ b/src/runtime/polyfills/Object.js
@@ -16,12 +16,13 @@ import {
   maybeAddFunctions,
   registerPolyfill
 } from './utils.js';
+import assign from './assign.js';
+export {assign};
 
 var {
   defineProperty,
   getOwnPropertyDescriptor,
   getOwnPropertyNames,
-  keys
 } = Object;
 
 // Object.is
@@ -31,20 +32,6 @@ export function is(left, right) {
   if (left === right)
     return left !== 0 || 1 / left === 1 / right;
   return left !== left && right !== right;
-}
-
-// Object.assign (19.1.3.1)
-export function assign(target) {
-  for (var i = 1; i < arguments.length; i++) {
-    var source = arguments[i];
-    var props = source == null ? [] : keys(source);
-    var p, length = props.length;
-    for (p = 0; p < length; p++) {
-      var name = props[p];
-      target[name] = source[name];
-    }
-  }
-  return target;
 }
 
 // Object.mixin (19.1.3.15)

--- a/src/runtime/polyfills/assign.js
+++ b/src/runtime/polyfills/assign.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Traceur Authors.
+// Copyright 2014 Traceur Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview import all runtime modules, eg for Traceur self-build.
- */
+const {keys} = Object;
 
-import './symbols.js';
-import './classes.js';
-import './exportStar.js';
-import './properTailCalls.js';
-import './relativeRequire.js';
-import './spread.js';
-import './destructuring.js';
-import './async.js';
-import './generators.js';
-import './template.js';
-import './jsx.js';
+// Object.assign (19.1.3.1)
+export default function assign(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    var props = source == null ? [] : keys(source);
+    var p, length = props.length;
+    for (p = 0; p < length; p++) {
+      var name = props[p];
+      target[name] = source[name];
+    }
+  }
+  return target;
+}

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -89,6 +89,7 @@ import {
   JSX_ELEMENT_NAME,
   JSX_ELEMENT,
   JSX_PLACEHOLDER,
+  JSX_SPREAD_ATTRIBUTE,
   JSX_TEXT,
   LITERAL_PROPERTY_NAME,
   METHOD,
@@ -736,7 +737,9 @@ export class ParseTreeValidator extends ParseTreeVisitor {
     this.checkType_(JSX_ELEMENT_NAME, tree.name, 'JSX Element Name expected');
     for (let i = 0; i < tree.attributes.length; i++) {
       let attr = tree.attributes[i];
-      this.checkVisit_(attr.type === JSX_ATTRIBUTE, attr,
+      this.checkVisit_(attr.type === JSX_ATTRIBUTE ||
+                       attr.type === JSX_SPREAD_ATTRIBUTE,
+                       attr,
                        'JSX Attribute expected');
     }
     for (let i = 0; i < tree.children.length; i++) {

--- a/src/syntax/trees/trees.json
+++ b/src/syntax/trees/trees.json
@@ -775,6 +775,14 @@
       "ParseTree"
     ]
   },
+  "JsxSpreadAttribute": {
+    "location": [
+      "SourceRange"
+    ],
+    "expression": [
+      "ParseTree"
+    ]
+  },
   "JsxText": {
     "location": [
       "SourceRange"

--- a/test/feature/JSX/SpreadAttributes.js
+++ b/test/feature/JSX/SpreadAttributes.js
@@ -1,0 +1,17 @@
+// Options: --jsx=f
+
+function f(name, props) {
+  return props;
+}
+
+assert.deepEqual(<p {...{a: 'a'}}/>, {a: 'a'});
+assert.deepEqual(<p a='a' {...{b: 'b'}}/>, {a: 'a', b: 'b'});
+assert.deepEqual(<p a='a' {...{b: 'b'}} c='c'/>, {a: 'a', b: 'b', c: 'c'});
+assert.deepEqual(<p a='a' b='b' {...{c: 'c'}}/>, {a: 'a', b: 'b', c: 'c'});
+assert.deepEqual(<p a='a' b='b' c='c' {...{}}/>, {a: 'a', b: 'b', c: 'c'});
+assert.deepEqual(<p {...{a: 'a'}} b='b' c='c'/>, {a: 'a', b: 'b', c: 'c'});
+assert.deepEqual(<p {...{a: 'a'}} {...{b: 'b'}} {...{c: 'c'}}/>,
+    {a: 'a', b: 'b', c: 'c'});
+
+assert.deepEqual(<p a={1} {...{a: 2}}/>, {a: 2});
+assert.deepEqual(<p {...{a: 1}} a={2}/>, {a: 2});


### PR DESCRIPTION
This allows spreading an object into props/attributes

```js
<p a='a' {...{b: 1, c: 2}}/>
// same as (except the expansion happens at runtime
<p a='a' b={1} c={2}/>
```