### PR TITLE
For the test files, switch based on global 'require'  rather than

### DIFF
--- a/test/asserts.js
+++ b/test/asserts.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 let chai;
-if (typeof window !== 'undefined') {
+if (typeof require === 'undefined') {
   // In the browwser we have no synchronous way of importing chai,
   // we have to rely on manual user include of <script>
   if (!window.chai) {

--- a/test/featureTestRunner.js
+++ b/test/featureTestRunner.js
@@ -331,7 +331,7 @@ class BrowserTraceurFeatureTestRunner extends BrowserTraceurTestRunner {
 }
 
 export let featureTestRunner;
-if (typeof window !== 'undefined') {
+if (typeof require === 'undefined') {
   featureTestRunner = new BrowserTraceurFeatureTestRunner();
 } else {
   featureTestRunner = new NodeTraceurFeatureTestRunner();

--- a/test/modular/MochaDependencies.js
+++ b/test/modular/MochaDependencies.js
@@ -18,7 +18,7 @@
   export let Runner;
   export let reporters;
 
-  if (typeof window === 'undefined') {
+  if (typeof require !== 'undefined') {
     Mocha = require('mocha');
     Runner = require('mocha/lib/runner');
     reporters = require('mocha/lib/reporters');

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -37,7 +37,7 @@ if (inputGlob) {
 unitTestRunner.applyOptions(globs);
 
 unitTestRunner.run().then((failures) => {
-    process.exit(failures || 0);
+    process.exit(failures);
   },(ex) => {
     console.log('unitTestRunner FAILED', ex.stack || ex);
     process.exit(-1);

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -37,7 +37,7 @@ if (inputGlob) {
 unitTestRunner.applyOptions(globs);
 
 unitTestRunner.run().then((failures) => {
-    process.exit(failures);
+    process.exit(failures || 0);
   },(ex) => {
     console.log('unitTestRunner FAILED', ex.stack || ex);
     process.exit(-1);

--- a/test/unit/unitTestRunner.js
+++ b/test/unit/unitTestRunner.js
@@ -18,7 +18,7 @@ import {BrowserTraceurTestRunner} from '../modular/BrowserTraceurTestRunner.js';
 export * from '../asserts.js';
 
 export let unitTestRunner;
-if (typeof window !== 'undefined') {
+if (typeof require === 'undefined') {
   unitTestRunner = new BrowserTraceurTestRunner();
 } else {
   unitTestRunner = new NodeTraceurTestRunner();


### PR DESCRIPTION
global 'window' to select between browser and node.
This is one step to allow debugging with a solution like iron-node.
As a practical matter we are good either way.