### PR TITLE
Fix logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Join the chat at https://gitter.im/google/traceur-compiler](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/google/traceur-compiler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/google/traceur-compiler.svg)](https://travis-ci.org/google/traceur-compiler)
 
-<img src="https://google.github.com/traceur-compiler/logo/tc.svg" alt="Traceur logo" width="200px">
+<img src="https://raw.githubusercontent.com/google/traceur-compiler/master/logo/tc.svg" alt="Traceur logo" width="200px">
 
 ## What is Traceur?
 


### PR DESCRIPTION
The original url of the traceur logo didn't work on certain devices, so I replaced it with a link that seems to work well.