### PR TITLE
CJS: Module exports should be enumerable

### DIFF
--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -130,8 +130,10 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
 
       switch (exp.type) {
         case GET_ACCESSOR: {
-          let getterFunction = createFunctionExpression(createEmptyParameterList(), exp.body);
-          descriptor = parseExpression `{get: ${getterFunction}}`;
+          let getterFunction =
+              createFunctionExpression(createEmptyParameterList(), exp.body);
+          descriptor =
+              parseExpression `{get: ${getterFunction}, enumerable: true}`;
           break;
         }
 

--- a/test/unit/node/resources/golden-cjs/dep.js
+++ b/test/unit/node/resources/golden-cjs/dep.js
@@ -1,8 +1,11 @@
 "use strict";
 var q = 'q';
 Object.defineProperties(module.exports, {
-  q: {get: function() {
+  q: {
+    get: function() {
       return q;
-    }},
+    },
+    enumerable: true
+  },
   __esModule: {value: true}
 });

--- a/test/unit/node/resources/golden-cjs/file.js
+++ b/test/unit/node/resources/golden-cjs/file.js
@@ -3,8 +3,11 @@ var $__dep_46_js__;
 var q = ($__dep_46_js__ = require("./dep.js"), $__dep_46_js__ && $__dep_46_js__.__esModule && $__dep_46_js__ || {default: $__dep_46_js__}).q;
 var p = 'module';
 Object.defineProperties(module.exports, {
-  p: {get: function() {
+  p: {
+    get: function() {
       return p;
-    }},
+    },
+    enumerable: true
+  },
   __esModule: {value: true}
 });


### PR DESCRIPTION
We created the properties on the module object as non enumerable.
This change makes them enumerable which is consistent with ES6 module
instance objects.

Fixes #2118