### PR TITLE
Setup module.exports first

### DIFF
--- a/src/codegeneration/AmdTransformer.js
+++ b/src/codegeneration/AmdTransformer.js
@@ -48,7 +48,7 @@ export class AmdTransformer extends ModuleTransformer {
   getExportProperties() {
     let properties = super.getExportProperties();
 
-    if (this.exportVisitor_.hasExports())
+    if (this.exportVisitor.hasExports())
       properties.push(parsePropertyDefinition `__esModule: true`);
     return properties;
   }

--- a/src/codegeneration/ClosureModuleTransformer.js
+++ b/src/codegeneration/ClosureModuleTransformer.js
@@ -53,7 +53,7 @@ export class ClosureModuleTransformer extends ModuleTransformer {
     return statements;
   }
 
-  appendExportStatement(statements) {
+  addExportStatement(statements) {
     if (!this.hasExports()) return statements;
     let exportObject = this.getExportObject();
     statements.push(parseStatement `exports = ${exportObject}`);

--- a/src/codegeneration/InlineES6ModuleTransformer.js
+++ b/src/codegeneration/InlineES6ModuleTransformer.js
@@ -117,7 +117,7 @@ export class InlineES6ModuleTransformer extends ModuleTransformer {
     if (this.isRootModule)
       return tree;
 
-    this.exportVisitor_.visitAny(tree);
+    this.exportVisitor.visitAny(tree);
     return this.transformAny(tree.declaration);
   }
 
@@ -154,11 +154,11 @@ export class InlineES6ModuleTransformer extends ModuleTransformer {
    *
    * @returns {Array} statements
    */
-  appendExportStatement(statements) {
+  addExportStatement(statements) {
     let exportProperties = this.getExportProperties();
     let exportObject = createObjectLiteral(exportProperties);
-    if (this.exportVisitor_.starExports.length) {
-      let starExports = this.exportVisitor_.starExports;
+    if (this.exportVisitor.starExports.length) {
+      let starExports = this.exportVisitor.starExports;
       let starIdents = starExports.map((moduleSpecifier) => {
         return createIdentifierExpression(
           this.getTempVarNameForModuleSpecifier(moduleSpecifier));

--- a/src/codegeneration/InstantiateModuleTransformer.js
+++ b/src/codegeneration/InstantiateModuleTransformer.js
@@ -362,7 +362,7 @@ export class InstantiateModuleTransformer extends ModuleTransformer {
    * });
    *
    */
-  appendExportStatement(statements) {
+  addExportStatement(statements) {
     let declarationExtractionTransformer = new DeclarationExtractionTransformer();
 
     // convert __moduleName identifiers into $__moduleContext.id

--- a/src/codegeneration/module/DirectExportVisitor.js
+++ b/src/codegeneration/module/DirectExportVisitor.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {ExportVisitor} from './ExportVisitor.js';
+import {TYPE_ALIAS_DECLARATION} from '../../syntax/trees/ParseTreeType.js';
 
 /**
  * Visits a parse tree and adds all the exports.
@@ -44,5 +45,10 @@ export class DirectExportVisitor extends ExportVisitor {
 
   hasExports() {
     return this.namedExports.length !== 0 || this.starExports.length !== 0;
+  }
+
+  getNonTypeNamedExports() {
+    return this.namedExports.filter(exp =>
+        exp.tree.type !== TYPE_ALIAS_DECLARATION);
   }
 }

--- a/test/commonjs/node-require.js
+++ b/test/commonjs/node-require.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-assert.equal('"use strict";\nvar $__fs__,\n    $__path__;',
-    fs.readFileSync(path.resolve(__dirname, 'node-require.js'))
-    .toString().substr(0, 41));
+var src = fs.readFileSync(path.resolve(__dirname, 'node-require.js'), 'utf8');
+assert.isTrue(
+    src.indexOf('fs ' + '= $__interopRequire("fs").default') !== -1);
+assert.isTrue(
+    src.indexOf('path ' + '= $__interopRequire("path").default') !== -1);

--- a/test/unit/codegeneration/InlineES6ModuleTransformer.js
+++ b/test/unit/codegeneration/InlineES6ModuleTransformer.js
@@ -63,7 +63,7 @@ suite('InlineES6ModuleTransformer.js', function() {
 
     let transformer = new InlineES6ModuleTransformer(
       new UniqueIdentifierGenerator(), reporter, options, metadata);
-    transformer.exportVisitor_.visitAny(exportStarTree);
+    transformer.exportVisitor.visitAny(exportStarTree);
     let transformed = transformer.transformAny(tree);
     assert.equal(write(transformed), expected);
   });

--- a/test/unit/node/resources/golden-cjs/dep.js
+++ b/test/unit/node/resources/golden-cjs/dep.js
@@ -1,11 +1,11 @@
 "use strict";
-var q = 'q';
 Object.defineProperties(module.exports, {
+  __esModule: {value: true},
   q: {
+    enumerable: true,
     get: function() {
       return q;
-    },
-    enumerable: true
-  },
-  __esModule: {value: true}
+    }
+  }
 });
+var q = 'q';

--- a/test/unit/node/resources/golden-cjs/file.js
+++ b/test/unit/node/resources/golden-cjs/file.js
@@ -1,13 +1,12 @@
 "use strict";
-var $__dep_46_js__;
-var q = ($__dep_46_js__ = require("./dep.js"), $__dep_46_js__ && $__dep_46_js__.__esModule && $__dep_46_js__ || {default: $__dep_46_js__}).q;
-var p = 'module';
 Object.defineProperties(module.exports, {
+  __esModule: {value: true},
   p: {
+    enumerable: true,
     get: function() {
       return p;
-    },
-    enumerable: true
-  },
-  __esModule: {value: true}
+    }
+  }
 });
+var q = require("./dep.js").q;
+var p = 'module';


### PR DESCRIPTION
This gives some much needed love to the CommonJS module output.

Most importantly it mutates the `module.exports` object before the
code is executed which allows some cyclic dependencies to work
(function declarations).

This also changes the transformer to work on the original code
instead of the already transformed code (from `ModuleTransformer`).

Things have been refactored so that more code is shared between
`CommonJsModuleTransformer` and `ModuleTransformer`.

Also, the require variable binding (with `__esModule`) has changed
so that we do not need temp variables (outside what is needed for
destructuring).