### PR TITLE
Use universal method of finding the global object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,3 +56,4 @@ Srinivasan Sekar <srinivasan.sekar1990@gmail.com>
 Jeff Shen<jeffshen86@gmail.com>
 Erik Arvidsson <erik.arvidsson@gmail.com>
 Mathias Rangel Wulff <m@rawu.dk>
+Christoph Leimbrock <christoph.leimbrock@gmx.de>

--- a/src/loader/ModuleStoreImpl.js
+++ b/src/loader/ModuleStoreImpl.js
@@ -301,4 +301,4 @@
   $traceurRuntime.setModule = ModuleStore.set;
   $traceurRuntime.normalizeModuleName = ModuleStore.normalize;
 
-})(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : this);
+})(new Function('return this;')());

--- a/src/loader/ModuleStoreImpl.js
+++ b/src/loader/ModuleStoreImpl.js
@@ -301,4 +301,17 @@
   $traceurRuntime.setModule = ModuleStore.set;
   $traceurRuntime.normalizeModuleName = ModuleStore.normalize;
 
-})(new Function('return this;')());
+})((function() {
+  try {
+    return new Function('return this;')();
+  } catch(e) {
+    if (typeof window !== 'undefined')
+      return window;
+    if (typeof global !== 'undefined')
+      return global;
+    if (typeof self !== 'undefined')
+      return self;
+
+    return this;
+  }
+})());

--- a/src/runtime/modules/symbols.js
+++ b/src/runtime/modules/symbols.js
@@ -169,10 +169,7 @@ function polyfillSymbol(global) {
   }
 }
 
-let g = typeof window !== 'undefined' ? window :
-    typeof global !== 'undefined' ? global :
-    typeof self !== 'undefined' ? self : this;
-polyfillSymbol(g);
+polyfillSymbol(new Function('return this;')());
 
 let typeOf = hasNativeSymbol() ?
     x => typeof x :

--- a/src/runtime/modules/symbols.js
+++ b/src/runtime/modules/symbols.js
@@ -169,7 +169,22 @@ function polyfillSymbol(global) {
   }
 }
 
-polyfillSymbol(new Function('return this;')());
+function findGlobal() {
+  try {
+    return new Function('return this;')();
+  } catch(e) {
+    if (typeof window !== 'undefined')
+      return window;
+    if (typeof global !== 'undefined')
+      return global;
+    if (typeof self !== 'undefined')
+      return self;
+
+    return this;
+  }
+}
+
+polyfillSymbol(findGlobal());
 
 let typeOf = hasNativeSymbol() ?
     x => typeof x :

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -37,4 +37,17 @@
     setupGlobals: setupGlobals,
     typeof: typeOf,
   };
-})(new Function('return this;')());
+})((function() {
+  try {
+    return new Function('return this;')();
+  } catch(e) {
+    if (typeof window !== 'undefined')
+      return window;
+    if (typeof global !== 'undefined')
+      return global;
+    if (typeof self !== 'undefined')
+      return self;
+
+    return this;
+  }
+})());

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -37,6 +37,4 @@
     setupGlobals: setupGlobals,
     typeof: typeOf,
   };
-})(typeof window !== 'undefined' ? window :
-    typeof global !== 'undefined' ? global :
-    typeof self !== 'undefined' ? self : this);
+})(new Function('return this;')());


### PR DESCRIPTION
The module store, runtime and symbol polyfills need access to the global object. This was done by checking the existance of `window`, `global`, `self` and falling back to `this` if none were defined. This can fail for two reasons. First, `this` should be expected to be set to `undefined` during module definitions (as is the case for symbols.js), thus rendering the fallback useless. Secondly some JavaScript implementations (e.g. JavaScript-Core Framework) might not even define a name for the global object that could be accessed within modules.
By using the Function-Constructor we create a new function in non-strict mode which has its _thisArg_ set to the gobal object if no other _thisArg_ is provided.