### PR TITLE
Teach runUnitTests.js to accept a glob from the command line

### DIFF
--- a/test/featureTestRunner.js
+++ b/test/featureTestRunner.js
@@ -337,11 +337,6 @@ if (typeof window !== 'undefined') {
   featureTestRunner = new NodeTraceurFeatureTestRunner();
 }
 
-featureTestRunner.applyOptions([
-  './test/feature/*/*.js',
-  './test/feature/*.js'
-]);
-
 let context = featureTestRunner.getContext();
 
 export let suite = context.suite;

--- a/test/runFeatureTests.js
+++ b/test/runFeatureTests.js
@@ -16,6 +16,18 @@
 
 import {featureTestRunner} from './featureTestRunner.js';
 
+let globs = [
+	'./test/feature/*/*.js',
+	'./test/feature/*.js'
+];
+
+let inputGlob = process.argv[2];
+
+if (inputGlob) {
+	globs = [inputGlob];
+}
+featureTestRunner.applyOptions(globs);
+
 featureTestRunner.run().catch((ex) => {
 	console.error('featureTestRunner FAILED ', ex.stack || ex);
 });

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -16,6 +16,26 @@
 
 import {unitTestRunner} from './unit/unitTestRunner.js';
 
+let globs = [
+  'test/unit/util/*.js',
+  'test/unit/syntax/*.js',
+  'test/unit/codegeneration/*.js',
+  'test/unit/semantics/*.js',
+  'test/unit/tools/*.js',
+  'test/unit/runtime/*.js',
+  'test/unit/system/*.js',
+  'test/unit/node/*.js',
+  'test/unit/*.js'
+];
+
+let inputGlob = process.argv[2];
+
+if (inputGlob) {
+	globs = [inputGlob];
+}
+
+unitTestRunner.applyOptions(globs);
+
 unitTestRunner.run().then((failures) => {
     process.exit(failures);
   },(ex) => {

--- a/test/unit/unitTestRunner.js
+++ b/test/unit/unitTestRunner.js
@@ -31,15 +31,3 @@ export let suite = context.suite;
 export let test = context.test;
 export let setup = context.setup;
 export let teardown = context.teardown;
-
-unitTestRunner.applyOptions([
-  'test/unit/util/*.js',
-  'test/unit/syntax/*.js',
-  'test/unit/codegeneration/*.js',
-  'test/unit/semantics/*.js',
-  'test/unit/tools/*.js',
-  'test/unit/runtime/*.js',
-  'test/unit/system/*.js',
-  'test/unit/node/*.js',
-  'test/unit/*.js'
-]);


### PR DESCRIPTION
eg ./tval test/runUnitTests.js "./test/unit/runtime/*.js"
The input glob has to be quoted or the shell will expand it, and
pattern failures seem to result in broken tests rather than error
messages, but it's a faster way to do partial tests than --grep.