### PR TITLE
Remove custom assert functions

### DIFF
--- a/test/asserts.js
+++ b/test/asserts.js
@@ -26,8 +26,3 @@ if (typeof require === 'undefined') {
 
 export let assert = chai.assert;
 export let AssertionError = chai.AssertionError;
-
-export function assertArrayEquals(expected, actual) {
-  assert.equal(JSON.stringify(actual, null, 2),
-               JSON.stringify(expected, null, 2));
-}

--- a/test/feature/Annotations/AnnotatedFunctionTypedParam.module.js
+++ b/test/feature/Annotations/AnnotatedFunctionTypedParam.module.js
@@ -7,4 +7,4 @@ import {
 @Anno
 function AnnotatedFnMultiParam(x:X, y) {}
 
-assertArrayEquals([[X], []], AnnotatedFnMultiParam.parameters);
+assert.deepEqual([[X], []], AnnotatedFnMultiParam.parameters);

--- a/test/feature/Annotations/AnnotatedTypedClass.module.js
+++ b/test/feature/Annotations/AnnotatedTypedClass.module.js
@@ -15,6 +15,6 @@ class AnnotatedTypedClass {
   bar(a:X) {}
 }
 
-assertArrayEquals([new Anno('class'), new Anno2('ctor')], AnnotatedTypedClass.annotations);
-assertArrayEquals([[X, new Anno], [new Anno('b')]], AnnotatedTypedClass.parameters);
-assertArrayEquals([[X]], AnnotatedTypedClass.prototype.bar.parameters);
+assert.deepEqual([new Anno('class'), new Anno2('ctor')], AnnotatedTypedClass.annotations);
+assert.deepEqual([[X, new Anno], [new Anno('b')]], AnnotatedTypedClass.parameters);
+assert.deepEqual([[X]], AnnotatedTypedClass.prototype.bar.parameters);

--- a/test/feature/Annotations/AnnotatedTypedParam.module.js
+++ b/test/feature/Annotations/AnnotatedTypedParam.module.js
@@ -6,4 +6,4 @@ import {
 
 function AnnotatedTypedParam(@Anno x:X) {}
 
-assertArrayEquals([[X, new Anno]], AnnotatedTypedParam.parameters);
+assert.deepEqual([[X, new Anno]], AnnotatedTypedParam.parameters);

--- a/test/feature/Annotations/Class.module.js
+++ b/test/feature/Annotations/Class.module.js
@@ -13,15 +13,15 @@ class AnnotatedClass {
   set prop(x) {}
 }
 
-assertArrayEquals([new Anno], AnnotatedClass.annotations);
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno], AnnotatedClass.annotations);
+assert.deepEqual([new Anno],
     AnnotatedClass.prototype.annotatedMethod.annotations);
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     Object.getOwnPropertyDescriptor(AnnotatedClass.prototype, 'prop').
         get.annotations);
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     Object.getOwnPropertyDescriptor(AnnotatedClass.prototype, 'prop').
         set.annotations);
 

--- a/test/feature/Annotations/ClassConstructor.module.js
+++ b/test/feature/Annotations/ClassConstructor.module.js
@@ -10,4 +10,4 @@ class AnnotatedClassCtor {
   constructor() {}
 }
 
-assertArrayEquals([new Anno, new Anno2], AnnotatedClassCtor.annotations);
+assert.deepEqual([new Anno, new Anno2], AnnotatedClassCtor.annotations);

--- a/test/feature/Annotations/ClassGeneratorMethod.module.js
+++ b/test/feature/Annotations/ClassGeneratorMethod.module.js
@@ -12,7 +12,7 @@ class AnnotatedClass {
   static *staticGenerate() {}
 }
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     AnnotatedClass.prototype.generate.annotations);
-assertArrayEquals([new Anno2],
+assert.deepEqual([new Anno2],
     AnnotatedClass.staticGenerate.annotations);

--- a/test/feature/Annotations/ClassInClass.module.js
+++ b/test/feature/Annotations/ClassInClass.module.js
@@ -23,8 +23,8 @@ class Outer {
 }
 
 var Inner = Outer.nested;
-assertArrayEquals([new Anno('outer'), new Anno2('outerCtor')], Outer.annotations);
-assertArrayEquals([new Anno('inner'), new Anno2('innerCtor')], Inner.annotations);
-assertArrayEquals([new Anno('innerMethod')], Inner.prototype.method.annotations);
-assertArrayEquals([[X, new Anno('innerMethodParam')]],
+assert.deepEqual([new Anno('outer'), new Anno2('outerCtor')], Outer.annotations);
+assert.deepEqual([new Anno('inner'), new Anno2('innerCtor')], Inner.annotations);
+assert.deepEqual([new Anno('innerMethod')], Inner.prototype.method.annotations);
+assert.deepEqual([[X, new Anno('innerMethodParam')]],
     Inner.prototype.method.parameters);

--- a/test/feature/Annotations/ClassInsideObjectGetter.module.js
+++ b/test/feature/Annotations/ClassInsideObjectGetter.module.js
@@ -11,6 +11,6 @@ var object = {
   }
 };
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     Object.getOwnPropertyDescriptor(object.foo.prototype, 'b').get.annotations);
 

--- a/test/feature/Annotations/Constructor.module.js
+++ b/test/feature/Annotations/Constructor.module.js
@@ -6,4 +6,4 @@ class AnnotatedCtor {
   constructor() {}
 }
 
-assertArrayEquals([new Anno2], AnnotatedCtor.annotations);
+assert.deepEqual([new Anno2], AnnotatedCtor.annotations);

--- a/test/feature/Annotations/ConstructorParam.module.js
+++ b/test/feature/Annotations/ConstructorParam.module.js
@@ -5,5 +5,5 @@ class CtorParam {
   constructor(@Anno x) {}
 }
 
-assertArrayEquals([[new Anno]], CtorParam.parameters);
+assert.deepEqual([[new Anno]], CtorParam.parameters);
 

--- a/test/feature/Annotations/ExportedClass.module.js
+++ b/test/feature/Annotations/ExportedClass.module.js
@@ -7,9 +7,9 @@ import {
 } from './resources/exported-classes.js';
 
 
-assertArrayEquals([new Anno], ExportedAnnotatedClass.annotations);
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno], ExportedAnnotatedClass.annotations);
+assert.deepEqual([new Anno],
     ExportedAnnotatedClass.prototype.annotatedMethod.annotations);
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     ExportedUnannotatedClass.prototype.annotatedMethod.annotations);

--- a/test/feature/Annotations/ExportedFunction.module.js
+++ b/test/feature/Annotations/ExportedFunction.module.js
@@ -7,7 +7,7 @@ import {
   exportedUnannotated
 } from './resources/exported-functions.js';
 
-assertArrayEquals([new Anno], exportedAnnotated.annotations);
-assertArrayEquals([[new Anno]], exportedAnnotated.parameters);
+assert.deepEqual([new Anno], exportedAnnotated.annotations);
+assert.deepEqual([[new Anno]], exportedAnnotated.parameters);
 assert.isUndefined(exportedUnannotated.annotations);
-assertArrayEquals([[new Anno]], exportedUnannotated.parameters);
+assert.deepEqual([[new Anno]], exportedUnannotated.parameters);

--- a/test/feature/Annotations/FunctionInsideClassGetter.module.js
+++ b/test/feature/Annotations/FunctionInsideClassGetter.module.js
@@ -10,5 +10,5 @@ class Test {
   }
 }
 
-assertArrayEquals([new Anno('Test')], Test.annotations);
-assertArrayEquals([new Anno('x')], new Test().annotatedFn.annotations);
+assert.deepEqual([new Anno('Test')], Test.annotations);
+assert.deepEqual([new Anno('x')], new Test().annotatedFn.annotations);

--- a/test/feature/Annotations/FunctionMultipleAnnotatedParameter.module.js
+++ b/test/feature/Annotations/FunctionMultipleAnnotatedParameter.module.js
@@ -6,5 +6,5 @@ import {
 
 function MultipleAnnotations(@Anno('x') @Anno2('x') x) {}
 
-assertArrayEquals([[new Anno('x'), new Anno2('x')]],
+assert.deepEqual([[new Anno('x'), new Anno2('x')]],
     MultipleAnnotations.parameters);

--- a/test/feature/Annotations/FunctionMultipleParameters.module.js
+++ b/test/feature/Annotations/FunctionMultipleParameters.module.js
@@ -3,5 +3,5 @@ import {Anno} from './resources/setup.js';
 
 function MultipleParams(@Anno('x') x, @Anno('y') y) {}
 
-assertArrayEquals([[new Anno('x')], [new Anno('y')]],
+assert.deepEqual([[new Anno('x')], [new Anno('y')]],
     MultipleParams.parameters);

--- a/test/feature/Annotations/FunctionParameter.module.js
+++ b/test/feature/Annotations/FunctionParameter.module.js
@@ -3,4 +3,4 @@ import {Anno} from './resources/setup.js';
 
 function AnnotatedParam(@Anno('x') x) {}
 
-assertArrayEquals([[new Anno('x')]], AnnotatedParam.parameters);
+assert.deepEqual([[new Anno('x')]], AnnotatedParam.parameters);

--- a/test/feature/Annotations/GeneratorFunction.module.js
+++ b/test/feature/Annotations/GeneratorFunction.module.js
@@ -4,4 +4,4 @@ import {Anno} from './resources/setup.js';
 @Anno
 function* generate() {}
 
-assertArrayEquals([new Anno], generate.annotations);
+assert.deepEqual([new Anno], generate.annotations);

--- a/test/feature/Annotations/GetAccessorStringName.module.js
+++ b/test/feature/Annotations/GetAccessorStringName.module.js
@@ -8,7 +8,7 @@ class C {
   get xyz() { return 1; }
 }
 
-assertArrayEquals([new Anno('x y z')],
+assert.deepEqual([new Anno('x y z')],
     Object.getOwnPropertyDescriptor(C.prototype, 'x y z').get.annotations);
-assertArrayEquals([new Anno('xyz')],
+assert.deepEqual([new Anno('xyz')],
     Object.getOwnPropertyDescriptor(C.prototype, 'xyz').get.annotations);

--- a/test/feature/Annotations/MemberExpressionAnnotation.js
+++ b/test/feature/Annotations/MemberExpressionAnnotation.js
@@ -23,10 +23,10 @@ class NestedWithArgs {
   annotatedMethod() {}
 }
 
-assertArrayEquals([new x.Simple], SimpleAnnotation.annotations);
-assertArrayEquals([new x.Simple],
+assert.deepEqual([new x.Simple], SimpleAnnotation.annotations);
+assert.deepEqual([new x.Simple],
     SimpleAnnotation.prototype.annotatedMethod.annotations);
 
-assertArrayEquals([new x.nested.Args('class')], NestedWithArgs.annotations);
-assertArrayEquals([new x.nested.Args('method')],
+assert.deepEqual([new x.nested.Args('class')], NestedWithArgs.annotations);
+assert.deepEqual([new x.nested.Args('method')],
     NestedWithArgs.prototype.annotatedMethod.annotations);

--- a/test/feature/Annotations/MethodParam.module.js
+++ b/test/feature/Annotations/MethodParam.module.js
@@ -5,5 +5,5 @@ class MethodParam {
   method(@Anno x) {}
 }
 
-assertArrayEquals([[new Anno]], MethodParam.prototype.method.parameters);
+assert.deepEqual([[new Anno]], MethodParam.prototype.method.parameters);
 

--- a/test/feature/Annotations/MultipleAnnotatedFunction.module.js
+++ b/test/feature/Annotations/MultipleAnnotatedFunction.module.js
@@ -8,5 +8,5 @@ import {
 @Anno2('val')
 function Multi() {}
 
-assertArrayEquals([new Anno, new Anno2('val')], Multi.annotations);
+assert.deepEqual([new Anno, new Anno2('val')], Multi.annotations);
 

--- a/test/feature/Annotations/MultipleParameterTypes.module.js
+++ b/test/feature/Annotations/MultipleParameterTypes.module.js
@@ -7,5 +7,5 @@ import {
 function MultiParamWithAnnotation(@Anno x:X, y) {}
 function MultiTypedParamsNoAnnotations(x:X, y:X) {}
 
-assertArrayEquals([[X, new Anno], []], MultiParamWithAnnotation.parameters);
-assertArrayEquals([[X], [X]], MultiTypedParamsNoAnnotations.parameters);
+assert.deepEqual([[X, new Anno], []], MultiParamWithAnnotation.parameters);
+assert.deepEqual([[X], [X]], MultiTypedParamsNoAnnotations.parameters);

--- a/test/feature/Annotations/NestedFunction.module.js
+++ b/test/feature/Annotations/NestedFunction.module.js
@@ -13,5 +13,5 @@ function f(a = function() {
 }
 
 var nested = f();
-assertArrayEquals([[X, new Anno]], nested.parameters);
+assert.deepEqual([[X, new Anno]], nested.parameters);
 

--- a/test/feature/Annotations/PropertyMethodStringName.module.js
+++ b/test/feature/Annotations/PropertyMethodStringName.module.js
@@ -8,5 +8,5 @@ class C {
   xyz() { return 1; }
 }
 
-assertArrayEquals([new Anno('x y z')], C.prototype['x y z'].annotations);
-assertArrayEquals([new Anno('xyz')], C.prototype.xyz.annotations);
+assert.deepEqual([new Anno('x y z')], C.prototype['x y z'].annotations);
+assert.deepEqual([new Anno('xyz')], C.prototype.xyz.annotations);

--- a/test/feature/Annotations/SetterParam.module.js
+++ b/test/feature/Annotations/SetterParam.module.js
@@ -5,6 +5,6 @@ class SetterParam {
   set prop(@Anno x) {}
 }
 
-assertArrayEquals([[new Anno]],
+assert.deepEqual([[new Anno]],
     Object.getOwnPropertyDescriptor(SetterParam.prototype, 'prop').
         set.parameters);

--- a/test/feature/Annotations/SimpleFunction.module.js
+++ b/test/feature/Annotations/SimpleFunction.module.js
@@ -4,4 +4,4 @@ import {Anno} from './resources/setup.js';
 @Anno
 function Simple() {}
 
-assertArrayEquals([new Anno], Simple.annotations);
+assert.deepEqual([new Anno], Simple.annotations);

--- a/test/feature/Annotations/StaticGetter.module.js
+++ b/test/feature/Annotations/StaticGetter.module.js
@@ -6,5 +6,5 @@ class StaticGetter {
   static get prop() { return 'getter'; }
 }
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     Object.getOwnPropertyDescriptor(StaticGetter, 'prop').get.annotations);

--- a/test/feature/Annotations/StaticMethod.module.js
+++ b/test/feature/Annotations/StaticMethod.module.js
@@ -6,5 +6,5 @@ class StaticMethod {
   static method(@Anno x) {}
 }
 
-assertArrayEquals([new Anno], StaticMethod.method.annotations);
-assertArrayEquals([[new Anno]], StaticMethod.method.parameters);
+assert.deepEqual([new Anno], StaticMethod.method.annotations);
+assert.deepEqual([[new Anno]], StaticMethod.method.parameters);

--- a/test/feature/Annotations/StaticSetter.module.js
+++ b/test/feature/Annotations/StaticSetter.module.js
@@ -6,7 +6,7 @@ class StaticSetter {
   static set prop(@Anno x) {}
 }
 
-assertArrayEquals([new Anno],
+assert.deepEqual([new Anno],
     Object.getOwnPropertyDescriptor(StaticSetter, 'prop').set.annotations);
-assertArrayEquals([[new Anno]],
+assert.deepEqual([[new Anno]],
     Object.getOwnPropertyDescriptor(StaticSetter, 'prop').set.parameters);

--- a/test/feature/Annotations/UnannotatedTypedClass.module.js
+++ b/test/feature/Annotations/UnannotatedTypedClass.module.js
@@ -16,8 +16,8 @@ class UnannotatedClass {
   }
 }
 
-assertArrayEquals([[X], []], UnannotatedClass.parameters);
-assertArrayEquals([[X]], UnannotatedClass.prototype.bar.parameters);
-assertArrayEquals([[X]],
+assert.deepEqual([[X], []], UnannotatedClass.parameters);
+assert.deepEqual([[X]], UnannotatedClass.prototype.bar.parameters);
+assert.deepEqual([[X]],
     Object.getOwnPropertyDescriptor(UnannotatedClass.prototype, 'setter').
         set.parameters);

--- a/test/feature/ArrayComprehension/Closure.js
+++ b/test/feature/ArrayComprehension/Closure.js
@@ -5,7 +5,7 @@
 var res = [for (x of [0, 1]) for (y of [2, 3]) () => [x, y]];
 
 assert.equal(4, res.length);
-assertArrayEquals([0, 2], res[0]());
-assertArrayEquals([0, 3], res[1]());
-assertArrayEquals([1, 2], res[2]());
-assertArrayEquals([1, 3], res[3]());
+assert.deepEqual([0, 2], res[0]());
+assert.deepEqual([0, 3], res[1]());
+assert.deepEqual([1, 2], res[2]());
+assert.deepEqual([1, 3], res[3]());

--- a/test/feature/ArrayComprehension/Simple.js
+++ b/test/feature/ArrayComprehension/Simple.js
@@ -7,10 +7,10 @@ function* range() {
 }
 
 var array = [for (x of [0, 1, 2, 3]) x];
-assertArrayEquals([0, 1, 2, 3], array);
+assert.deepEqual([0, 1, 2, 3], array);
 
 var array2 = [for (x of [0, 1, 2]) for (y of [0, 1, 2]) x + '' + y];
-assertArrayEquals(['00', '01', '02', '10', '11', '12', '20', '21', '22'],
+assert.deepEqual(['00', '01', '02', '10', '11', '12', '20', '21', '22'],
              array2);
 
 var array3 = [
@@ -18,7 +18,7 @@ var array3 = [
       for (y of range())
         if (x === y)
           x + '' + y];
-assertArrayEquals(['00', '11', '22', '33', '44'], array3);
+assert.deepEqual(['00', '11', '22', '33', '44'], array3);
 
 // Ensure this works as expression statement
 [for (testVar of []) testVar];
@@ -29,4 +29,4 @@ var array4 = [
       for (y of range())
         if (y % 2 === 1)
           x + '' + y];
-assertArrayEquals(['01', '03', '21', '23', '41', '43'], array4);
+assert.deepEqual(['01', '03', '21', '23', '41', '43'], array4);

--- a/test/feature/ArrowFunctions/ArrowFunctions.js
+++ b/test/feature/ArrowFunctions/ArrowFunctions.js
@@ -38,11 +38,11 @@ assert.equal(42, f());
 
 {
   let g = (...xs) => xs;
-  assertArrayEquals([0, 1, true], g(0, 1, true));
+  assert.deepEqual([0, 1, true], g(0, 1, true));
 }
 
 var h = (x, ...xs) => xs;
-assertArrayEquals([0, 1, true], h(-1, 0, 1, true));
+assert.deepEqual([0, 1, true], h(-1, 0, 1, true));
 
 assert.equal(typeof (() => {}), 'function');
 assert.equal(Object.getPrototypeOf(() => {}), Function.prototype);

--- a/test/feature/AsyncFunctions/Throw.js
+++ b/test/feature/AsyncFunctions/Throw.js
@@ -21,7 +21,7 @@ function asyncTimeout(ms) {
   var value;
   try {
     value = await asyncThrow(1);
-    fail("shouldn't get here");
+    assert.fail("shouldn't get here");
   } catch (e) {
     assert.equal(1, e);
   }

--- a/test/feature/AsyncFunctionsUsingGenerator/Throw.js
+++ b/test/feature/AsyncFunctionsUsingGenerator/Throw.js
@@ -22,7 +22,7 @@ function asyncTimeout(ms) {
   var value;
   try {
     value = await asyncThrow(1);
-    fail("shouldn't get here");
+    assert.fail("shouldn't get here");
   } catch (e) {
     assert.equal(1, e);
   }

--- a/test/feature/AtScript/AtScript.js
+++ b/test/feature/AtScript/AtScript.js
@@ -13,5 +13,5 @@ class Foo {
 
 var foo = new Foo(new Bar());
 
-assertArrayEquals([new Inject], Foo.annotations);
-assertArrayEquals([[Bar]], Foo.parameters);
+assert.deepEqual([new Inject], Foo.annotations);
+assert.deepEqual([[Bar]], Foo.parameters);

--- a/test/feature/Classes/ClassNameInStack.js
+++ b/test/feature/Classes/ClassNameInStack.js
@@ -6,7 +6,7 @@ class MyClassName {
 
 try {
   new MyClassName().m();
-  fail('Should have thrown');
+  assert.fail('Should have thrown');
 } catch (ex) {
   if (ex.stack)
     assert.isTrue(String(ex.stack).indexOf('MyClassName') >= 0);
@@ -22,7 +22,7 @@ class MySecondClass extends MyClassName{
 
 try {
   new MySecondClass().m();
-  fail('Should have thrown');
+  assert.fail('Should have thrown');
 } catch (ex) {
   if (ex.stack)
     assert.isTrue(String(ex.stack).indexOf('MySecondClass') >= 0);

--- a/test/feature/Classes/Constructor.js
+++ b/test/feature/Classes/Constructor.js
@@ -22,7 +22,7 @@ assert.equal(1, p.x);
 assert.equal(2, p.y);
 
 for (var element in Point) {
-  fail('Point contains static member : ' + element);
+  assert.fail('Point contains static member : ' + element);
 }
 
 // Tests to ensure that we're not binding function identifier per class

--- a/test/feature/Classes/EmptyClass.js
+++ b/test/feature/Classes/EmptyClass.js
@@ -13,7 +13,7 @@ for (var element in e) {
 }
 
 for (var element in Empty) {
-  fail('Empty contains static member : ' + element);
+  assert.fail('Empty contains static member : ' + element);
 }
 
 // Instances should be different.

--- a/test/feature/Classes/FieldInitializers.js
+++ b/test/feature/Classes/FieldInitializers.js
@@ -19,5 +19,5 @@ assert.equal(0, p2.y);
 assert.equal(1, p.x);
 
 for (var element in Point) {
-  fail('Point contains static member : ' + element);
+  assert.fail('Point contains static member : ' + element);
 }

--- a/test/feature/Classes/InheritanceFromMemberExpression.js
+++ b/test/feature/Classes/InheritanceFromMemberExpression.js
@@ -25,7 +25,10 @@ var a = new MemberExprBase('w value');
 var pa = Object.getPrototypeOf(a);
 var ppa = Object.getPrototypeOf(pa);
 
-assertHasOwnProperty(a, 'yyy', 'w', 'z');
-assertLacksOwnProperty(a, 'x');
-assertHasOwnProperty(pa, 'constructor');
-assertHasOwnProperty(ppa, 'x', 'constructor');
+assert.isTrue(a.hasOwnProperty('yyy'));
+assert.isTrue(a.hasOwnProperty('w'));
+assert.isTrue(a.hasOwnProperty('z'));
+assert.isFalse(a.hasOwnProperty('x'));
+assert.isTrue(pa.hasOwnProperty('constructor'));
+assert.isTrue(ppa.hasOwnProperty('x'));
+assert.isTrue(ppa.hasOwnProperty('constructor'));

--- a/test/feature/Classes/Method.js
+++ b/test/feature/Classes/Method.js
@@ -17,5 +17,5 @@ assert.equal(keys.indexOf('answer'), -1);
 assert.equal(keys.indexOf('constructor'), -1);
 
 for (var key in Universe) {
-  fail('Universe contains static member : ' + key);
+  assert.fail('Universe contains static member : ' + key);
 }

--- a/test/feature/Classes/MethodInheritance.js
+++ b/test/feature/Classes/MethodInheritance.js
@@ -20,13 +20,16 @@ var pa = Object.getPrototypeOf(a);
 var pb = Object.getPrototypeOf(b);
 var pc = Object.getPrototypeOf(c);
 
-assertNoOwnProperties(a);
-assertNoOwnProperties(b);
-assertNoOwnProperties(c);
+assert.equal(Object.getOwnPropertyNames(a).length, 0);
+assert.equal(Object.getOwnPropertyNames(b).length, 0);
+assert.equal(Object.getOwnPropertyNames(c).length, 0);
 
-assertHasOwnProperty(pa, 'ma');
-assertLacksOwnProperty(pa, 'mb', 'mc');
-assertHasOwnProperty(pb, 'mb');
-assertLacksOwnProperty(pb, 'ma', 'mc');
-assertHasOwnProperty(pc, 'mc');
-assertLacksOwnProperty(pc, 'ma', 'mb');
+assert.isTrue(pa.hasOwnProperty('ma'));
+assert.isFalse(pa.hasOwnProperty('mb'));
+assert.isFalse(pa.hasOwnProperty('mc'));
+assert.isTrue(pb.hasOwnProperty('mb'));
+assert.isFalse(pb.hasOwnProperty('ma'));
+assert.isFalse(pb.hasOwnProperty('mc'));
+assert.isTrue(pc.hasOwnProperty('mc'));
+assert.isFalse(pc.hasOwnProperty('ma'));
+assert.isFalse(pc.hasOwnProperty('mb'));

--- a/test/feature/Classes/PropertyAccessors.js
+++ b/test/feature/Classes/PropertyAccessors.js
@@ -24,12 +24,12 @@ assert.equal(20, immutable.y_);
 
 try {
   immutable.x = 11;
-  fail('should not be able to set a get only property');
+  assert.fail('should not be able to set a get only property');
 } catch (except) {
 }
 try {
   immutable.y = 11;
-  fail('should not be able to set a get only property');
+  assert.fail('should not be able to set a get only property');
 } catch (except) {
 }
 assert.equal(10, immutable.x);
@@ -48,12 +48,12 @@ assert.equal(20, mutable.y_);
 try {
   mutable.x = 11;
 } catch (except) {
-  fail('should be able to set a read/write property');
+  assert.fail('should be able to set a read/write property');
 }
 try {
   mutable.y = 12;
 } catch (except) {
-  fail('should be able to set a read/write property');
+  assert.fail('should be able to set a read/write property');
 }
 assert.equal(11, mutable.x);
 assert.equal(12, mutable.y);

--- a/test/feature/Classes/RestParams.js
+++ b/test/feature/Classes/RestParams.js
@@ -10,6 +10,6 @@ class RestParams {
 // ----------------------------------------------------------------------------
 
 var obj = new RestParams(0, 1, 2);
-assertArrayEquals([0, 1, 2], obj.rest);
-assertArrayEquals([3, 4, 5], obj.instanceMethod(3, 4, 5));
+assert.deepEqual([0, 1, 2], obj.rest);
+assert.deepEqual([3, 4, 5], obj.instanceMethod(3, 4, 5));
 

--- a/test/feature/Classes/Static.js
+++ b/test/feature/Classes/Static.js
@@ -65,6 +65,6 @@ class AccessorNamedStatic {
 
 x = 2;
 c = new AccessorNamedStatic();
-assertArrayEquals([c, 2], c.static);
+assert.deepEqual([c, 2], c.static);
 c.static = 3;
-assertArrayEquals([c, 3], x);
+assert.deepEqual([c, 3], x);

--- a/test/feature/Classes/StaticSuper.js
+++ b/test/feature/Classes/StaticSuper.js
@@ -28,8 +28,8 @@ class C extends B {
   }
 }
 
-assertArrayEquals([C, 'B.method'], C.method());
-assertArrayEquals([C, 'B.getter'], C.getter);
+assert.deepEqual([C, 'B.method'], C.method());
+assert.deepEqual([C, 'B.getter'], C.getter);
 
 C.setter = 'B.setter';
-assertArrayEquals([C, 'B.setter'], x);
+assert.deepEqual([C, 'B.setter'], x);

--- a/test/feature/Classes/StaticSuperNoExtends.js
+++ b/test/feature/Classes/StaticSuperNoExtends.js
@@ -35,12 +35,12 @@ class NoExtends {
 }
 
 var call = Function.prototype.call;
-assertArrayEquals([NoExtends, 42, call], NoExtends.method());
+assert.deepEqual([NoExtends, 42, call], NoExtends.method());
 
-assertArrayEquals([NoExtends, 42, call], NoExtends.getter);
+assert.deepEqual([NoExtends, 42, call], NoExtends.getter);
 
 NoExtends.setter = 1;
-assertArrayEquals([NoExtends, 1, call], x);
+assert.deepEqual([NoExtends, 1, call], x);
 
 delete Function.prototype.testFunction;
 delete Function.prototype.testGetter;

--- a/test/feature/Collections/Map.js
+++ b/test/feature/Collections/Map.js
@@ -95,7 +95,7 @@ t.forEach(function (value, key, map) {
 assert.equal(cnt, 10);
 t.delete('foo');
 
-assertArrayEquals(arrKeys, [
+assert.deepEqual(arrKeys, [
   undefinedKey,
   nullKey,
   stringKey,
@@ -107,7 +107,7 @@ assertArrayEquals(arrKeys, [
   frozenKey,
   'foo'
 ]);
-assertArrayEquals(arr, [
+assert.deepEqual(arr, [
   'value8',
   'value9',
   'value5',
@@ -138,10 +138,10 @@ for (var mapIterItem of t) {
 assert.equal(cnt, 10);
 t.delete('foo');
 
-assertArrayEquals(arrKeys, [ undefinedKey, nullKey, stringKey,
+assert.deepEqual(arrKeys, [ undefinedKey, nullKey, stringKey,
     numberKey, booleanKey, objectKey,
     nanKey, zeroKey, frozenKey, 'foo' ]);
-assertArrayEquals(arr, [
+assert.deepEqual(arr, [
   'value8',
   'value9',
   'value5',
@@ -168,7 +168,7 @@ for (var mapIterItem of t.entries()) {
 }
 assert.equal(cnt, 9);
 
-assertArrayEquals(arrKeys, [
+assert.deepEqual(arrKeys, [
   undefinedKey,
   nullKey,
   stringKey,
@@ -179,7 +179,7 @@ assertArrayEquals(arrKeys, [
   zeroKey,
   frozenKey
 ]);
-assertArrayEquals(arr, [
+assert.deepEqual(arr, [
   'value8',
   'value9',
   'value5',
@@ -202,7 +202,7 @@ for (var mapIterKey of t.keys()) {
 }
 assert.equal(cnt, 9);
 
-assertArrayEquals(arrKeys, [
+assert.deepEqual(arrKeys, [
   undefinedKey,
   nullKey,
   stringKey,
@@ -225,7 +225,7 @@ for (var mapIterVal of t.values()) {
 }
 assert.equal(cnt, 9);
 
-assertArrayEquals(arr, [
+assert.deepEqual(arr, [
   'value8',
   'value9',
   'value5',

--- a/test/feature/Collections/Set.js
+++ b/test/feature/Collections/Set.js
@@ -82,7 +82,7 @@ t.forEach(function(val, val2, obj) {
 }, context);
 
 assert.equal(cnt, 9);
-assertArrayEquals(arr, expected);
+assert.deepEqual(arr, expected);
 
 // iterator
 arr = [];
@@ -93,7 +93,7 @@ for (var setIterVal of t) {
   cnt++;
 }
 assert.equal(cnt, 9);
-assertArrayEquals(arr, expected);
+assert.deepEqual(arr, expected);
 
 // .values()
 arr = [];
@@ -104,7 +104,7 @@ for (var setIterVal of t.values()) {
   cnt++;
 }
 assert.equal(cnt, 9);
-assertArrayEquals(arr, expected);
+assert.deepEqual(arr, expected);
 
 var t3 = new Set([[], {}, NaN]);
 assert.equal(t3.size, 3);

--- a/test/feature/Destructuring/Array.js
+++ b/test/feature/Destructuring/Array.js
@@ -14,7 +14,7 @@ function destructArray() {
 var result = destructArray();
 assert.equal('hello', result.a);
 assert.equal(',', result.b);
-assertArrayEquals(['world'], result.c);
+assert.deepEqual(['world'], result.c);
 assert.isUndefined(result.d);
 
 function testNested() {

--- a/test/feature/Destructuring/ArrowFunction.js
+++ b/test/feature/Destructuring/ArrowFunction.js
@@ -2,10 +2,10 @@ var f = ({x}) => x;
 assert.equal(42, f({x: 42}));
 
 var g = ({x: y, z: [a, b, ...c]}) => [y, a, b, c];
-assertArrayEquals([1, 2, 3, [4, 5]], g({x: 1, z: [2, 3, 4, 5]}));
+assert.deepEqual([1, 2, 3, [4, 5]], g({x: 1, z: [2, 3, 4, 5]}));
 
 var h = ([a, {b: c, d}]) => [a, c, d];
-assertArrayEquals([1, 2, 3], h([1, {b: 2, d: 3}]));
+assert.deepEqual([1, 2, 3], h([1, {b: 2, d: 3}]));
 
 var i = ([, a]) => a;
 assert.equal(i([0, 1]), 1);

--- a/test/feature/Destructuring/Catch.js
+++ b/test/feature/Destructuring/Catch.js
@@ -11,7 +11,7 @@ try {
   throw new MyError('abc');
 } catch ({message: [head, ...tail], name}) {
   assert.equal('a', head);
-  assertArrayEquals(['b', 'c'], tail);
+  assert.deepEqual(['b', 'c'], tail);
   assert.equal('Error', name);
 }
 

--- a/test/feature/Destructuring/Class.js
+++ b/test/feature/Destructuring/Class.js
@@ -6,19 +6,19 @@ function MyError(s) {
 class C {
   constructor({message: [head, ...tail], name}) {
     assert.equal('a', head);
-    assertArrayEquals(['b', 'c'], tail);
+    assert.deepEqual(['b', 'c'], tail);
     assert.equal('Error', name);
   }
 
   method({message: [head, ...tail], name}) {
     assert.equal('a', head);
-    assertArrayEquals(['b', 'c'], tail);
+    assert.deepEqual(['b', 'c'], tail);
     assert.equal('Error', name);
   }
 
   set x({message: [head, ...tail], name}) {
     assert.equal('a', head);
-    assertArrayEquals(['b', 'c'], tail);
+    assert.deepEqual(['b', 'c'], tail);
     assert.equal('Error', name);
   }
 }

--- a/test/feature/Destructuring/EvaluatesToRvalue.js
+++ b/test/feature/Destructuring/EvaluatesToRvalue.js
@@ -6,4 +6,4 @@ function destructEvaluatesToRvalue() {
 // ----------------------------------------------------------------------------
 
 var result = destructEvaluatesToRvalue();
-assertArrayEquals([1, 2, 3], result);
+assert.deepEqual([1, 2, 3], result);

--- a/test/feature/Destructuring/ForInLoop.js
+++ b/test/feature/Destructuring/ForInLoop.js
@@ -10,7 +10,7 @@ var expectedTails = [['b', 'c'], ['e','f']];
 var i = 0;
 for (var [head, ...tail] in object) {
   assert.equal(expectedHeads[i], head);
-  assertArrayEquals(expectedTails[i], tail);
+  assert.deepEqual(expectedTails[i], tail);
   i++;
 }
 assert.equal(2, i);

--- a/test/feature/Destructuring/ForOfLoop.js
+++ b/test/feature/Destructuring/ForOfLoop.js
@@ -10,7 +10,7 @@ var expectedTails = [['b', 'c'], ['e','f']];
 var i = 0;
 for (var [head, ...tail] of gen()) {
   assert.equal(expectedHeads[i], head);
-  assertArrayEquals(expectedTails[i], tail);
+  assert.deepEqual(expectedTails[i], tail);
   i++;
 }
 assert.equal(2, i);

--- a/test/feature/Destructuring/FunctionArrayPattern.js
+++ b/test/feature/Destructuring/FunctionArrayPattern.js
@@ -1,7 +1,7 @@
 function f([a, b, ...c], d) {
   return [a, b, c, d];
 }
-assertArrayEquals([1, 2, [3, 4], 5], f([1, 2, 3, 4], 5));
+assert.deepEqual([1, 2, [3, 4], 5], f([1, 2, 3, 4], 5));
 
 function g([, a]) {
   return a;

--- a/test/feature/Destructuring/FunctionObjectPattern.js
+++ b/test/feature/Destructuring/FunctionObjectPattern.js
@@ -2,4 +2,4 @@ function f({a, b: {c}}, d) {
   return [a, c, d];
 }
 
-assertArrayEquals([1, 2, 3], f({a: 1, b: {c: 2}}, 3));
+assert.deepEqual([1, 2, 3], f({a: 1, b: {c: 2}}, 3));

--- a/test/feature/Destructuring/Method.js
+++ b/test/feature/Destructuring/Method.js
@@ -6,7 +6,7 @@ function MyError(s) {
 var object = {
   method({message: [head, ...tail], name}) {
     assert.equal('a', head);
-    assertArrayEquals(['b', 'c'], tail);
+    assert.deepEqual(['b', 'c'], tail);
     assert.equal('Error', name);
   }
 };

--- a/test/feature/Destructuring/Rest.js
+++ b/test/feature/Destructuring/Rest.js
@@ -7,10 +7,10 @@ function destructRest() {
 }
 
 var result = destructRest();
-assertArrayEquals([1, 2, 3], result.a);
+assert.deepEqual([1, 2, 3], result.a);
 assert.equal(1, result.b);
-assertArrayEquals([2, 3], result.c);
-assertArrayEquals([], result.d);
+assert.deepEqual([2, 3], result.c);
+assert.deepEqual([], result.d);
 
 assert.throw(function() {
   var e;

--- a/test/feature/Destructuring/RestIterator.js
+++ b/test/feature/Destructuring/RestIterator.js
@@ -10,7 +10,7 @@
   [, x, , x2, , ...xs] = f();
   assert.equal(1, x);
   assert.equal(3, x2);
-  assertArrayEquals([5, 6, 7], xs);
+  assert.deepEqual([5, 6, 7], xs);
 
   [] = f();
   assert.equal(8, i);  // Since we never call next().
@@ -34,7 +34,7 @@
   var [, x, , x2, , ...xs] = f();
   assert.equal(1, x);
   assert.equal(3, x2);
-  assertArrayEquals([5, 6, 7], xs);
+  assert.deepEqual([5, 6, 7], xs);
 
   var [] = f();
   assert.equal(8, i);  // Since we never call next().

--- a/test/feature/Destructuring/SetAccessor.js
+++ b/test/feature/Destructuring/SetAccessor.js
@@ -6,7 +6,7 @@ function MyError(s) {
 var object = {
   set x({message: [head, ...tail], name}) {
     assert.equal('a', head);
-    assertArrayEquals(['b', 'c'], tail);
+    assert.deepEqual(['b', 'c'], tail);
     assert.equal('Error', name);
   }
 };

--- a/test/feature/Destructuring/TopLevel.js
+++ b/test/feature/Destructuring/TopLevel.js
@@ -6,4 +6,4 @@ var a, b, c, d;
 assert.equal('hello', a);
 assert.equal(',', b);
 assert.equal('junk', c);
-assertArrayEquals(['world'], d);
+assert.deepEqual(['world'], d);

--- a/test/feature/GeneratorComprehension/Skip_Closure.js
+++ b/test/feature/GeneratorComprehension/Skip_Closure.js
@@ -17,7 +17,7 @@ var f4 = iter.current;
 
 assert.isFalse(iter.moveNext());
 
-assertArrayEquals([0, 2], f1());
-assertArrayEquals([0, 3], f2());
-assertArrayEquals([1, 2], f3());
-assertArrayEquals([1, 3], f4());
+assert.deepEqual([0, 2], f1());
+assert.deepEqual([0, 3], f2());
+assert.deepEqual([1, 2], f3());
+assert.deepEqual([1, 3], f4());

--- a/test/feature/NumericLiteral/Simple.js
+++ b/test/feature/NumericLiteral/Simple.js
@@ -30,7 +30,7 @@
     0B11: 3,
     0B0100: 4
   };
-  assertArrayEquals(['0', '1', '2', '3', '4'], Object.keys(o));
+  assert.deepEqual(['0', '1', '2', '3', '4'], Object.keys(o));
 
   var o = {
     0o0: 0,
@@ -39,7 +39,7 @@
     0O10: 8,
     0O011: 9
   };
-  assertArrayEquals(['0', '1', '7', '8', '9'], Object.keys(o));
+  assert.deepEqual(['0', '1', '7', '8', '9'], Object.keys(o));
 
   var o = {
     get 0b0() {},
@@ -48,7 +48,7 @@
     get 0B11() {},
     get 0B0100() {}
   };
-  assertArrayEquals(['0', '1', '2', '3', '4'], Object.keys(o));
+  assert.deepEqual(['0', '1', '2', '3', '4'], Object.keys(o));
 
   var o = {
     set 0o0(v) {},
@@ -57,7 +57,7 @@
     set 0O10(v) {},
     set 0O011(v) {}
   };
-  assertArrayEquals(['0', '1', '7', '8', '9'], Object.keys(o));
+  assert.deepEqual(['0', '1', '7', '8', '9'], Object.keys(o));
 
   var o = {
     0b0() {},
@@ -66,7 +66,7 @@
     0B11() {},
     0B0100() {}
   };
-  assertArrayEquals(['0', '1', '2', '3', '4'], Object.keys(o));
+  assert.deepEqual(['0', '1', '2', '3', '4'], Object.keys(o));
 
   class C {
     0b0() {}

--- a/test/feature/PropertyMethodAssignment/PropertyMethodAssignment.js
+++ b/test/feature/PropertyMethodAssignment/PropertyMethodAssignment.js
@@ -20,7 +20,7 @@ var object = {
 
 // ----------------------------------------------------------------------------
 
-assertArrayEquals([
+assert.deepEqual([
   '42',
   'x',
   'f',
@@ -58,7 +58,7 @@ assertMethod(object, 'class');
 assert.equal(object.f, object.f());
 
 // Test the nested object.
-assertArrayEquals(['j'], Object.keys(object.x));
+assert.deepEqual(['j'], Object.keys(object.x));
 assertMethod(object.x, 'j');
 
 // Test name binding.

--- a/test/feature/Rest/Simple.js
+++ b/test/feature/Rest/Simple.js
@@ -6,11 +6,11 @@ function g(a, ...p) {
   return p;
 }
 
-assertArrayEquals([], f());
-assertArrayEquals([0], f(0));
-assertArrayEquals([0, 1], f(0, 1));
+assert.deepEqual([], f());
+assert.deepEqual([0], f(0));
+assert.deepEqual([0, 1], f(0, 1));
 
-assertArrayEquals([], g());
-assertArrayEquals([], g(0));
-assertArrayEquals([1], g(0, 1));
-assertArrayEquals([1, 2], g(0, 1, 2));
+assert.deepEqual([], g());
+assert.deepEqual([], g(0));
+assert.deepEqual([1], g(0, 1));
+assert.deepEqual([1, 2], g(0, 1, 2));

--- a/test/feature/Scope/LetForInInitializers1.js
+++ b/test/feature/Scope/LetForInInitializers1.js
@@ -17,6 +17,6 @@ var result;
 
 // ----------------------------------------------------------------------------
 
-assertArrayEquals(['0', 'one'], result[0]());
-assertArrayEquals(['1', 'two'], result[1]());
-assertArrayEquals(['2', 'three'], result[2]());
+assert.deepEqual(['0', 'one'], result[0]());
+assert.deepEqual(['1', 'two'], result[1]());
+assert.deepEqual(['2', 'three'], result[2]());

--- a/test/feature/Spread/Array.js
+++ b/test/feature/Spread/Array.js
@@ -7,8 +7,8 @@ var f = [0, ...[[1, 2], [3, 4]], 5];
 
 // ----------------------------------------------------------------------------
 
-assertArrayEquals([0], b);
-assertArrayEquals([0, 0], c);
-assertArrayEquals([1, 2], d);
-assertArrayEquals([0, 1, 2, 3], e);
-assertArrayEquals([0, [1, 2], [3, 4], 5], f);
+assert.deepEqual([0], b);
+assert.deepEqual([0, 0], c);
+assert.deepEqual([1, 2], d);
+assert.deepEqual([0, 1, 2, 3], e);
+assert.deepEqual([0, [1, 2], [3, 4], 5], f);

--- a/test/feature/Spread/Call.js
+++ b/test/feature/Spread/Call.js
@@ -8,10 +8,10 @@ function f(...args) {
 }
 
 var result = f(0, ...[1, 2], 3, ...G());
-assertArrayEquals([0, 1, 2, 3, 'hi', 'there'], result);
+assert.deepEqual([0, 1, 2, 3, 'hi', 'there'], result);
 
 result = f(...G());
-assertArrayEquals(['hi', 'there'], result);
+assert.deepEqual(['hi', 'there'], result);
 
 function g() {
   'use strict';

--- a/test/feature/Spread/Iterators.js
+++ b/test/feature/Spread/Iterators.js
@@ -11,7 +11,7 @@ var d = [4, ...G(), 5];
 
 // ----------------------------------------------------------------------------
 
-assertArrayEquals([1, 2, 3], a);
-assertArrayEquals([4, 1, 2, 3], b);
-assertArrayEquals([1, 2, 3, 4], c);
-assertArrayEquals([4, 1, 2, 3, 5], d);
+assert.deepEqual([1, 2, 3], a);
+assert.deepEqual([4, 1, 2, 3], b);
+assert.deepEqual([1, 2, 3, 4], c);
+assert.deepEqual([4, 1, 2, 3, 5], d);

--- a/test/feature/Spread/MethodCall.js
+++ b/test/feature/Spread/MethodCall.js
@@ -15,4 +15,4 @@ var result = {
 // ----------------------------------------------------------------------------
 
 assert.equal(result.obj, result.result.self);
-assertArrayEquals([0, 1, 2, 3], result.result.args);
+assert.deepEqual([0, 1, 2, 3], result.result.args);

--- a/test/feature/Spread/MethodCallQuotedName.js
+++ b/test/feature/Spread/MethodCallQuotedName.js
@@ -15,4 +15,4 @@ var result = {
 // ----------------------------------------------------------------------------
 
 assert.equal(result.obj, result.result.self);
-assertArrayEquals([0, 1, 2, 3], result.result.args);
+assert.deepEqual([0, 1, 2, 3], result.result.args);

--- a/test/feature/Spread/String.js
+++ b/test/feature/Spread/String.js
@@ -7,7 +7,7 @@ var f = [... new String('abc')];
 
 // ----------------------------------------------------------------------------
 
-assertArrayEquals(['b'], b);
-assertArrayEquals(['b', 'b'], c);
-assertArrayEquals([0, '1', '2', 3], e);
-assertArrayEquals(['a', 'b', 'c'], f);
+assert.deepEqual(['b'], b);
+assert.deepEqual(['b', 'b'], c);
+assert.deepEqual([0, '1', '2', 3], e);
+assert.deepEqual(['a', 'b', 'c'], f);

--- a/test/feature/SpreadProperties/Setters.js
+++ b/test/feature/SpreadProperties/Setters.js
@@ -1,12 +1,8 @@
 // Options: --spread-properties
 
-function fail() {
-  assert.isTrue(false, 'unreachable');
-}
-
 var o;
-assert.deepEqual({set a(x) {fail()}, ...{a: 'a'}}, {a: 'a'});
-assert.deepEqual(o = {a: 'a', ...{set a(x) {fail()}}}, {a: undefined});
+assert.deepEqual({set a(x) {assert.fail()}, ...{a: 'a'}}, {a: 'a'});
+assert.deepEqual(o = {a: 'a', ...{set a(x) {assert.fail()}}}, {a: undefined});
 o.a = 'b';
 assert.equal(o.a, 'b');
 

--- a/test/feature/Symbol/GetOwnPropertySymbols.js
+++ b/test/feature/Symbol/GetOwnPropertySymbols.js
@@ -4,4 +4,4 @@ var object = {a: 'a'};
 object[s1] = 's1';
 object.b = 'b';
 object[s2] = 's2';
-assertArrayEquals([s1, s2], Object.getOwnPropertySymbols(object));
+assert.deepEqual([s1, s2], Object.getOwnPropertySymbols(object));

--- a/test/feature/Symbol/Object.js
+++ b/test/feature/Symbol/Object.js
@@ -4,7 +4,7 @@ object[s] = 42;
 assert.equal(42, object[s]);
 // Native Symbol throws for ToString.
 // assert.isUndefined(object[s + '']);
-assertArrayEquals([], Object.getOwnPropertyNames(object));
+assert.deepEqual([], Object.getOwnPropertyNames(object));
 assert.isTrue(object.hasOwnProperty(s));
 
 assert.equal(32, object[s] -= 10);

--- a/test/feature/Syntax/StringEscapes.js
+++ b/test/feature/Syntax/StringEscapes.js
@@ -8,6 +8,6 @@ var o2 = {
   '\0\b\f\n\r\t\v\x42\u1234': 1234
 };
 
-assertArrayEquals(Object.keys(o1), Object.keys(o2));
+assert.deepEqual(Object.keys(o1), Object.keys(o2));
 assert.equal(42, o1['\\\'']);
 assert.equal(42, o2['\\\'']);

--- a/test/feature/TemplateLiterals/Tag.js
+++ b/test/feature/TemplateLiterals/Tag.js
@@ -39,49 +39,49 @@
   assert.equal(1, expose``[0].length);
   assert.equal(1, expose``[0].raw.length);
 
-  assertArrayEquals(['a'], expose`a`[0].raw);
-  assertArrayEquals(['a'], expose`a`[0]);
+  assert.deepEqual(['a'], expose`a`[0].raw);
+  assert.deepEqual(['a'], expose`a`[0]);
 
-  assertArrayEquals(['\\n'], expose`\n`[0].raw);
-  assertArrayEquals(['\n'], expose`\n`[0]);
+  assert.deepEqual(['\\n'], expose`\n`[0].raw);
+  assert.deepEqual(['\n'], expose`\n`[0]);
 
-  assertArrayEquals(['\\r'], expose`\r`[0].raw);
-  assertArrayEquals(['\r'], expose`\r`[0]);
+  assert.deepEqual(['\\r'], expose`\r`[0].raw);
+  assert.deepEqual(['\r'], expose`\r`[0]);
 
-  assertArrayEquals(['\\f'], expose`\f`[0].raw);
-  assertArrayEquals(['\f'], expose`\f`[0]);
+  assert.deepEqual(['\\f'], expose`\f`[0].raw);
+  assert.deepEqual(['\f'], expose`\f`[0]);
 
-  assertArrayEquals(['\\b'], expose`\b`[0].raw);
-  assertArrayEquals(['\b'], expose`\b`[0]);
+  assert.deepEqual(['\\b'], expose`\b`[0].raw);
+  assert.deepEqual(['\b'], expose`\b`[0]);
 
-  assertArrayEquals(['\\u2028'], expose`\u2028`[0].raw);
-  assertArrayEquals(['\u2028'], expose`\u2028`[0]);
+  assert.deepEqual(['\\u2028'], expose`\u2028`[0].raw);
+  assert.deepEqual(['\u2028'], expose`\u2028`[0]);
 
-  assertArrayEquals(['\\u2029'], expose`\u2029`[0].raw);
-  assertArrayEquals(['\u2029'], expose`\u2029`[0]);
+  assert.deepEqual(['\\u2029'], expose`\u2029`[0].raw);
+  assert.deepEqual(['\u2029'], expose`\u2029`[0]);
 
-  assertArrayEquals(['a', 'b'], expose`a${x}b`[0].raw);
-  assertArrayEquals(['a', 'b'], expose`a${x}b`[0]);
+  assert.deepEqual(['a', 'b'], expose`a${x}b`[0].raw);
+  assert.deepEqual(['a', 'b'], expose`a${x}b`[0]);
 
   // These have tab characters in them.
-  assertArrayEquals(['\t', '\\t'], expose`	${x}\t`[0].raw);
-  assertArrayEquals(['\t', '\t'], expose`	${x}\t`[0]);
+  assert.deepEqual(['\t', '\\t'], expose`	${x}\t`[0].raw);
+  assert.deepEqual(['\t', '\t'], expose`	${x}\t`[0]);
 
-  assertArrayEquals(['\n', '\\n'], expose`
+  assert.deepEqual(['\n', '\\n'], expose`
 ${x}\n`[0].raw);
-  assertArrayEquals(['\n', '\n'], expose`
+  assert.deepEqual(['\n', '\n'], expose`
 ${x}\n`[0]);
 
   // These contains the ES new line chars \u2028 and \u2029
-  assertArrayEquals(['\u2028', '\\u2028'], expose` ${x}\u2028`[0].raw);
-  assertArrayEquals(['\u2028', '\u2028'], expose` ${x}\u2028`[0]);
+  assert.deepEqual(['\u2028', '\\u2028'], expose` ${x}\u2028`[0].raw);
+  assert.deepEqual(['\u2028', '\u2028'], expose` ${x}\u2028`[0]);
 
-  assertArrayEquals(['\u2029', '\\u2029'], expose` ${x}\u2029`[0].raw);
-  assertArrayEquals(['\u2029', '\u2029'], expose` ${x}\u2029`[0]);
+  assert.deepEqual(['\u2029', '\\u2029'], expose` ${x}\u2029`[0].raw);
+  assert.deepEqual(['\u2029', '\u2029'], expose` ${x}\u2029`[0]);
 
-  assertArrayEquals(['a/*b*/c'], expose`a/*b*/c`[0].raw);
-  assertArrayEquals(['a/*b*/c'], expose`a/*b*/c`[0]);
+  assert.deepEqual(['a/*b*/c'], expose`a/*b*/c`[0].raw);
+  assert.deepEqual(['a/*b*/c'], expose`a/*b*/c`[0]);
 
-  assertArrayEquals(['a'], expose/* comment */`a`[0].raw);
-  assertArrayEquals(['a'], expose/* comment */`a`[0]);
+  assert.deepEqual(['a'], expose/* comment */`a`[0].raw);
+  assert.deepEqual(['a'], expose/* comment */`a`[0]);
 }

--- a/test/featureTestRunner.js
+++ b/test/featureTestRunner.js
@@ -19,7 +19,7 @@ import {BrowserTraceurTestRunner} from './modular/BrowserTraceurTestRunner.js';
 import {Options} from '../src/Options.js';
 import {ModuleStore} from '../src/loader/ModuleStore.js';
 
-import {assert, assertArrayEquals} from './asserts.js';
+import {assert} from './asserts.js';
 export * from './asserts.js';
 
 function forEachPrologLine(s, f) {
@@ -80,37 +80,6 @@ assert.type = function (actual, type) {
   assert.typeOf(actual, type.name);
   return actual;
 };
-
-function assertNoOwnProperties(o) {
-  let m = Object.getOwnPropertyNames(o);
-  if (m.length) {
-    fail('Unexpected members found:' + m.join(', '));
-  }
-}
-
-function assertHasOwnProperty(o) {
-  let args = Array.prototype.slice.call(arguments, 1);
-  for (let i = 0; i < args.length; i ++) {
-    let m = args[i];
-    if (!o.hasOwnProperty(m)) {
-      fail('Expected member ' + m + ' not found.');
-    }
-  }
-}
-
-function assertLacksOwnProperty(o) {
-  let args = Array.prototype.slice.call(arguments, 1);
-  for (let i = 0; i < args.length; i ++) {
-    let m = args[i];
-    if (o.hasOwnProperty(m)) {
-      fail('Unxpected member ' + m + ' found.');
-    }
-  }
-}
-
-function fail(message) {
-  throw new AssertionError(message);
-}
 
 let pathRe = /([^\s']+?)(?=test(?:[\/\\])feature(?:[\/\\]))/g;
 
@@ -243,7 +212,7 @@ function cloneTest(name, url) {
     let tree = parse(source);
 
     if (reporter.hadError()) {
-      fail('cloneTest Error compiling ' + name + '.\n' +
+      assert.fail('cloneTest Error compiling ' + name + '.\n' +
            reporter.errorsAsString());
       return;
     }
@@ -257,8 +226,8 @@ function cloneTest(name, url) {
     // Parse again to ensure that writer generates valid code.
     clone = parse(cloneCode);
     if (reporter.hadError()) {
-      fail('Error compiling generated code for ' + name + '.\n' +
-           reporter.errors.join('\n'));
+      assert.fail('Error compiling generated code for ' + name + '.\n' +
+                  reporter.errors.join('\n'));
       return;
     }
 
@@ -279,18 +248,13 @@ function cloneTest(name, url) {
       doTest(data);
       done();
     }, (ex) => {
-      fail('Load error for ' + url + ': ' + ex);
+      assert.fail('Load error for ' + url + ': ' + ex);
       done();
     });
   });
 }
 
 Reflect.global.assert = assert;
-Reflect.global.assertArrayEquals = assertArrayEquals;
-Reflect.global.assertHasOwnProperty = assertHasOwnProperty;
-Reflect.global.assertLacksOwnProperty = assertLacksOwnProperty;
-Reflect.global.assertNoOwnProperties = assertNoOwnProperties;
-Reflect.global.fail = fail;
 
 function importFeatureFiles(files) {
   return new Promise((resolve) => {

--- a/test/unit/codegeneration/SourceMap.js
+++ b/test/unit/codegeneration/SourceMap.js
@@ -16,7 +16,6 @@ import {
   suite,
   test,
   assert,
-  assertArrayEquals
 } from '../../unit/unitTestRunner.js';
 
 import {Compiler} from '../../../src/Compiler.js';
@@ -214,7 +213,7 @@ suite('SourceMap.js', function() {
 
     var map = JSON.parse(scriptCompiler.getSourceMap(outFilename));
     assert.equal(outFilename, map.file);
-    assertArrayEquals(['a.js', 'b.js', 'c.js'], map.sources);
+    assert.deepEqual(['a.js', 'b.js', 'c.js'], map.sources);
   });
 
   test('ImportSpecifierSetSourceMap', function() {

--- a/test/unit/runtime/Loader.js
+++ b/test/unit/runtime/Loader.js
@@ -16,7 +16,6 @@ import {
   suite,
   test,
   assert,
-  assertArrayEquals,
   setup,
   teardown
 } from '../../unit/unitTestRunner.js';
@@ -89,7 +88,7 @@ function loadAndCheck(depsByName, expectedCalls, done) {
     assert(codeUnit.normalizedName === 'foo');
     // This kind of log is very handy:
     // console.log('calls ', '[\n\'' + calls.join('\',\n\'') + '\'\n]');
-    assertArrayEquals(calls, expectedCalls);
+    assert.deepEqual(calls, expectedCalls);
     done();
   }).catch(done);
 }

--- a/test/unit/runtime/LoaderIntegration.js
+++ b/test/unit/runtime/LoaderIntegration.js
@@ -100,7 +100,7 @@ suite('Loader.js', function() {
     var reporter = new MutedErrorReporter();
     getTestLoader(reporter).script('export var x = 5;', {}).then(
       function(result) {
-        fail('should not have succeeded');
+        assert.fail('should not have succeeded');
         done();
       }, function(ex) {
         assert(ex);
@@ -145,7 +145,7 @@ suite('Loader.js', function() {
     var code = 'DeliboratelyUndefined; \n';
     var result = getTestLoader().module(code, {}).then(
       function(value) {
-        fail('Should not have succeeded');
+        assert.fail('Should not have succeeded');
         done();
       }, function(ex) {
         assert((ex + '').indexOf('DeliboratelyUndefined') !== -1);
@@ -165,7 +165,7 @@ suite('Loader.js', function() {
   test('LoaderLoad.Fail', function(done) {
     var reporter = new MutedErrorReporter();
     getTestLoader(reporter).loadAsScript('./test/unit/runtime/resources/non_existing.js', {}).then(function(result) {
-      fail('should not have succeeded');
+      assert.fail('should not have succeeded');
       done();
     }, function(error) {
       assert(error);
@@ -224,7 +224,7 @@ suite('Loader.js', function() {
   test('LoaderImport.Fail', function(done) {
     var reporter = new MutedErrorReporter();
     getTestLoader(reporter).import('./test/unit/runtime/resources/non_existing.js', {}).then(function(mod) {
-      fail('should not have succeeded')
+      assert.fail('should not have succeeded')
       done();
     }, function(error) {
       assert(error);
@@ -241,7 +241,7 @@ suite('Loader.js', function() {
     var metadata = {traceurOptions: {sourceMaps: 'memory'}};
     getTestLoader(reporter).import('test/unit/runtime/loads/main.js', {metadata: metadata}).then(
       function(mod) {
-        fail('should not have succeeded')
+        assert.fail('should not have succeeded')
         done();
       }, function(error) {
         assert((error + '').indexOf('ModuleEvaluationError: dep error in') !== -1);
@@ -275,7 +275,7 @@ suite('Loader.js', function() {
     getTestLoader().import('./test/unit/runtime/resources/side-effect.js', {}).then(function(mod) {
       var src = 'syntax error';
       getTestLoader().define(name, src, {}).then(function() {
-          fail('should not have succeeded');
+          assert.fail('should not have succeeded');
           done();
         }, function(error) {
           assert(error);


### PR DESCRIPTION
The motivation is to make running tests in other environments
easier.

assertArrayEquals -> assert.deepEqual
fail -> assert.fail
assertNoOwnProperties -> assert.equal(getOwnPropertyNames, 0)
assertHasOwnProperty -> assert.isTrue(hasOwnProperty)
assertLacksOwnProperty -> assert.isFalse(hasOwnProperty)