### PR TITLE
Cleanup generated code for export default declaration

### DIFF
--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -172,7 +172,17 @@ export class ModuleTransformer extends ImportRuntimeTrait(TempVarTransformer) {
     let returnExpression;
     switch (tree.type) {
       case EXPORT_DEFAULT:
-        returnExpression = createIdentifierExpression('$__default');
+        switch (tree.expression.type) {
+          case CLASS_DECLARATION:
+          case FUNCTION_DECLARATION: {
+            const nameBinding = tree.expression.name;
+            returnExpression =
+                createIdentifierExpression(nameBinding.identifierToken);
+            break;
+          }
+          default:
+            returnExpression = createIdentifierExpression('$__default');
+        }
         break;
 
       case EXPORT_SPECIFIER:
@@ -266,14 +276,8 @@ export class ModuleTransformer extends ImportRuntimeTrait(TempVarTransformer) {
   transformExportDefault(tree) {
     switch (tree.expression.type) {
       case CLASS_DECLARATION:
-      case FUNCTION_DECLARATION: {
-        let nameBinding = tree.expression.name;
-        let name = createIdentifierExpression(nameBinding.identifierToken);
-        return new AnonBlock(null, [
-          tree.expression,
-          parseStatement `var $__default = ${name}`
-        ]);
-      }
+      case FUNCTION_DECLARATION:
+        return tree.expression;
     }
     return parseStatement `var $__default = ${tree.expression}`;
   }

--- a/test/feature/Modules/DefaultLiveBinding.js
+++ b/test/feature/Modules/DefaultLiveBinding.js
@@ -1,0 +1,5 @@
+import * as m from './resources/default-live.js';
+
+assert.equal(m.default(), 1);
+m.changeDefault();
+assert.equal(m.default, 2);

--- a/test/feature/Modules/resources/default-live.js
+++ b/test/feature/Modules/resources/default-live.js
@@ -1,0 +1,7 @@
+export default function f() {
+  return 1;
+}
+
+export function changeDefault() {
+  f = 2;
+}


### PR DESCRIPTION
For:

```js
export default function f() {}
```

We used to generate:

```js
function f() {}
var $__default = f;
... = {
  get default() {
    return $__default;
  }
}
```

With this change we skip the `$__default` var:

```js
function f() {}
... = {
  get default() {
    return f;
  }
}
```