### PR TITLE
docs: Fix simple typo, intializer -> initializer

### DIFF
--- a/test/feature/ArrowFunctions/Skip_InitializerShorthand.js
+++ b/test/feature/ArrowFunctions/Skip_InitializerShorthand.js
@@ -1,8 +1,8 @@
 // Skip. Not implemented.
 
-// TODO: needs the intializer shorthand implemented for arrow functions
+// TODO: needs the initializer shorthand implemented for arrow functions
 
-// Object intializer shorthand: "method" = function-valued property with dynamic ''this''
+// Object initializer shorthand: "method" = function-valued property with dynamic ''this''
 const obj = {
   method() -> {
     return => this;


### PR DESCRIPTION
There is a small typo in test/feature/ArrowFunctions/Skip_InitializerShorthand.js.

Should read `initializer` rather than `intializer`.

