### PR TITLE
Fix PropertyMethodAssignment test

### DIFF
--- a/test/feature/PropertyMethodAssignment/PropertyMethodAssignment.js
+++ b/test/feature/PropertyMethodAssignment/PropertyMethodAssignment.js
@@ -41,7 +41,9 @@ function assertMethod(object, name) {
   assert.isTrue(descriptor.enumerable);
   assert.equal('function', typeof object[name]);
   // IE does not have a name property on functions.
-  assert.isTrue(object[name].name === '' || object[name].name === undefined);
+  // ES6 compliant engines will set the name of {x: function() {}} to x
+  var fn = object[name].name;
+  assert.include(['', undefined, name], fn);
 }
 
 assertMethod(object, 'f');


### PR DESCRIPTION
The test was testing the name of a method. With newer versions of
Node, Node uses the ES6 semantics for inferring the function name
which leads to test failures.