### PR TITLE
JSX: Fix whitespace and escaping of attribute values

### DIFF
--- a/src/codegeneration/JsxTransformer.js
+++ b/src/codegeneration/JsxTransformer.js
@@ -17,6 +17,7 @@ import {
   JSX_PLACEHOLDER,
   JSX_SPREAD_ATTRIBUTE,
   JSX_TEXT,
+  LITERAL_EXPRESSION,
 } from '../syntax/trees/ParseTreeType.js';
 import {
   JsxText,
@@ -24,6 +25,7 @@ import {
   LiteralPropertyName,
   SpreadExpression,
 } from '../syntax/trees/ParseTrees.js';
+import {LiteralToken} from '../syntax/LiteralToken.js';
 import {ParseTreeTransformer} from './ParseTreeTransformer.js';
 import {STRING} from '../syntax/TokenType.js';
 import {
@@ -135,6 +137,13 @@ export class JsxTransformer extends ParseTreeTransformer {
     let value;
     if (tree.value === null) {
       value = createTrueLiteral();
+    } else if (tree.value.type === LITERAL_EXPRESSION) {
+      const {literalToken} = tree.value;
+      const v = literalToken.value;
+      const {location} = literalToken;
+      const lit =
+          new LiteralToken(STRING, normalizeAttributeValue(v), location);
+      value = new LiteralExpression(location, lit);
     } else {
       value = this.transformAny(tree.value);
     }
@@ -201,4 +210,10 @@ function jsxIdentifierToToken(token) {
     return createStringLiteralToken(value);
   }
   return createIdentifierToken(value);
+}
+
+function normalizeAttributeValue(s) {
+  return JSON.stringify(
+      s.slice(1, -1).  // remove the quotes
+      replace(/\n\s+/g, ' '));
 }

--- a/test/feature/JSX/AttributesWhitespace.js
+++ b/test/feature/JSX/AttributesWhitespace.js
@@ -1,0 +1,30 @@
+// Options: --jsx=f
+
+// This file has trailing whitespace. Make sure your editor does not strip
+// them.
+
+function f(name, props) {
+  return props.b;
+}
+
+assert.equal(<a b=" c "/>, ' c ');
+assert.equal(<a b="  c  "/>, '  c  ');
+assert.equal(<a b="c "/>, 'c ');
+assert.equal(<a b="c "/>, 'c ');
+assert.equal(<a b="\tc\n"/>, '\\tc\\n');
+assert.equal(<a b="'"/>, '\'');
+assert.equal(<a b='"'/>, '"');
+assert.equal(<a b="&"/>, '&');
+assert.equal(<a b='
+'/>, '\n');
+assert.equal(<a b=' 
+'/>, ' \n');
+assert.equal(<a b='
+ '/>, ' ');
+assert.equal(<a b='
+
+'/>, ' ');
+assert.equal(<a b=' 
+
+'/>, '  ');
+assert.equal(<a b='	'/>, '\t');


### PR DESCRIPTION
The behavior is reversed engineer from Babel since the
semantics is not documented in the JSX "spec".

Fixes #2088